### PR TITLE
fix missing header in proxy

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <memory>
 #include <condition_variable>
+#include <string.h>
 #include "../blob_server_func_deps.h"
 #include "../../ca_blobs_fs/content_addressed_fs.h"
 #include "../../ca_blobs_fs/src/fileio.h"


### PR DESCRIPTION
fix error:
```
proxy_file_lib.cpp:104:97: error: 'strlen' was not declared in this scope
  104 |     for (const char* at = accessed_files.data(), *e = at + accessed_files.size(); at < e; at += strlen(at)+1)
      |                                                                                                 ^~~~~~
proxy_file_lib.cpp:11:1: note: 'strlen' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
```