### PR TITLE
cvs history fix and improvement

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/cvstools/TriggerLibrary.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/cvstools/TriggerLibrary.cpp
@@ -154,7 +154,7 @@ namespace
 		return ret;
 	}
 
-	int COM_history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+	int COM_history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 	{
 		CTriggerLibrary::trigger_info_t *inf = (CTriggerLibrary::trigger_info_t*)cb->plugin.__cvsnt_reserved;
 		CTriggerLibrary::InfoStruct *i = &inf->is;

--- a/cvsnt/cvsnt-2.5.05.3744/cvstools/trigger_interface.h
+++ b/cvsnt/cvsnt-2.5.05.3744/cvstools/trigger_interface.h
@@ -54,7 +54,7 @@ typedef struct trigger_interface_t
 	int (*pretag)(const struct trigger_interface_t* cb, const char *message, const char *directory, int name_list_count, const char **name_list, const char **version_list, char tag_type, const char *action, const char *tag);
 	int (*verifymsg)(const struct trigger_interface_t* cb, const char *directory, const char *filename);
 	int (*loginfo)(const struct trigger_interface_t* cb, const char *message, const char *status, const char *directory, int change_list_count, change_info_t *change_list);
-	int (*history)(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message);
+	int (*history)(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory);
 	int (*notify)(const struct trigger_interface_t* cb, const char *message, const char *bugid, const char *directory, const char *notify_user, const char *tag, const char *type, const char *file);
 	int (*precommit)(const struct trigger_interface_t* cb, int name_list_count, const char **name_list, const char *message, const char *directory);
 	int (*postcommit)(const struct trigger_interface_t* cb, const char *directory);

--- a/cvsnt/cvsnt-2.5.05.3744/doc/cvs.dbk
+++ b/cvsnt/cvsnt-2.5.05.3744/doc/cvs.dbk
@@ -14679,6 +14679,14 @@ Release Tags: release_tag</screen> Next, separated by an empty line, is the
               <para>Name of affected file</para>
             </listitem>
           </varlistentry>
+
+          <varlistentry>
+            <term>%p</term>
+
+            <listitem>
+              <para>Directory path relative to repository root</para>
+            </listitem>
+          </varlistentry>
         </variablelist></para>
 
       <para>By default the string <command>%t|%d|%u|%w|%s|%v</command> is

--- a/cvsnt/cvsnt-2.5.05.3744/src/diff.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/diff.cpp
@@ -560,6 +560,10 @@ static int diff_fileproc (void *callerdat, struct file_info *finfo)
 	}
     }
     empty_file = diff_file_nodiff (finfo, vers, empty_file, default_branch);
+	if (use_rev1 != NULL)
+		history_write ('D', finfo->update_dir, use_rev1, finfo->file, finfo->repository,NULL,NULL);
+	if (use_rev2 != NULL)
+		history_write ('D', finfo->update_dir, use_rev2, finfo->file, finfo->repository,NULL,NULL);
     if (empty_file == DIFF_SAME || empty_file == DIFF_ERROR)
     {
 	freevers_ts (&vers);

--- a/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
@@ -745,12 +745,7 @@ void history_write (int type, const char *update_dir, const char *revs, const ch
 		}
     }
 
-    if (type == 'T')
-    {
-		repos = update_dir;
-		update_dir = "";
-    }
-    else if (update_dir && *update_dir)
+    if (update_dir && *update_dir)
 		slash = "/";
     else
 		update_dir = "";

--- a/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
@@ -216,7 +216,7 @@ static void save_module (const char *module);
 static void save_user(const char *name);
 static void save_bugid(const char *name);
 
-#define ALL_REC_TYPES "TOEFWUCGMAReu"
+#define ALL_REC_TYPES "TOEFWUCGMAReuP"
 
 char *logHistory = ALL_REC_TYPES;
 

--- a/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
@@ -268,6 +268,7 @@ struct historyproc_param_t
 	const char *name;
 	const char *bugid;
 	const char *message;
+    const char *directory;
 };
 
 /* This is pretty unclear.  First of all, separating "flags" vs.
@@ -313,7 +314,7 @@ static int historyinfo_proc (void *params, const trigger_interface *cb)
 	int ret = 0;
 	if(cb->history)
 	{
-		ret = cb->history(cb,args->type,args->workdir,args->revs,args->name, args->bugid, args->message);
+		ret = cb->history(cb,args->type,args->workdir,args->revs,args->name, args->bugid, args->message, args->directory);
 	}
 	return ret;
 }
@@ -831,6 +832,7 @@ void history_write (int type, const char *update_dir, const char *revs, const ch
 	args.message = message;
 	args.revs=revs;
 	args.name=name;
+    args.directory=repos;
 
 	TRACE(3,"run history trigger");
 	if (run_trigger (&args, historyinfo_proc) > 0)

--- a/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/history.cpp
@@ -28,6 +28,7 @@
  *		R	"Commit" cmd - "Removed" file.
  *		e	"edit" cmd - file edited
  *		u	"unedit" cmd - file unedited
+ *		D	"diff" cmd - Diff was sent (2 records - one for each revision).
  *
  *  date  is a minimum 8-char hex representation of a Unix time_t.
  *		[Starting here, variable fields are delimited by '|' chars.]
@@ -216,7 +217,7 @@ static void save_module (const char *module);
 static void save_user(const char *name);
 static void save_bugid(const char *name);
 
-#define ALL_REC_TYPES "TOEFWUCGMAReuP"
+#define ALL_REC_TYPES "TOEFWUCGMAReuPD"
 
 char *logHistory = ALL_REC_TYPES;
 

--- a/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
@@ -1193,6 +1193,7 @@ static int tag_fileproc (void *callerdat, struct file_info *finfo)
 	else
 		tag_set_ok = 1;
 	TRACE(3,"tag_fileproc - finally RCS_settag ok");
+	history_write ('T', finfo->update_dir, rev, finfo->file, finfo->repository, NULL, NULL);
     if (branch_mode)
 	xfree (rev);
 	TRACE(3,"tag_fileproc(2) rewrite rcsfile=\"%s\" symtag=\"%s\", rev=\"%s\", date=\"%s\"",

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -1761,13 +1761,10 @@ VERS: ", 0);
 			vers_ts->vn_rcs = xstrdup (xvers_ts->vn_rcs);
 		}
 
-		/* If this is really Update and not Checkout, recode history */
-		if (strcmp (command_name, "update") == 0)
-		{
-			TRACE(3,"If this is really Update and not Checkout, recode history.");
-			history_write ('U', finfo->update_dir, xvers_ts->vn_rcs, xfile,
-				finfo->repository, xvers_ts->edit_bugid, NULL);
-		}
+		/* Recode history */
+        TRACE(3,"Recode history.");
+        history_write ('U', finfo->update_dir, xvers_ts->vn_rcs, xfile,
+            finfo->repository, xvers_ts->edit_bugid, NULL);
 		TRACE(3,"free xvers_ts");
 		freevers_ts (&xvers_ts);
 		TRACE(3,"free xvers_ts OK");
@@ -2134,10 +2131,9 @@ static int patch_file (struct file_info *finfo, Vers_TS *vers_ts, int *docheckou
 	if (CVS_STAT (finfo->file, &file_info) < 0)
 	    error (1, errno, "could not stat %s", finfo->file);
 
-	/* If this is really Update and not Checkout, recode history */
-	if (strcmp (command_name, "update") == 0)
-	    history_write ('P', finfo->update_dir, xvers_ts->vn_rcs, finfo->file,
-			   finfo->repository, xvers_ts->edit_bugid, NULL);
+	/* Recode history */
+    history_write ('P', finfo->update_dir, xvers_ts->vn_rcs, finfo->file,
+           finfo->repository, xvers_ts->edit_bugid, NULL);
 
 	freevers_ts (&xvers_ts);
 

--- a/cvsnt/cvsnt-2.5.05.3744/triggers/audit_trigger.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/triggers/audit_trigger.cpp
@@ -328,7 +328,7 @@ int loginfoaudit(const struct trigger_interface_t* cb, const char *message, cons
 	return 0;
 }
 
-int historyaudit(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+int historyaudit(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 {
 	if(g_AuditLogHistory)
 	{

--- a/cvsnt/cvsnt-2.5.05.3744/triggers/checkout_trigger.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/triggers/checkout_trigger.cpp
@@ -131,7 +131,7 @@ int loginfo(const struct trigger_interface_t* cb, const char *message, const cha
 	return 0;
 }
 
-int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 {
 	return 0;
 }

--- a/cvsnt/cvsnt-2.5.05.3744/triggers/email_trigger.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/triggers/email_trigger.cpp
@@ -287,7 +287,7 @@ int loginfo(const struct trigger_interface_t* cb, const char *message, const cha
 	return 0;
 }
 
-int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 {
 	return 0;
 }

--- a/cvsnt/cvsnt-2.5.05.3744/triggers/info_trigger.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/triggers/info_trigger.cpp
@@ -404,6 +404,7 @@ struct history_information
 	const char *name; // %s - name
 	const char *bugid; // %b - bugid
 	const char *message; // %m - message
+    const char *directory; // %p - directory
 };
 
 history_information hist_info;
@@ -416,6 +417,7 @@ options history_options[] =
 	{ 's', &hist_info.name },
 	{ 'b', &hist_info.bugid },
 	{ 'm', &hist_info.message },
+	{ 'p', &hist_info.directory },
 	{ 0 }
 };
 
@@ -726,7 +728,7 @@ int loginfo(const struct trigger_interface_t* cb, const char *message, const cha
 	return parse_info(CVSROOT_LOGINFO,"",msg.c_str(),directory,generic_options,loginfo_options);
 }
 
-int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 {
 	hist_info.type=type;
 	hist_info.revs=revs;
@@ -734,6 +736,7 @@ int history(const struct trigger_interface_t* cb, char type, const char *workdir
 	hist_info.name=name;
 	hist_info.bugid=bugid;
 	hist_info.message=message;
+    hist_info.directory=directory;
 
 	return parse_info(CVSROOT_HISTORYINFO,"%t|%d|%u|%w|%s|%v","",NULL,generic_options,history_options);
 }

--- a/cvsnt/cvsnt-2.5.05.3744/triggers/script_trigger.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/triggers/script_trigger.cpp
@@ -446,7 +446,7 @@ int loginfo(const struct trigger_interface_t* cb, const char *message, const cha
 	return CallDispatch(L"loginfo",args,sizeof(args)/sizeof(args[0]));
 }
 
-int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message)
+int history(const struct trigger_interface_t* cb, char type, const char *workdir, const char *revs, const char *name, const char *bugid, const char *message, const char *directory)
 {
 	if(!g_pEngine)
 		return 0;


### PR DESCRIPTION
1. Removed a check for the command before logging update events to the history since on the server, the command is always `server`, making this check always false and preventing update events from being logged to history.
2. Added a missing history type (`P`) to the check before writing to the history file.
3. Introduced a new parameter to the history info trigger. `%p` refers to the path of the affected file.
4. Write a history record (type T) for each tagged file when the tag command is called.