### PR TITLE
fix cafs proxy compilation

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/Makefile.am
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/Makefile.am
@@ -10,7 +10,7 @@ cafs_proxy_server_SOURCES = \
 
 bin_PROGRAMS=cafs_proxy_server
 
-cafs_proxy_server_LDADD = ../clientLib/libkv_client_lib.la ../blob_sockets/libblob_sockets_lib.la
+cafs_proxy_server_LDADD = ../clientLib/libkv_client_lib.la ../blob_sockets/libblob_sockets_lib.la ../../ca_blobs_fs/libca_blobs_fs.la
 
 if ALLOW_LIBSTDC_FS
 cafs_proxy_server_LDADD += -lstdc++fs


### PR DESCRIPTION
compilation fails on ubuntu:focal with linking errors:

```
/bin/bash ../../libtool  --tag=CXX   --mode=link g++  -g -O2    -o cafs_proxy_server free_disk_space.o cafs_proxy_server.o proxy_file_lib.o gc_proc_monitor.o fileio.o blob_push_proc.o blob_push_server.o ../clientLib/libkv_client_lib.la ../blob_sockets/libblob_sockets_lib.la -lstdc++fs -lcrypt -lxml2 -lresolv
libtool: link: g++ -g -O2 -o .libs/cafs_proxy_server free_disk_space.o cafs_proxy_server.o proxy_file_lib.o gc_proc_monitor.o fileio.o blob_push_proc.o blob_push_server.o  ../clientLib/.libs/libkv_client_lib.so ../blob_sockets/.libs/libblob_sockets_lib.so -lstdc++fs -lcrypt -lxml2 -lresolv
/usr/bin/ld: proxy_file_lib.o: in function `caddressed_fs::DownloadBlobInfo::~DownloadBlobInfo()':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/../../ca_blobs_fs/streaming_blobs.h:27: undefined reference to `streaming_compression::finish_decompress_stream(char*)'
/usr/bin/ld: /data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/../../ca_blobs_fs/streaming_blobs.h:27: undefined reference to `streaming_compression::finish_decompress_stream(char*)'
/usr/bin/ld: proxy_file_lib.o: in function `PullThroughTemp::start(ClientConnection const*, char const*, char const*, unsigned long&)':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp:345: undefined reference to `init_blob_hash_context(char*, unsigned long)'
/usr/bin/ld: proxy_file_lib.o: in function `PullThroughTemp::finish(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp:441: undefined reference to `finalize_blob_hash(char*, unsigned char*, unsigned long)'
/usr/bin/ld: proxy_file_lib.o: in function `PullThroughTemp::pull(unsigned long, unsigned long&)::{lambda(char const*, int)#1}::operator()(char const*, int) const::{lambda(void const*, unsigned long)#1}::operator()(void const, unsigned long) const':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp:385: undefined reference to `update_blob_hash(char*, char const*, unsigned long)'
/usr/bin/ld: proxy_file_lib.o: in function `bool caddressed_fs::decode_stream_blob_data<PullThroughTemp::pull(unsigned long, unsigned long&)::{lambda(char const*, int)#1}::operator()(char const*, int) const::{lambda(void const*, unsigned long)#1}>(caddressed_fs::DownloadBlobInfo&, char const*, unsigned long, PullThroughTemp::pull(unsigned long, unsigned long&)::{lambda(char const*, int)#1}::operator()(char const*, int) const::{lambda(void const*, unsigned long)#1})':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/../../ca_blobs_fs/streaming_blobs.h:87: undefined reference to `streaming_compression::decompress_stream(char*, char const*, unsigned long&, unsigned long, char*, unsigned long&, unsigned long)'
/usr/bin/ld: proxy_file_lib.o: in function `PullThroughTemp::pull(unsigned long, unsigned long&)::{lambda(char const*, int)#1}::operator()(char const*, int) const::{lambda(void const*, unsigned long)#1}::operator()(void const, unsigned long) const':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/proxy_file_lib.cpp:385: undefined reference to `update_blob_hash(char*, char const*, unsigned long)'
/usr/bin/ld: proxy_file_lib.o: in function `caddressed_fs::init_decompress_blob_stream(char*, unsigned long, caddressed_fs::BlobHeader const&)':
/data/G-CVSNT/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/../../ca_blobs_fs/streaming_blobs.h:47: undefined reference to `streaming_compression::init_decompress_stream(char*, unsigned long, streaming_compression::StreamType)'
collect2: error: ld returned 1 exit status
```