### PR TITLE
fix illegial instuction on AMD

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/blake3/Makefile.am
+++ b/cvsnt/cvsnt-2.5.05.3744/blake3/Makefile.am
@@ -8,14 +8,16 @@ libblake3_la_SOURCES = \
   blake3_dispatch.c
 
 if BUILD_ARM64
-AM_CPPFLAGS += -DBLAKE3_USE_NEON
+AM_CFLAGS = -DBLAKE3_USE_NEON
 libblake3_la_SOURCES += blake3_neon.c
 else
-AM_CPPFLAGS += -msse4.1
+AM_CFLAGS = -msse4.1
 libblake3_la_SOURCES += blake3_avx2_x86-64_unix.S blake3_sse2_x86-64_unix.S blake3_sse41_x86-64_unix.S
 if BUILD_AVX512
-AM_CPPFLAGS += -mavx -mavx2 -mavx512f
+AM_CFLAGS += -mavx -mavx2 -mavx512f
 libblake3_la_SOURCES += blake3_avx512_x86-64_unix.S
+else
+AM_CFLAGS += -DBLAKE3_NO_AVX512=1
 endif
 endif
 

--- a/cvsnt/cvsnt-2.5.05.3744/configure.in
+++ b/cvsnt/cvsnt-2.5.05.3744/configure.in
@@ -731,7 +731,19 @@ fi
 AM_CONDITIONAL(WITH_MAC_HFS_SUPPORT, test "x$acx_mac_hfs_support" = "xyes" )
 AC_MSG_RESULT($acx_mac_hfs_support)
 
-acx_build_avx512=yes
+AC_MSG_CHECKING(AVX512 instruction set)
+AC_ARG_ENABLE(avx512,
+[  --enable-avx512            enable avx512 instruction set (default))
+   --disable-avx512           disable avx512])
+
+
+if test "x$enable_avx512" != "xno"; then
+  acx_build_avx512="yes"
+else
+  acx_build_avx512="no"
+fi
+
+acx_mac_build="no"
 case "${target_os}" in
   darwin*)
     acx_mac_build=yes
@@ -745,7 +757,9 @@ case "${target_os}" in
   *)
     ;;
 esac
+AC_MSG_RESULT($acx_build_avx512)
 
+AC_MSG_CHECKING(mac build)
 AC_MSG_RESULT($acx_mac_build)
 AM_CONDITIONAL(WITH_LIBLTDL, test "x$acx_mac_build" != "xyes" )
 AM_CONDITIONAL(ALLOW_OPENMP, test "x$acx_mac_build" != "xyes" )


### PR DESCRIPTION
avx512 support started only from zen4 architecture. add option to allow build without avx512 for older but powerfull AMD CPUs

./autoreconf -i
./configure --disable-avx512

also fix compile flags for blake. AM_CFLAGS should be used for C code