### PR TITLE
fix: execute premodule triggers before update operation

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/src/modules.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/modules.cpp
@@ -56,7 +56,7 @@ struct modproc_args_t
 
 static int sort_order(const PTR l, const PTR r);
 static void save_d(char *k, int ks, char *d, int ds);
-static int premodule_proc(void *param, const trigger_interface *cb);
+int premodule_proc(void *param, const trigger_interface *cb);
 static int postmodule_proc(void *param, const trigger_interface *cb);
 
 


### PR DESCRIPTION
Previously, premodule triggers were only executed after the update operation completed, making it impossible to abort updates when trigger scripts returned exit code 1. This inconsistency existed between checkout (which properly ran premodule before operation) and update commands.

Changes:
- Add premodule trigger execution before do_update() in update.cpp
- Remove static modifier from premodule_proc in modules.cpp to allow external access
- Pass actual module name from command line arguments to premodule trigger

Now both 'cvs get' and 'cvs update' will:
1. Execute premodule trigger with module name before operation
2. Abort operation if trigger returns non-zero exit code
3. Execute postmodule trigger after operation (existing behavior)