### PR TITLE
docs: build instructions, architecture documentation and audit reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,16 @@ tmp/*.*
 CVS
 log1
 log2
+
+# Build-generated sources (produced by mc.exe / midl.exe during the Windows build)
+cvsnt/cvsnt-2.5.05.3744/cvsapi/win32/MSG00001.bin
+cvsnt/cvsnt-2.5.05.3744/cvsapi/win32/ServiceMsg.h
+cvsnt/cvsnt-2.5.05.3744/cvsapi/win32/ServiceMsg.rc
+cvsnt/cvsnt-2.5.05.3744/cvsservice/ServiceMsg.h
+cvsnt/cvsnt-2.5.05.3744/cvsservice/ServiceMsg.rc
+cvsnt/cvsnt-2.5.05.3744/cvstools/trigger_h.h
+cvsnt/cvsnt-2.5.05.3744/cvstools/trigger_i.c
+cvsnt/cvsnt-2.5.05.3744/cvstools/win32/trigger.tlb
+cvsnt/cvsnt-2.5.05.3744/triggers/Server_h.h
+cvsnt/cvsnt-2.5.05.3744/triggers/Server_i.c
+cvsnt/cvsnt-2.5.05.3744/triggers/script_trigger.tlb

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -1,0 +1,186 @@
+# How to build G-CVSNT
+
+G-CVSNT is the Gaijin fork of CVSNT 2.5.05, versioned as **CVSNT 3.5.x**. The
+actual source tree lives in [`cvsnt/cvsnt-2.5.05.3744/`](cvsnt/cvsnt-2.5.05.3744)
+(the directory name kept the original upstream version). It has two build
+systems:
+
+| Platform | Build system | Entry point |
+|----------|--------------|-------------|
+| Windows (client + server) | Visual C++ solution (`cvsnt.sln`, toolset v142) | `cvsnt/build-windows.py` or Visual Studio |
+| Linux (server, mostly) | autotools | `cvsnt/build-linux-server` |
+| macOS (client) | autotools + osx packaging script | `cvsnt/build-macosx` |
+
+All third-party dependencies needed on Windows are vendored in the tree
+(`external_libs/` contains OpenSSL and iconv headers + prebuilt `.lib`s, the
+sqlite3 amalgamation; `zlib/`, `pcre/`, `libxml/`, `zstd/`, `blake3/` are full
+vendored sources built as projects of the solution).
+
+---
+
+## Windows
+
+### Option A: `build-windows.py` (no Visual Studio installation required) — verified
+
+[`cvsnt/build-windows.py`](cvsnt/build-windows.py) is a self-contained driver
+that parses the `.vcxproj` files and invokes `cl.exe` / `ml64.exe` / `rc.exe` /
+`mc.exe` / `midl.exe` / `lib.exe` / `link.exe` directly, so **no MSBuild and no
+VS installation is needed** — a bare MSVC toolchain package plus a Windows 10
+SDK is enough (e.g. the Gaijin devtools packages).
+
+Requirements:
+
+* Python 3
+* MSVC toolchain directory (contains `bin\Hostx64\x64\cl.exe`, `include`, `lib`,
+  `atlmfc`) — e.g. `D:\devtools\vc2019_16.11.34` (VS2019/v142, matches the
+  solution) or `vc2022_*`
+* Windows 10 SDK directory (contains `include\<ver>`, `lib\<ver>`, and
+  `bin\<ver>\x64\rc.exe`) — e.g. `D:\devtools\win.sdk.100`
+
+```bash
+cd cvsnt
+python build-windows.py --vc D:\devtools\vc2019_16.11.34 --sdk D:\devtools\win.sdk.100
+```
+
+Or, if you have real Visual Studio, from a *x64 Native Tools Command Prompt*:
+
+```bash
+cd cvsnt
+python build-windows.py
+```
+
+Useful switches: `--config Release|Debug`, `--platform x64|Win32`,
+`--projects name1,name2` (partial rebuild), `--with-optional` (also builds
+`co`/`rcsdiff`/`rlog`, `cvsdiag`, `extnt`, `su`, `genkey`, installer helpers…),
+`--jobs N`.
+
+Output lands in `cvsnt/cvsnt-2.5.05.3744/Releasex64/`:
+
+```
+cvs.exe                  the client/server binary
+cvsapi.dll  cvstools.dll core libraries
+cvsservice.dll           NT service
+lockservice.exe          cvslock daemon
+plink.dll                bundled PuTTY link (used by :ssh:)
+protocols\*.dll          pserver, sserver, sspi, ssh, ext, enum, fork, server
+triggers\*.dll           info, audit, email, script, checkout plugins
+database\sqlite_database.dll, odbc_database.dll
+mdns\mdns_mini.dll, mdnsclient.dll
+xdiff\xml_xdiff.dll
+```
+
+Notes on generated sources (the script runs these automatically; Visual Studio
+runs them as custom build steps):
+
+* `cvsapi/win32/ServiceMsg.mc` → `ServiceMsg.h`/`.rc` via `mc.exe`
+  (needed by `cvsapi` and `cvsservice`)
+* `cvstools/win32/trigger.idl` → `trigger_h.h`, `trigger_i.c`,
+  `win32/trigger.tlb` via `midl.exe`
+* `triggers/server.idl` → `Server_h.h`, `Server_i.c`, `script_trigger.tlb`
+
+### Option B: Visual Studio
+
+Open `cvsnt/cvsnt-2.5.05.3744/cvsnt.sln` with Visual Studio 2019 or newer
+(the projects use PlatformToolset **v142**; install the "MSVC v142" component
+or retarget). Build configuration `Release|x64`. The `Desktop development with
+C++` workload plus **ATL** (for `script_trigger` and the control panel) and the
+Windows 10 SDK are required.
+
+### Running the freshly built cvs.exe
+
+`cvs.exe` locates its protocol/trigger DLLs through the CVSNT install
+directory (registry `HKLM\SOFTWARE\CVS\Pserver` / the directory of an installed
+CVSNT). If you run the fresh `cvs.exe` in place next to its `protocols\`
+subdirectory it works standalone for `--version` and local operations; to use
+it as your day-to-day client, either replace the files of an existing CVSNT
+installation (e.g. `C:\Program Files (x86)\CVSNT\`) or build & install the MSI.
+
+### MSI installer
+
+WiX sources and tools are vendored:
+
+```bash
+cd cvsnt
+make_msix64.bat     # candle.exe + light.exe on cvsnt-x64-3.5.05.<build>.wxs
+```
+
+`make_msi.bat` is the Win32 variant. The `.wxs` files reference the binaries
+produced by the Release build; bump the version/build number in the `.wxs`
+file name and content when releasing (see *Versioning* below).
+
+---
+
+## Linux (server)
+
+Scripted in [`cvsnt/build-linux-server`](cvsnt/build-linux-server). On
+RHEL-family distros install the packages from
+[`cvsnt/install-yum-packages`](cvsnt/install-yum-packages) first
+(devtoolset-9 gcc/g++, dh-autoreconf, libxml2-devel, pcre-devel,
+libtool-ltdl-devel, glibc-static, libstdc++-static, libzstd-devel, zstd,
+pam-devel):
+
+```bash
+cd cvsnt/cvsnt-2.5.05.3744
+autoreconf -i
+bash configure \
+    --enable-pam --enable-server --enable-pserver --enable-sspi --enable-ext \
+    --disable-mysql --disable-postgres --disable-sqlite --enable-64bit
+( cd zstd && make && sudo make install )   # vendored zstd first
+make
+sudo make install
+cd tools && ./build_tools                  # blob utilities, see below
+```
+
+`build-rhel6` and `build-altlinux` are older distro-specific variants of the
+same sequence (`build-altlinux` applies `cvsnt-2.5.05-alt-system-pcre.patch`).
+
+`tools/build_tools` builds the Gaijin blob-server maintenance utilities with
+clang++ (`cvtblob` — convert an RCS repository to content-addressed blobs,
+`gc-blobs`, `repack-blobs`, `blake3-calc`, `sha256_calc`, `simplelock`,
+`unlock`). They link against the already-installed `libblake3`/`libca_blobs_fs`
+that `make install` produced.
+
+---
+
+## macOS (client)
+
+Per the top-level [README.md](README.md) — Homebrew is required:
+
+```bash
+cd cvsnt
+./build-macosx
+```
+
+The script installs autoconf/automake/pkg-config/libtool/pcre/openssl@3 via
+brew, symlinks openssl@3 into `/usr/local`, runs `autoreconf`, builds the
+vendored zstd, then delegates to `osx/build-mac` which produces
+`cvsnt-3.5.*.tar.gz`. Unpack the archive and run `./install_copy_cvsnt.sh` to
+copy into `/usr/local`. Edit `BUILD_ARCH`/`PKG_BUILD_SUFFIX` at the top of the
+script to select x86_64 vs arm64. After the build, discard the tree changes the
+build made: `git checkout .`
+
+---
+
+## Versioning
+
+The product version lives in `cvsnt-2.5.05.3744/version_no.h`
+(`CVSNT_PRODUCT_MAJOR/MINOR/PATCH` and the build number). On Windows,
+`genbuild.exe` (built from `genbuild/`) regenerates the build number/date; the
+MSI `.wxs` files carry the version in their file names and contents and must be
+kept in sync manually.
+
+## Troubleshooting
+
+* **`Cannot open include file: 'ServiceMsg.h'` / `'trigger_h.h'` /
+  `'Server_h.h'`** — the `.mc`/`.idl` code generation step has not run; use
+  `build-windows.py` (it runs `mc.exe`/`midl.exe` on demand) or build the full
+  solution once in VS.
+* **`file not found: win32\trigger.tlb`** in `cvstools.rc2` — same cause, the
+  MIDL type library was not generated.
+* **`atlbase.h` not found** — ATL is missing (install VS ATL component, or use
+  a toolchain package that ships `atlmfc/`).
+* **`the :pserver: access method is not available`** — the protocol DLLs were
+  not found at run time (see *Running the freshly built cvs.exe* above).
+* **Unresolved OpenSSL/iconv symbols** — link inputs come prebuilt from
+  `external_libs/x64` (`libssl.lib`, `libcrypto.lib`, `libiconv.lib`); make
+  sure that directory is intact.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ G-CVSNT
 
 G-CVSNT Gaijin (and Gamedev) CVSNT version - modified for large amounts of binary data (typically for gamedev)
 
+Documentation: [docs/](docs/README.md) (architecture, Gaijin modifications, blob storage, performance notes) and [HOWTOBUILD.md](HOWTOBUILD.md) (Windows/Linux/macOS build instructions).
+
 
 OSX 10.9+ notes:
 

--- a/_reports/README.md
+++ b/_reports/README.md
@@ -1,0 +1,116 @@
+# G-CVSNT code audit — findings index
+
+Static analysis of the Gaijin-modified CVSNT source
+(`cvsnt/cvsnt-2.5.05.3744/`). Each `*.md` file is one finding: location,
+severity, a code snippet, why it is a bug, and a suggested fix. Prefixes:
+`blob-` = content-addressed blob layer, `core-` = core cvs commands/client/
+server, `api-` = cvsapi / protocols / Windows layer, `perf-` = the
+update/tag/branch performance analysis.
+
+**62 findings: 1 critical, 15 high, 28 medium, 18 low.** Findings are static —
+each was verified by re-reading the surrounding source, and several were
+independently confirmed while auditing (e.g. a correct sibling implementation
+proving the buggy one wrong). They are not all runtime-reproduced; treat
+severity as "worst plausible impact".
+
+## Critical
+
+| # | Area | Summary |
+|---|------|---------|
+| [api-009](api-009-sspi-unix-server-read-buffer-overflow.md) | protocols | sspi (unix) **server**: client-controlled length drives `read()` into a fixed 1024-byte stack buffer — remote pre-auth stack overflow |
+
+## High
+
+| # | Area | Summary |
+|---|------|---------|
+| [core-011](core-011-send-modified-size-truncated-4gb.md) | client | `send_modified` announces file size with `%lu` — silently truncates >4 GB files on Windows, desyncing the protocol |
+| [core-013](core-013-server-receive-file-size-int-overflow.md) | server | receive path uses `int`/`atoi` for file size — >2 GB uploads overflow |
+| [core-015](core-015-server-updated-size-unsigned-long-truncation.md) | server | `server_updated` uses 32-bit `unsigned long` + `%lu` — truncates >4 GB checkouts on Windows |
+| [core-014](core-014-server-updated-blob-ref-created-dead-condition.md) | server/blob | `Blob-ref-created` branch is dead code (`vers==NULL && vers->ts_user`), can clobber untracked local files |
+| [core-017](core-017-rcs-checkin-static-diffopts-strcat-overflow.md) | server | `RCS_checkin` `strcat`s encoding onto a `static char[64]` every call — accumulates and overflows |
+| [core-001](core-001-join-file-frees-global-options.md) | update/merge | `join_file` frees the global `options` instead of the local copy — drops sticky `-kb`, possible double free |
+| [blob-001](blob-001-compress-stream-zlib-calls-inflate.md) | blob | streaming ZLIB compressor calls `inflate()` instead of `deflate()` |
+| [blob-002](blob-002-split-header-hdrpart-miscalc.md) | blob | `decode_stream_blob_data` miscomputes header-part size when the header is split across chunks — remotely triggerable OOB |
+| [blob-007](blob-007-mmap-failure-not-checked-map-failed.md) | blob | POSIX `mmap` `MAP_FAILED` not detected; `(void*)-1` used as a mapping → server crash |
+| [api-001](api-001-sserver-unscramble-null-deref.md) | protocols | sserver auth: NULL-pointer `strcpy` on malformed scrambled password (pserver guards it, sserver doesn't) |
+| [api-003](api-003-sserver-win32-unscramble-null-deref.md) | protocols | sserver (win32): same Unscramble NULL deref |
+| [api-018](api-018-breaknameintoparts-unbounded-copy-preauth-overflow.md) | win32 | `BreakNameIntoParts` unbounded copy → pre-auth server stack overflow via client username |
+| [api-022](api-022-sspi-unix-client-challenge-overflow.md) | protocols | sspi (unix) client: server-controlled length drives `tcp_read` into a fixed challenge struct |
+| [api-014](api-014-sspi-client-format-string.md) | protocols | sspi client passes a server-controlled string as a printf format |
+| [api-015](api-015-sspi-unix-client-format-string.md) | protocols | sspi (unix) client: same format-string bug |
+
+## Medium
+
+| # | Area | Summary |
+|---|------|---------|
+| [core-002](core-002-checkout-file-resurrect-frees-rcs-node-version.md) | update | `checkout_file` frees RCS-owned version string when resurrecting during a join |
+| [core-003](core-003-bound-merge-by-bugid-null-deref.md) | update | `bound_merge_by_bugid` NULL deref when the bug's earliest change is the first revision |
+| [core-004](core-004-commit-sends-bare-i-argument.md) | client | commit sends bare `i` instead of `-i` for ignore-keywords, breaking option parsing |
+| [core-007](core-007-commit-fileproc-lock-leak-on-error.md) | commit | error paths skip `do_unlock_file`, leaving files write-locked on the lock server |
+| [core-008](core-008-pretag-proc-uninitialized-ret.md) | tag | `pretag_proc` returns an uninitialized value when a trigger lib has no pretag handler |
+| [core-009](core-009-tag-alias-plus-branch-double-free.md) | tag | `cvs tag/rtag -A -b` double-frees the revision string |
+| [core-010](core-010-send-blob-file-direct-unchecked-fopen.md) | blob | `send_blob_file_direct` never checks `fopen` before `fread`/`fclose` |
+| [core-012](core-012-serve-entry-extra-null-deref.md) | server | `serve_entry_extra` NULL deref if `EntryExtra` arrives before any `Entry` (remote) |
+| [core-018](core-018-client-overwrite-existing-never-reset-C.md) | client | `update -C`: `client_overwrite_existing` latches on and never resets, silently overwriting untracked in-the-way files (found during client-port research) |
+| [blob-003](blob-003-oneshot-decompress-unpacked-returns-error.md) | blob | one-shot `decompress()` returns Error for Unpacked data on success; leaks z_stream on error |
+| [blob-005](blob-005-finish-leaks-temp-file-on-error.md) | blob | `finish()` leaks the temp blob file on error paths (remote disk-fill when trust off) |
+| [blob-006](blob-006-blobe-fileio-pull-ignores-from-offset.md) | blob | `blobe_fileio_pull` ignores the `from` offset — corrupts any non-zero-offset pull |
+| [blob-009](blob-009-send-blob-file-data-net-unchecked-fopen.md) | blob | `send_blob_file_data_net` uses `fopen` result without NULL check |
+| [blob-012](blob-012-get-session-blob-ref-unchecked-fopen.md) | blob | `get_session_blob_reference_hash` uses `fopen` result without NULL check |
+| [blob-014](blob-014-start-push-server-should-stop-not-dereferenced.md) | blob | accept loop tests the `should_stop` pointer, not `*should_stop` |
+| [blob-015](blob-015-exchange-session-keys-leaks-decrypt-ctx.md) | blob | `exchange_session_keys` frees the wrong cipher ctx, leaks decrypt ctx per handshake |
+| [blob-016](blob-016-available-disk-space-inverted-error-check.md) | blob | `available_disk_space` inverts the error check — disk-full GC never triggers |
+| [blob-018](blob-018-handle-pull-oversends-partial-range.md) | blob | `handle_pull` over-sends the whole blob for a bounded range request |
+| [api-002](api-002-sserver-win32-uninitialized-certonly.md) | protocols | sserver (win32) uses uninitialized `certonly` when the registry value is absent |
+| [api-004](api-004-sspi-tokensource-sprintf-overflow.md) | protocols | SSPI client: unbounded `sprintf` of hostname into a 60-byte SPN buffer |
+| [api-006](api-006-ext-disconnect-wrong-fd-reset.md) | protocols | `ext_disconnect` resets `current_in` twice, leaving `current_out` stale/closed |
+| [api-007](api-007-fork-disconnect-wrong-fd-reset.md) | protocols | `fork_disconnect`: same double-reset (copy-paste twin of api-006) |
+| [api-011](api-011-cvs-wide-utf8-oob-read.md) | cvsapi | `cvs::wide` UTF-8 decoder reads past end on truncated multibyte |
+| [api-012](api-012-filaccess-mimetype-byte-vs-wchar-oob.md) | cvsapi | `CFileAccess::mimetype` writes NUL at a byte index into a `wchar_t` buffer |
+| [api-013](api-013-unix-socketio-recv-bufpos-corruption.md) | cvsapi | unix `CSocketIO::recv` over-advances `m_bufpos`, dropping buffered bytes |
+| [api-017](api-017-setuid-lsa-rights-wrong-index.md) | win32 | `nt_setuid` reads `lsaUserRights[0]` instead of `[n]` when building token privileges |
+| [api-020](api-020-pserver-auth-end-double-free-missing-return.md) | protocols | pserver auth: double-free + accepts bad protocol end when `server_error` returns |
+| [api-021](api-021-service-unison-setstdhandle-race.md) | service | `DoUnisonThread` races on process-global std handles across connections |
+
+## Low
+
+| # | Area | Summary |
+|---|------|---------|
+| [core-005](core-005-fixaddfile-leaves-really-quiet-set.md) | add | `fixaddfile` fails to restore `really_quiet` (and leaks) on unparseable RCS |
+| [core-006](core-006-rcs-checkout-options-passed-as-nametag.md) | remove/import | keyword-expansion options passed in the `nametag` slot of `RCS_checkout` |
+| [core-016](core-016-scratch-entry-duplicate-entrieslog-line.md) | entries | `Scratch_Entry`/`Rename_Entry` write a duplicate implicit-Add line into `Entries.Log` |
+| [blob-004](blob-004-compress-stream-wrong-ctx-pointer.md) | blob | one-shot `compress_stream` reads StreamType from the wrong pointer in the Unpacked branch |
+| [blob-008](blob-008-set-root-null-contract-crash.md) | blob | `set_root()` dereferences its arg despite a documented nullptr contract |
+| [blob-010](blob-010-ftell-long-truncation-large-files.md) | blob | upload size via `ftell` (`long`) truncates for >2 GB blobs |
+| [blob-011](blob-011-http-err-code-appended-as-char.md) | blob | HTTP error message appends the status code as a raw char |
+| [blob-013](blob-013-pull-at-once-ignores-decode-failure-uninit-tail.md) | blob | `pull_at_once` ignores decode failures, exposes uninitialized tail |
+| [blob-017](blob-017-connect-timeout-format-string-arg-mismatch.md) | blob | `connect_with_timeout` log has two `%d` but one argument (varargs UB) |
+| [blob-019](blob-019-base-repo-trailing-slash-off-by-one.md) | blob | `base_repo` trailing-slash check indexes the NUL terminator, yields `//` |
+| [blob-020](blob-020-atomic-wrapper-assignment-missing-return.md) | blob | `atomic_wrapper` copy-assignment has no return statement (UB) |
+| [blob-021](blob-021-sample-pushfile-chunk-size-arithmetic.md) | blob (sample) | sample `cafs_client` PUSHFILE computes the wrong chunk size |
+| [blob-022](blob-022-sample-server-wont-compile.md) | blob (sample) | `sample_server.cpp` does not compile |
+| [api-005](api-005-ssh-key-parse-null-deref.md) | protocols | `ssh_connect` dereferences `strchr` result before its NULL check |
+| [api-008](api-008-ext-expand-command-line-overflow.md) | protocols | ext `expand_command_line`: unbounded `%`-expansion strcpy + off-by-one |
+| [api-010](api-010-server-rsh-read-return-truncated.md) | protocols | server (rsh): `tcp_read` int return truncated into `unsigned char` |
+| [api-016](api-016-common-proxy-error-missing-format-specifier.md) | protocols | `tcp_connect_http`: proxy error text dropped due to missing `%s` |
+| [api-019](api-019-zeroconf-srv-resize-underflow.md) | cvsapi | Zeroconf SRV parse: `size_t` underflow in `resize(i-1)` on crafted mDNS name |
+
+## Themes worth noting
+
+* **Large-file (>2 GB/4 GB) handling in the legacy non-blob transfer path is
+  broken in both directions and both processes** (core-011 client send,
+  core-013 server receive, core-015 server send). The newer blob path uses
+  `uint64_t`/`atoll` correctly, but any fallback to `Modified`/`Updated`
+  truncates. This directly undermines the fork's reason to exist.
+* **Copy-paste divergence between sibling implementations**: pserver vs
+  sserver Unscramble guard (api-001), win32 vs unix `recv` bookkeeping
+  (api-013), ext vs fork disconnect (api-006/007), UNICODE vs ANSI bounds
+  (api-018). When fixing one, check its twin.
+* **Unvalidated on-wire lengths in the network/auth layer** (api-009,
+  api-018, api-022) are the most security-sensitive: remotely reachable,
+  pre-authentication, memory-corrupting.
+* **Blob-reference feature bugs** (core-014, core-010, blob-002, blob-006)
+  sit directly in the fork's flagship code.
+
+See [../docs/performance.md](../docs/performance.md) for the separate
+update/tag/branch scaling analysis (`perf-analysis.md` in this folder).

--- a/_reports/api-001-sserver-unscramble-null-deref.md
+++ b/_reports/api-001-sserver-unscramble-null-deref.md
@@ -1,0 +1,83 @@
+---
+# sserver auth: NULL-pointer strcpy when client sends malformed scrambled password
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sserver.cpp
+- **Line(s):** 498
+- **Severity:** high
+- **Confidence:** high
+- **Category:** security
+
+## Code
+```cpp
+    server_getline(protocol, &tmp, PATH_MAX);
+    if (strcmp (tmp,
+        sserver_protocol_interface.verify_only ?
+        "END SSL VERIFICATION REQUEST" : "END SSL AUTH REQUEST")
+    != 0)
+    {
+        server_printf ("bad auth protocol end: %s\n", tmp);
+        free(tmp);
+        return CVSPROTO_FAIL;
+    }
+
+    strcpy(sserver_protocol_interface.auth_password, scramble.Unscramble(sserver_protocol_interface.auth_password));
+```
+
+`CScramble::Unscramble()` (cvstools/Scramble.cpp:63-76) returns `NULL` whenever the
+first byte of the cipher text is not `'A'`:
+
+```cpp
+const char *CScramble::Unscramble(const char *cypher)
+{
+    const unsigned char *s = (unsigned char *)(cypher+1);
+    unsigned char *d;
+    if(cypher[0]!='A')
+        return NULL;
+    ...
+}
+```
+
+## Why this is a bug
+`auth_password` is read straight off the wire from the (as-yet unauthenticated)
+client via `server_getline()`. On the server side this is attacker-controlled input.
+If the client sends a password line whose first character is not `'A'` — including the
+trivial case of an *empty* password line, where `server_getline` yields `""` and
+`cypher[0]=='\0'` — `Unscramble()` returns `NULL`, and the code calls
+`strcpy(dst, NULL)`, which dereferences a NULL pointer and crashes the server
+connection handler.
+
+This is reachable pre-authentication: the SSL layer is set up with
+`SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL)` without
+`SSL_VERIFY_FAIL_IF_NO_PEER_CERT`, so `SSL_accept()` succeeds even when the client
+presents no certificate. An attacker only needs to complete the SSL handshake and send
+`BEGIN SSL AUTH REQUEST` / repository / username / a non-'A' password / `END SSL AUTH
+REQUEST`. The result is a remotely triggerable crash (denial of service).
+
+The sibling pserver implementation handles exactly this case correctly
+(pserver.cpp:229-235):
+
+```cpp
+const char *unscrambled_password = scramble.Unscramble(pserver_protocol_interface.auth_password);
+if(!unscrambled_password || !*unscrambled_password)
+{
+    CServerIo::trace(1,"PROTOCOL VIOLATION: Invalid scrambled password sent by client...");
+    unscrambled_password="";
+}
+strcpy(pserver_protocol_interface.auth_password, unscrambled_password);
+```
+
+The sserver path is missing that guard.
+
+## Suggested fix
+Mirror the pserver guard:
+```cpp
+const char *unscrambled = scramble.Unscramble(sserver_protocol_interface.auth_password);
+if(!unscrambled)
+{
+    CServerIo::trace(1,"PROTOCOL VIOLATION: Invalid scrambled password sent by client.");
+    unscrambled = "";
+}
+strcpy(sserver_protocol_interface.auth_password, unscrambled);
+```
+(The destination buffer is at least as large as the source, so the copy itself is safe
+once the NULL is handled.)
+---

--- a/_reports/api-002-sserver-win32-uninitialized-certonly.md
+++ b/_reports/api-002-sserver-win32-uninitialized-certonly.md
@@ -1,0 +1,57 @@
+---
+# sserver (win32) uses uninitialized `certonly` when CertificatesOnly registry value is absent
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sserver_win32.cpp
+- **Line(s):** 361, 375-376, 460
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+int sserver_auth_protocol_connect(const struct protocol_interface *protocol, const char *auth_string)
+{
+    CScramble scramble;
+    char *tmp;
+    int certonly;                 // <-- NOT initialized
+    ...
+    if(!CGlobalSettings::GetGlobalValue("cvsnt","PServer","CertificatesOnly",keyfile,sizeof(keyfile)))
+        certonly = atoi(keyfile); // <-- only assigned when the value exists
+    ...
+    switch(certonly)              // <-- read here; may be indeterminate
+    {
+    case 0:
+        break;
+    case 1:
+        if(!cert) { ... return CVSPROTO_AUTHFAIL; }
+        free(sserver_protocol_interface.auth_password);
+        sserver_protocol_interface.auth_password = NULL;
+        break;
+    case 2:
+        if(!cert) { ... return CVSPROTO_AUTHFAIL; }
+        break;
+    };
+```
+
+## Why this is a bug
+`certonly` is declared without an initializer. It is assigned only inside the `if(!CGlobalSettings::GetGlobalValue(...))` branch, i.e. only when the `CertificatesOnly`
+registry value is present and readable. When that value is *absent* — which is the
+default configuration for a password-based sserver — `GetGlobalValue` returns non-zero,
+the assignment is skipped, and `switch(certonly)` reads an indeterminate stack value.
+
+This is undefined behavior. In practice it makes the server's authentication policy
+depend on stack garbage: if the garbage happens to be `1` or `2`, the server will
+demand a client certificate (`case 1`/`case 2` → `CVSPROTO_AUTHFAIL` when the client
+presented none) or free/NULL the password (`case 1`), instead of performing normal
+password authentication. The result can be intermittent, machine-dependent
+authentication failures (or an unintended change in whether the password is even
+considered).
+
+The portable Unix implementation gets this right — sserver.cpp:385 declares
+`int certonly = 0;`. The win32 port dropped the initializer.
+
+## Suggested fix
+Initialize the variable to the safe default:
+```cpp
+int certonly = 0;
+```
+---

--- a/_reports/api-003-sserver-win32-unscramble-null-deref.md
+++ b/_reports/api-003-sserver-win32-unscramble-null-deref.md
@@ -1,0 +1,55 @@
+---
+# sserver (win32) auth: NULL-pointer strcpy when client sends malformed scrambled password
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sserver_win32.cpp
+- **Line(s):** 456
+- **Severity:** high
+- **Confidence:** high
+- **Category:** security
+
+## Code
+```cpp
+    server_getline(protocol, &tmp, MAX_PATH);
+    if (strcmp (tmp,
+        sserver_protocol_interface.verify_only ?
+        "END SSL VERIFICATION REQUEST" : "END SSL AUTH REQUEST")
+    != 0)
+    {
+        server_printf ("bad auth protocol end: %s\n", tmp);
+        free(tmp);
+        return CVSPROTO_FAIL;
+    }
+
+    strcpy(sserver_protocol_interface.auth_password, scramble.Unscramble(sserver_protocol_interface.auth_password));
+```
+
+## Why this is a bug
+This is the Windows/SChannel port of the same defect reported in
+api-001 (protocols/sserver.cpp:498). `CScramble::Unscramble()`
+(cvstools/Scramble.cpp:63-76) returns `NULL` whenever the cipher text does not begin
+with `'A'`:
+
+```cpp
+if(cypher[0]!='A')
+    return NULL;
+```
+
+`auth_password` is read directly from the network from the not-yet-authenticated
+client via `server_getline()`. If the client sends a password line whose first byte is
+not `'A'` (including an empty line, which yields `""`), `Unscramble()` returns `NULL`
+and the server executes `strcpy(dst, NULL)` — a NULL-pointer dereference that crashes
+the connection handler. It is reachable after only the SChannel handshake (a client
+certificate is explicitly optional, see the `SEC_E_NO_CREDENTIALS` handling around
+line 401), so an unauthenticated peer can trigger it: remote denial of service.
+
+The pserver implementation guards this correctly (pserver.cpp:229-235); both sserver
+variants do not.
+
+## Suggested fix
+Add the same NULL guard used by pserver before copying:
+```cpp
+const char *unscrambled = scramble.Unscramble(sserver_protocol_interface.auth_password);
+if(!unscrambled)
+    unscrambled = "";
+strcpy(sserver_protocol_interface.auth_password, unscrambled);
+```
+---

--- a/_reports/api-004-sspi-tokensource-sprintf-overflow.md
+++ b/_reports/api-004-sspi-tokensource-sprintf-overflow.md
@@ -1,0 +1,49 @@
+---
+# SSPI client: unbounded sprintf of hostname into 60-byte SPN buffer
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sspi.cpp
+- **Line(s):** 662, 693
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+int ClientAuthenticate(const char *protocol, const char *name, const char *pwd, const char *domain, const char *hostname)
+{
+    ...
+    char myTokenSource[DNLEN*4];         // DNLEN == 15 -> 60 bytes
+    ...
+    if(strcmp(secPackInfo->Name,"Schannel"))
+    {
+        ...
+        sprintf (myTokenSource, "cvs/%s", hostname);   // <-- unbounded
+    }
+    else
+    {
+        ...
+        strncpy(myTokenSource,hostname,sizeof(myTokenSource));  // bounded (Schannel branch)
+    }
+```
+
+## Why this is a bug
+`myTokenSource` is a fixed 60-byte stack buffer (`DNLEN` is 15 in `<lmcons.h>`). In the
+NTLM/Kerberos/Negotiate branch the service principal name is built with an unbounded
+`sprintf(... "cvs/%s", hostname)`. `hostname` is the CVSROOT host and is not length
+checked anywhere on this path. Writing `"cvs/"` (4 bytes) + hostname + NUL overflows the
+buffer whenever the hostname is 56 characters or longer — well within the range of a
+legitimate fully-qualified domain name (DNS names may be up to 255 characters).
+
+The result is a classic stack buffer overflow that can corrupt the return address /
+adjacent locals and crash (or potentially be exploited). Note the sibling Schannel
+branch (line 728) correctly uses a bounded `strncpy(..., sizeof(myTokenSource))`, which
+shows the size limit was known; the `sprintf` path simply forgot it.
+
+## Suggested fix
+Use a bounded formatter and size the buffer for a real hostname, e.g.:
+```cpp
+char myTokenSource[MAX_PATH];
+...
+snprintf(myTokenSource, sizeof(myTokenSource), "cvs/%s", hostname);
+```
+(and make the Schannel branch's `strncpy` explicitly NUL-terminate).
+---

--- a/_reports/api-005-ssh-key-parse-null-deref.md
+++ b/_reports/api-005-ssh-key-parse-null-deref.md
@@ -1,0 +1,63 @@
+---
+# ssh_connect: strchr result dereferenced before its NULL check when parsing stored key
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/ssh.cpp
+- **Line(s):** 200-206
+- **Severity:** low
+- **Confidence:** high
+- **Category:** memory
+
+## Code
+```cpp
+if(!strncmp(crypt_password,"KEY;",4))
+{
+    key=strchr(crypt_password+4,';');
+    if(!key || !*key)
+    {
+        /* Something wrong - ignore password */
+        server_error(1,"No password or key set.  Try 'cvs login'\n");
+    }
+    *key++ = '\0';
+    key=strchr(key,';');
+    *key++ = '\0';                       // <-- line 201: deref BEFORE the check
+    if(!key || !*key)                    // <-- line 202: check happens too late
+    {
+        /* Something wrong - ignore password */
+        server_error(1,"No password or key set.  Try 'cvs login'\n");
+    }
+    version = crypt_password+4;
+}
+```
+
+## Why this is a bug
+The second `strchr` (line 200) can return `NULL` when the stored password value has a
+`KEY;` prefix and a first `;` but no second `;` (e.g. a value like `"KEY;a;b"`, which has
+exactly one `;` in the tail). Line 201 then executes `*key++ = '\0'` on that `NULL`
+pointer, writing to address 0 and crashing, *before* the guard on lines 202-206 gets a
+chance to run. The guard is therefore misordered/dead: by the time it runs, `key` has
+already been dereferenced and incremented, so `!key` can never be true.
+
+Contrast the first occurrence (lines 193-199), where the `if(!key || !*key)` check is
+placed *before* the `*key++`. The second occurrence dropped that ordering.
+
+The input comes from the local `cvspass` store, so this is not directly
+attacker-controlled in normal use; it triggers on a corrupted, hand-edited, or
+foreign-format stored key entry. Still a genuine NULL-pointer write.
+
+(Also note both `server_error(1,...)` calls here only avoid the subsequent deref if
+`server_error` with fatal=1 never returns; if it can return, line 199 has the same
+exposure.)
+
+## Suggested fix
+Check the pointer before dereferencing, mirroring the first block:
+```cpp
+key=strchr(key,';');
+if(!key || !*key)
+{
+    server_error(1,"No password or key set.  Try 'cvs login'\n");
+    return CVSPROTO_FAIL;   /* or otherwise stop */
+}
+*key++ = '\0';
+```
+and make the first block `return`/stop after `server_error` rather than falling through
+to `*key++`.
+---

--- a/_reports/api-006-ext-disconnect-wrong-fd-reset.md
+++ b/_reports/api-006-ext-disconnect-wrong-fd-reset.md
@@ -1,0 +1,49 @@
+---
+# ext_disconnect resets current_in twice, leaving current_out as a stale/closed fd
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/ext.cpp
+- **Line(s):** 185-189
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+int ext_disconnect(const struct protocol_interface *protocol)
+{
+    if(current_in>0)
+    {
+        close(current_in);
+        current_in=-1;
+    }
+    if(current_out>0)
+    {
+        close(current_out);
+        current_in=-1;        // <-- should be current_out=-1
+    }
+    return CVSPROTO_SUCCESS;
+}
+```
+
+## Why this is a bug
+After closing `current_out`, the code assigns `current_in=-1` a second time instead of
+`current_out=-1`. `current_out` (a module-level `static`) therefore retains the value of
+the file descriptor that was just closed.
+
+On a subsequent `ext_disconnect` (or a reconnect that leaves the stale value in place),
+`if(current_out>0)` is still true, so `close(current_out)` runs again on an
+already-closed descriptor. If that descriptor number has since been reused by another
+`open`/`socket`/pipe in the process, this closes an unrelated, live fd — leading to
+mysterious I/O failures or, in a server context, closing a descriptor belonging to
+another operation. This is a classic double-close / fd-confusion defect.
+
+The identical typo exists in fork.cpp (fork_disconnect) — see api-007.
+
+## Suggested fix
+```cpp
+    if(current_out>0)
+    {
+        close(current_out);
+        current_out=-1;
+    }
+```
+---

--- a/_reports/api-007-fork-disconnect-wrong-fd-reset.md
+++ b/_reports/api-007-fork-disconnect-wrong-fd-reset.md
@@ -1,0 +1,45 @@
+---
+# fork_disconnect resets current_in twice, leaving current_out as a stale/closed fd
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/fork.cpp
+- **Line(s):** 146-150
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+int fork_disconnect(const struct protocol_interface *protocol)
+{
+    if(current_in>0)
+    {
+        close(current_in);
+        current_in=-1;
+    }
+    if(current_out>0)
+    {
+        close(current_out);
+        current_in=-1;        // <-- should be current_out=-1
+    }
+    return CVSPROTO_SUCCESS;
+}
+```
+
+## Why this is a bug
+Same copy-paste defect as ext.cpp (api-006). After `close(current_out)` the code sets
+`current_in=-1` again instead of `current_out=-1`, so the module-level `static
+current_out` keeps the already-closed descriptor value.
+
+A later `fork_disconnect` then sees `current_out>0` and calls `close()` on the stale
+descriptor a second time. If that fd number has been reused in the meantime, an
+unrelated live descriptor is closed, causing hard-to-diagnose I/O errors. Double-close
+of a descriptor is undefined/dangerous.
+
+## Suggested fix
+```cpp
+    if(current_out>0)
+    {
+        close(current_out);
+        current_out=-1;
+    }
+```
+---

--- a/_reports/api-008-ext-expand-command-line-overflow.md
+++ b/_reports/api-008-ext-expand-command-line-overflow.md
@@ -1,0 +1,70 @@
+---
+# ext expand_command_line: unbounded %-expansion strcpy and off-by-one terminator write
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/ext.cpp
+- **Line(s):** 219-249
+- **Severity:** low
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+int expand_command_line(char *result, int length, const char *command, const cvsroot* root)
+{
+    const char *p;
+    char *q;
+
+    q=result;
+    for(p=command; *p && (q-result)<length; p++)
+    {
+        if(*p=='%')
+        {
+            switch(*(p+1))
+            {
+            ...
+            case 'u':
+                strcpy(q, get_username(root));   // no bound check
+                q+=strlen(q);
+                break;
+            case 'h':
+                strcpy(q, root->hostname);       // no bound check
+                q+=strlen(q);
+                break;
+            case 'd':
+                strcpy(q, root->directory);      // no bound check
+                q+=strlen(q);
+                break;
+            }
+            p++;
+        }
+        else
+            *(q++)=*p;
+    }
+    *(q++)='\0';                                 // can write result[length]
+    return 0;
+}
+```
+
+## Why this is a bug
+Two distinct overruns of the caller's `result` buffer (`command_line[1024]` in
+`ext_connect`):
+
+1. The loop guard `(q-result)<length` limits the number of *iterations* but not the
+   length written per iteration. Each `%u`/`%h`/`%d` case does a raw `strcpy` of the
+   username / hostname / directory into `q` with no remaining-space check, so a long
+   CVSROOT field writes past the end of `result`.
+
+2. Off-by-one on the terminator: the char-copy branch can advance `q` until
+   `q-result == length` (it writes `result[length-1]` and increments), the loop then
+   exits, and `*(q++)='\0'` writes `result[length]` — one byte beyond the buffer — even
+   when no `%` expansion is involved.
+
+These fields originate from the (client-side) CVSROOT, so this is not typically
+remotely controlled, but overlong values (a long repository `directory`, a long FQDN)
+corrupt the stack. The command string is then handed to `run_command`.
+
+## Suggested fix
+Track remaining space and bound every write, e.g. build with `snprintf`/`cvs::sprintf`
+into a sized buffer, or before each `strcpy` verify
+`strlen(src) < length-(q-result)` and truncate/fail otherwise; reserve one byte for the
+final NUL so the loop stops at `length-1`.
+---

--- a/_reports/api-009-sspi-unix-server-read-buffer-overflow.md
+++ b/_reports/api-009-sspi-unix-server-read-buffer-overflow.md
@@ -1,0 +1,66 @@
+---
+# sspi (unix) server: client-controlled length drives read() into fixed 1024-byte stack buffer (remote pre-auth overflow)
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sspi_unix.cpp
+- **Line(s):** 228-230, 264-266, 274
+- **Severity:** critical
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+int sspi_auth_protocol_connect(const struct protocol_interface *protocol, const char *auth_string)
+{
+    ...
+    short len;
+    char line[1024];
+    char buf[1024];
+    ...
+    do
+    {
+    read(current_server()->in_fd,&len,2);        // len fully controlled by client
+    len=ntohs(len);
+    l=read(current_server()->in_fd,buf,len);     // <-- read up to `len` bytes into buf[1024]
+    if(l<0)
+      return CVSPROTO_FAIL;
+    ...
+    l=base64enc((unsigned char *)buf,(unsigned char *)line+3,len);  // also overflows line[]
+    ...
+```
+
+## Why this is a bug
+This is the server side of the `:sspi:` (winbind/NTLM) handshake, executed *before the
+client is authenticated*. `len` is a signed `short` read straight off the network. It is
+byte-swapped and then used, unchecked, as the byte count for
+`read(in_fd, buf, len)` where `buf` is a fixed 1024-byte stack array.
+
+- If the client sends any length > 1024 (e.g. 2000), `read` writes up to 2000 bytes into
+  the 1024-byte `buf`, smashing the stack.
+- Worse, `len` is *signed*: a value like `0x8000` becomes `-32768` after `ntohs`/assign,
+  which, converted to the `size_t` parameter of `read`, is an enormous count — an
+  effectively unbounded overflow.
+
+Because `buf` is a stack buffer, this is a classic remotely-triggerable stack buffer
+overflow reachable prior to authentication (the attacker only needs to reach the SSPI
+auth handshake). A second overflow follows at line 274, where `base64enc` expands `len`
+bytes (4/3 growth) into `line+3` (a 1021-byte tail of `line[1024]`).
+
+This path is gated on the server having a `WinbindWrapper` configured (see `init()`,
+which nulls `auth_protocol_connect` when it is unset). When SSPI/winbind auth is enabled,
+this is a critical remote code-execution / crash vector.
+
+Note the Win32 sibling (sspi.cpp `ServerAuthenticate`) avoids this by `malloc`-ing the
+client-specified size instead of reading into a fixed buffer; the unix port does not.
+
+## Suggested fix
+Validate the length against the buffer size (and treat it as unsigned) before reading,
+and check the `read` return values:
+```cpp
+unsigned short ulen;
+if (read(current_server()->in_fd,&ulen,2) != 2) return CVSPROTO_FAIL;
+ulen = ntohs(ulen);
+if (ulen > sizeof(buf)) return CVSPROTO_FAIL;
+l = read(current_server()->in_fd, buf, ulen);
+if (l < 0) return CVSPROTO_FAIL;
+```
+Also bound the subsequent `base64enc` output so it cannot exceed `sizeof(line)-3`.
+---

--- a/_reports/api-010-server-rsh-read-return-truncated.md
+++ b/_reports/api-010-server-rsh-read-return-truncated.md
@@ -1,0 +1,49 @@
+---
+# server (rsh): tcp_read int return truncated into unsigned char, defeating error check
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/server.cpp
+- **Line(s):** 123, 164-166
+- **Severity:** low
+- **Confidence:** medium
+- **Category:** error-handling
+
+## Code
+```cpp
+    unsigned char c;
+    ...
+    if(tcp_read(&c,1)<1)
+        return CVSPROTO_FAIL;
+    if(c)
+    {
+        char msg[257];
+        if((c=tcp_read(msg,256))<1)     // tcp_read returns int; c is unsigned char
+            return CVSPROTO_FAIL;
+        msg[c]='\0';
+        server_error(0,"rsh server reported: %s",msg);
+        return CVSPROTO_FAIL;
+    }
+```
+
+## Why this is a bug
+`tcp_read` returns an `int` (byte count, or a negative value on error). Its result is
+assigned to `unsigned char c` *before* the `<1` comparison. The truncation to 8 bits
+breaks the error check:
+
+- On a read error, `tcp_read` returns `-1`; `(unsigned char)(-1)` is `255`, so `255 < 1`
+  is false. The code does *not* return failure — it proceeds to `msg[255]='\0'` and
+  prints a buffer that was never filled (uninitialized stack contents).
+- A full 256-byte read returns `256`; `(unsigned char)256` is `0`, so `0 < 1` is true and
+  a complete message is misreported as a failed read.
+
+No overflow occurs (`msg[257]`, `c<=255`), so impact is limited to mis-handling the
+error/short-read case and leaking uninitialized stack bytes into an error message. This
+is the rarely used client-side `:server:` (rsh) path.
+
+## Suggested fix
+Use a separate `int` for the return value and range-check before indexing:
+```cpp
+int n = tcp_read(msg, 256);
+if (n < 1)
+    return CVSPROTO_FAIL;
+msg[n] = '\0';
+```
+---

--- a/_reports/api-011-cvs-wide-utf8-oob-read.md
+++ b/_reports/api-011-cvs-wide-utf8-oob-read.md
@@ -1,0 +1,54 @@
+---
+# cvs::wide UTF-8 decoder reads past end of string on truncated multibyte sequence
+- **File:** cvsnt/cvsnt-2.5.05.3744/cvsapi/cvs_string.h
+- **Line(s):** 225-235 (function utf82ucs2)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** memory
+
+## Code
+```cpp
+void utf82ucs2(const char *src)
+{
+    unsigned char *p=(unsigned char *)src;
+    wchar_t ch;
+    size_t strlen_src=(src)?strlen(src):0;
+    w_str.reserve(strlen_src);
+    while(*p)
+    {
+        if(*p<0x80) { ch = p[0]; p++; }
+        else if(*p<0xe0) { ch = ((p[0]&0x3f)<<6)+(p[1]&0x3f); p+=2; }
+        else if(*p<0xf0) { ch = ((p[0]&0x1f)<<12)+((p[1]&0x3f)<<6)+(p[2]&0x3f); p+=3; }
+        else if(*p<0xf8) { ch = ...p[3]...; p+=4; }
+        else if(*p<0xfc) { ch = ...p[4]...; p+=5; }
+        else if(*p<0xfe) { ch = ...p[5]...; p+=6; }
+        else { ch = '?'; p++; }
+        w_str+=(wchar_t)ch;
+    }
+}
+```
+
+## Why this is a bug
+The decoder chooses how many bytes to consume based purely on the lead byte and then
+reads the continuation bytes `p[1]..p[5]` without checking that they lie within the
+input string. When `src` ends with a truncated multibyte sequence — e.g. a lone lead
+byte `0xF0` immediately before the terminating NUL — the code reads `p[1]` (the NUL),
+`p[2]`, `p[3]` (both past the end of the buffer) and then does `p+=4`, stepping the
+cursor *past* the NUL terminator. The `while(*p)` guard then continues reading whatever
+memory follows until it happens to hit a zero byte, so a single malformed trailing byte
+turns into an unbounded out-of-bounds read (crash / DoS, or leakage of adjacent heap
+bytes into the produced wide string).
+
+`cvs::wide` is the standard UTF-8 to UTF-16 helper used throughout the Win32 layer to
+feed file names and paths into wide Windows APIs, so malformed UTF-8 arriving from a
+repository path, filename, or protocol field can reach it. Continuation bytes are also
+never validated (they need not have the `10xxxxxx` form), which compounds the
+over-read.
+
+## Suggested fix
+Bound every access to the known length and validate continuation bytes, e.g. compute the
+sequence length, check `p + n <= src + strlen_src`, verify each continuation byte is
+`0x80..0xBF`, and emit `'?'` (and stop/advance by one) on any violation instead of
+reading ahead. The sibling `narrow`/`ucs22utf8` encoder is fine; only the decoder lacks
+bounds checks.
+---

--- a/_reports/api-012-filaccess-mimetype-byte-vs-wchar-oob.md
+++ b/_reports/api-012-filaccess-mimetype-byte-vs-wchar-oob.md
@@ -1,0 +1,47 @@
+---
+# CFileAccess::mimetype writes NUL at byte-count index into wchar_t buffer (OOB write)
+- **File:** cvsnt/cvsnt-2.5.05.3744/cvsapi/win32/FileAccess.cpp
+- **Line(s):** 580-587
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+TCHAR str[256];
+DWORD len = sizeof(str)-sizeof(TCHAR);            // 512 - 2 = 510 (BYTES)
+if(RegQueryValueEx(hk,L"Content Type",NULL,NULL,(LPBYTE)str,&len))
+{
+    RegCloseKey(hk);
+    return "";
+}
+str[len]='\0';                                    // len is BYTES, str is wchar_t[]
+return (const char *)cvs::narrow(str);
+```
+
+## Why this is a bug
+`RegQueryValueEx` reports the size of the returned data in **bytes** via `len`. `str` is
+`TCHAR str[256]`, i.e. `wchar_t[256]` in this Unicode build, so `str[len]` indexes by
+*wide characters* — it writes at byte offset `len * 2`.
+
+For a `Content Type` registry value larger than 256 bytes (128 wide chars) but not so
+large that the call fails with `ERROR_MORE_DATA` (the cap is 510 bytes), `len` lands in
+[256, 510], and `str[len]` writes a 2-byte NUL at wide-char index 256..510 — byte offset
+512..1020 — which is up to ~508 bytes past the end of the 512-byte stack buffer. That is
+an out-of-bounds stack write. Even for shorter values the terminator is placed at twice
+the intended offset.
+
+The value comes from `HKEY_CLASSES_ROOT\<.ext>\Content Type`, selected by the file's
+extension, so a file whose extension maps to an unusually long registry Content Type
+triggers the overwrite.
+
+## Suggested fix
+Index by wide-character count, and guard the range:
+```cpp
+DWORD n = len / sizeof(TCHAR);
+if(n >= (sizeof(str)/sizeof(TCHAR))) n = (sizeof(str)/sizeof(TCHAR)) - 1;
+str[n]='\0';
+```
+(REG_SZ data is normally already NUL-terminated, but the terminator index must be a
+character count, not a byte count.)
+---

--- a/_reports/api-013-unix-socketio-recv-bufpos-corruption.md
+++ b/_reports/api-013-unix-socketio-recv-bufpos-corruption.md
@@ -1,0 +1,55 @@
+---
+# unix CSocketIO::recv over-advances m_bufpos (drops buffered bytes) — diverges from win32
+- **File:** cvsnt/cvsnt-2.5.05.3744/cvsapi/unix/SocketIO.cpp
+- **Line(s):** 308-313 (esp. 311)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+unix (buggy):
+```cpp
+    m_buflen = rd;
+    if((len-oldlen)<=m_buflen)
+    {
+        memcpy(buf+oldlen,m_buffer,len-oldlen);
+        m_bufpos+=len;                 // <-- wrong
+        return len;
+    }
+```
+win32 (correct — same function, FileAccess sibling):
+```cpp
+    m_buflen = rd;
+    if((len-oldlen)<=m_buflen)
+    {
+        memcpy(buf+oldlen,m_buffer,len-oldlen);
+        m_bufpos+=(len-oldlen);        // <-- correct
+        return len;
+    }
+```
+
+## Why this is a bug
+This branch is reached when the request could not be satisfied from the bytes already
+buffered, so the code first copies the `oldlen` leftover bytes into `buf[0..oldlen-1]`,
+refills `m_buffer` with `rd` freshly-read bytes (resetting `m_bufpos=0`), then copies the
+remaining `len-oldlen` bytes out of the new buffer into `buf[oldlen..len-1]`.
+
+The number of bytes consumed *from the freshly read buffer* is therefore `len-oldlen`,
+so `m_bufpos` must become `len-oldlen`. The unix version instead does `m_bufpos+=len`,
+overshooting by `oldlen`. On the next `recv`, reads resume from `m_buffer[len]` instead of
+`m_buffer[len-oldlen]`, silently **skipping `oldlen` bytes** of received data — a stream
+corruption/desync. (The win32 twin computes `m_bufpos+=(len-oldlen)`, confirming the
+intended value.)
+
+The defect only manifests when `recv` is called with `len > 1` and there was leftover
+buffered data (`oldlen > 0`); the common `getline` path uses `recv(&c,1)` where
+`oldlen` is always 0, which is why it hides. But multi-byte callers exist and use this
+exact unix path, e.g. `cvstools/unix/GlobalSettings.cpp:53`
+(`sock.recv(buffer,buffer_len)`), so corrupted reads are reachable.
+
+## Suggested fix
+```cpp
+    m_bufpos += (len - oldlen);
+```
+to match the win32 implementation and the buffer invariant.
+---

--- a/_reports/api-014-sspi-client-format-string.md
+++ b/_reports/api-014-sspi-client-format-string.md
@@ -1,0 +1,53 @@
+---
+# sspi client passes server-controlled string as printf format to server_error (format-string bug)
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sspi.cpp
+- **Line(s):** 241-245 (server_error at 244)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** security
+
+## Code
+```cpp
+    tcp_readline(protocols, sizeof(protocols));
+    if((p=strstr(protocols,"[server aborted"))!=NULL)
+    {
+        server_error(1, p);          // p points into a server-supplied line
+        return CVSPROTO_FAIL;
+    }
+```
+`server_error` (protocols/common.cpp:178) forwards its argument straight into a
+`vsnprintf(temp, sizeof(temp), fmt, va)`:
+```cpp
+int server_error(int fatal, const char *fmt, ...) {
+    char temp[1024]; va_list va; va_start(va,fmt);
+    vsnprintf(temp,sizeof(temp),fmt,va);   // fmt == p, no matching varargs
+    ...
+}
+```
+
+## Why this is a bug
+`protocols` is read from the network by `tcp_readline` during the pre-encryption SSPI
+negotiation, so `p` is fully controlled by the peer (a malicious or MITM CVS server).
+It is then used as the *format string* of `server_error`, which passes it to
+`vsnprintf` with no variadic arguments. Any conversion specifiers embedded in the
+server's `"[server aborted ...]"` message are interpreted:
+
+- `%s`/`%x`/`%p` read arbitrary words from the `va_list`/stack — crash or information
+  disclosure;
+- `%n` (where the CRT honors it) writes to memory — potential control-flow corruption.
+
+This is a remotely triggerable format-string vulnerability against the CVS client,
+reachable before any authentication or channel encryption is established.
+
+## Suggested fix
+Always use a constant format string:
+```cpp
+server_error(1, "%s", p);
+```
+The same defect exists in sspi_unix.cpp:164 (see api-015).
+
+## Note
+The nearby call at sspi.cpp:261 (`server_error(1, "...got '%s'...", protocols)`) is
+correct — there `protocols` is an argument, not the format. Only the `server_error(1, p)`
+form is vulnerable.
+---

--- a/_reports/api-015-sspi-unix-client-format-string.md
+++ b/_reports/api-015-sspi-unix-client-format-string.md
@@ -1,0 +1,35 @@
+---
+# sspi (unix) client passes server-controlled string as printf format to server_error
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sspi_unix.cpp
+- **Line(s):** 161-165 (server_error at 164)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** security
+
+## Code
+```cpp
+    tcp_readline(protocols, sizeof(protocols));
+    if((p=strstr(protocols,"[server aborted"))!=NULL)
+    {
+        server_error(1, p);          // p is a server-supplied string used as format
+    }
+```
+
+## Why this is a bug
+Identical defect to api-014 (sspi.cpp), in the unix winbind SSPI client. `protocols` is
+read from the socket by `tcp_readline` during the cleartext SSPI negotiation, so `p` is
+attacker-controlled (malicious or MITM server). It is handed to `server_error` as the
+format string, which passes it to `vsnprintf(temp, sizeof(temp), p, va)` with no
+matching variadic arguments. Format specifiers in the server's `"[server aborted ...]"`
+text are interpreted: `%s`/`%x` cause out-of-bounds `va_list`/stack reads (crash or
+info leak), and `%n` (where honored) yields an arbitrary write.
+
+Note also that, unlike sspi.cpp, this call is not followed by a `return`, so control
+continues after `server_error` (relying on fatal=1 aborting) — but the format-string
+issue is the primary bug.
+
+## Suggested fix
+```cpp
+server_error(1, "%s", p);
+```
+---

--- a/_reports/api-016-common-proxy-error-missing-format-specifier.md
+++ b/_reports/api-016-common-proxy-error-missing-format-specifier.md
@@ -1,0 +1,37 @@
+---
+# tcp_connect_http: proxy error message dropped due to missing %s in format string
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/common.cpp
+- **Line(s):** 250
+- **Severity:** low
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+    if((code/100)!=2)
+    {
+        if(code==407)
+        {
+            ...
+        }
+        else
+            server_error(1,"Proxy server connect failed: ",p?p:"No response");
+    }
+```
+
+## Why this is a bug
+`server_error(int fatal, const char *fmt, ...)` treats its second argument as a
+`printf` format string. Here the format `"Proxy server connect failed: "` contains no
+conversion specifier, so the third argument (`p ? p : "No response"` — the proxy's
+actual status text) is passed but never consumed or printed. The diagnostic silently
+loses the reason the proxy connection failed, making these failures much harder to
+troubleshoot.
+
+This is the inverse of the format-string bugs (api-014/015): there a variable was used
+as the format; here the format forgot the `%s` for its intended argument.
+
+## Suggested fix
+```cpp
+server_error(1,"Proxy server connect failed: %s", p?p:"No response");
+```
+---

--- a/_reports/api-017-setuid-lsa-rights-wrong-index.md
+++ b/_reports/api-017-setuid-lsa-rights-wrong-index.md
@@ -1,0 +1,57 @@
+---
+# nt_setuid: user-rights loop always reads lsaUserRights[0] instead of [n] when building token privileges
+- **File:** cvsnt/cvsnt-2.5.05.3744/windows-NT/setuid.cpp
+- **Line(s):** 350-355 (bug at 353)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+if(LsaEnumerateAccountRights(hLsa,UserSid,&lsaUserRights,&NumUserRights)==ERROR_SUCCESS)
+{
+    TokenPrivs->PrivilegeCount=NumUserRights;
+    TokenPrivs=(PTOKEN_PRIVILEGES)realloc(TokenPrivs,sizeof(TOKEN_PRIVILEGES)+sizeof(LUID_AND_ATTRIBUTES)*TokenPrivs->PrivilegeCount);
+
+    for(n=0,j=0; n<(int)NumUserRights; n++)
+    {
+        TokenPrivs->Privileges[j].Attributes=SE_PRIVILEGE_ENABLED | SE_PRIVILEGE_ENABLED_BY_DEFAULT;
+        LookupPrivilegeValueW(wszMachine,lsaUserRights->Buffer,&TokenPrivs->Privileges[j].Luid);  // <-- lsaUserRights[0]
+        j++;
+    }
+    NetApiBufferFree(lsaUserRights);
+}
+```
+
+## Why this is a bug
+`LsaEnumerateAccountRights` returns an array of `LSA_UNICODE_STRING` in `lsaUserRights`
+with `NumUserRights` elements. The loop iterates `n` over that array but always
+dereferences `lsaUserRights->Buffer`, i.e. `lsaUserRights[0].Buffer`, so it looks up the
+LUID of the *first* privilege name on every iteration. The result is that
+`TokenPrivs->Privileges[0..NumUserRights-1]` are all filled with the LUID of the first
+directly-assigned right, and every other right the account holds is dropped.
+
+The correct index is used just below, in the group-rights loop (line 369 uses
+`lsaUserRights[p].Buffer`), confirming the intended form.
+
+This code builds the privilege set handed to `NtCreateToken` for the impersonation token
+(`nt_setuid`). The defect means the impersonated user's token does not carry the
+privileges actually granted to that account — a security-relevant correctness bug in
+token construction (privileges silently altered/lost; duplicate LUIDs may also make
+`NtCreateToken` behave unexpectedly). The `LookupPrivilegeValueW` return value is also
+unchecked here (contrast line 373), so a lookup failure leaves the `Luid` field
+whatever the reallocated (uninitialized) memory held.
+
+## Suggested fix
+```cpp
+for(n=0,j=0; n<(int)NumUserRights; n++)
+{
+    LUID luid;
+    if(!LookupPrivilegeValueW(wszMachine,lsaUserRights[n].Buffer,&luid))
+        continue;
+    TokenPrivs->Privileges[j].Attributes=SE_PRIVILEGE_ENABLED | SE_PRIVILEGE_ENABLED_BY_DEFAULT;
+    TokenPrivs->Privileges[j].Luid=luid;
+    j++;
+}
+```
+---

--- a/_reports/api-018-breaknameintoparts-unbounded-copy-preauth-overflow.md
+++ b/_reports/api-018-breaknameintoparts-unbounded-copy-preauth-overflow.md
@@ -1,0 +1,73 @@
+---
+# BreakNameIntoParts (UNICODE path) unbounded _tcscpy/_tcsncpy → pre-auth stack overflow via client username
+- **File:** cvsnt/cvsnt-2.5.05.3744/windows-NT/win32.cpp
+- **Line(s):** 530-536 (BreakNameIntoParts), 591-613 (win32_valid_user)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+BreakNameIntoParts:
+```cpp
+    ptr=(TCHAR*)_tcschr(name, '\\');
+    if (ptr)
+    {
+#ifdef _UNICODE
+        _tcscpy(w_name,ptr+1);                 // unbounded
+        _tcsncpy(w_domain,name,ptr-name);      // bound = domain length, not dest size
+        w_domain[ptr-name]='\0';               // index can exceed dest
+#else
+        w_name[MultiByteToWideChar(win32_global_codepage,0,ptr+1,-1,w_name,UNLEN+1)]='\0';   // bounded
+        w_domain[MultiByteToWideChar(win32_global_codepage,0,name,ptr-name,w_domain,DNLEN)]='\0'; // bounded
+#endif
+    }
+    else
+    {
+#ifdef _UNICODE
+        _tcscpy(w_name,name);                  // unbounded
+#else
+        w_name[MultiByteToWideChar(...,w_name,UNLEN+1)]='\0';   // bounded
+#endif
+        ...
+    }
+```
+win32_valid_user (server-side password check, reached before LogonUser):
+```cpp
+    TCHAR User[UNLEN+1] = {0};          // 257 wchars
+    TCHAR Domain[DNLEN+1] = {0};        // 257 wchars (DNLEN is #defined 256 in this file)
+    TCHAR user[UNLEN+DNLEN+2] = {0};    // 514 wchars
+    ...
+    // user := [domain "\\"] username   (client-controlled username copied in)
+    if(BreakNameIntoParts(user, User, Domain, NULL))   // splits 514-wide buffer into 257-wide targets
+        return 0;
+    ...
+    LogonUserW(User,Domain,Password,...);
+```
+
+## Why this is a bug
+`win32_valid_user` validates a username/password pair supplied by an **unauthenticated**
+pserver client. It assembles `user` (a 514-wide-char buffer) from the client's username
+(which may itself contain a `\`), then calls `BreakNameIntoParts` to split it into `User`
+and `Domain`, each only `UNLEN+1`/`DNLEN+1` = 257 wide chars.
+
+The `_UNICODE` branch of `BreakNameIntoParts` copies with `_tcscpy(w_name, ptr+1)` and
+`_tcsncpy(w_domain, name, ptr-name)` (plus `w_domain[ptr-name]='\0'`) using the *source*
+lengths, with no clamp to the destination size. Since the source `user` can hold up to
+~513 wide chars while the destinations hold 257, a username whose component before or
+after the `\` exceeds 256 characters overflows `User` or `Domain` on the stack. The `\0`
+store at `w_domain[ptr-name]` can also land one past the end.
+
+This runs before authentication succeeds (before `LogonUserW`), so it is a remotely
+triggerable, pre-auth server-side stack buffer overflow. The ANSI branch of the same
+function is correctly bounded (it passes `UNLEN+1`/`DNLEN` as `cchWideChar` to
+`MultiByteToWideChar`), and the other caller `win32getpwnam` pre-bounds its input to a
+257-wide buffer — so only the `user`-is-larger-than-target case in `win32_valid_user`
+is exposed. The exact overflow length depends on the username-length cap on the path to
+this function (PATH_MAX), but the unbounded copy is the defect regardless.
+
+## Suggested fix
+Bound the UNICODE copies to the destination capacities, e.g. use `lstrcpynW(w_name,
+ptr+1, UNLEN+1)` and copy at most `min(ptr-name, DNLEN)` wide chars into `w_domain`
+(NUL-terminating within bounds), mirroring the ANSI branch. Additionally, validate/limit
+the username length in `win32_valid_user` before splitting.
+---

--- a/_reports/api-019-zeroconf-srv-resize-underflow.md
+++ b/_reports/api-019-zeroconf-srv-resize-underflow.md
@@ -1,0 +1,42 @@
+---
+# CZeroconf::_service_srv_func: size_t underflow in resize(i-1) on crafted mDNS name
+- **File:** cvsnt/cvsnt-2.5.05.3744/cvsapi/Zeroconf.cpp
+- **Line(s):** 71-84 (bug at 77)
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+void CZeroconf::_service_srv_func(const char *name, unsigned short port, const char *target)
+{
+    cvs::string nm = name;
+    size_t i = nm.find(m_service);
+    if(i==cvs::string::npos)
+        return;
+    nm.resize(i-1);            // i can be 0 -> resize((size_t)-1)
+    ...
+}
+```
+
+## Why this is a bug
+`name` is taken from an mDNS/DNS-SD response, i.e. it is supplied by whatever device is
+answering service discovery on the local network. The code locates the service substring
+with `find`, guards only against `npos`, then trims with `nm.resize(i-1)`, assuming the
+service name is always preceded by at least one character.
+
+If a (malicious or simply malformed) responder returns a name whose text begins with the
+service string, `find` returns `i == 0`, and `i-1` wraps to `SIZE_MAX`.
+`std::string::resize(SIZE_MAX)` throws `std::length_error`/`bad_alloc`, which is not
+caught here, terminating the client. This is a remotely-triggerable (local-segment)
+denial of service when Zeroconf discovery is in use.
+
+## Suggested fix
+Validate `i` before subtracting:
+```cpp
+if(i==cvs::string::npos || i==0)
+    return;
+nm.resize(i-1);
+```
+(or `nm.resize(i ? i-1 : 0)` if an empty service name is acceptable).
+---

--- a/_reports/api-020-pserver-auth-end-double-free-missing-return.md
+++ b/_reports/api-020-pserver-auth-end-double-free-missing-return.md
@@ -1,0 +1,56 @@
+---
+# pserver_auth_protocol_connect: double-free of tmp and accepts bad protocol end if server_error returns
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/pserver.cpp
+- **Line(s):** 219-238
+- **Severity:** medium
+- **Confidence:** low
+- **Category:** memory
+
+## Code
+```cpp
+    server_getline(protocol, &tmp, PATH_MAX);
+    if (strcmp (tmp,
+        pserver_protocol_interface.verify_only ?
+        "END VERIFICATION REQUEST" : "END AUTH REQUEST")
+    != 0)
+    {
+        server_error (1, "bad auth protocol end: %s", tmp);
+        free(tmp);                 // freed here ...
+    }
+
+    const char *unscrambled_password = scramble.Unscramble(...);
+    ...
+    free(tmp);                     // ... and again here
+    return CVSPROTO_SUCCESS;
+```
+
+## Why this is a bug
+When the client's trailing line is not the expected `END AUTH REQUEST` /
+`END VERIFICATION REQUEST`, the code calls `server_error(1, ...)` and `free(tmp)`, but
+does **not** return. Control falls through to the common tail, which frees `tmp` a second
+time (line 237) and returns `CVSPROTO_SUCCESS`.
+
+This is correct only if `server_error` with `fatal=1` never returns (i.e. it aborts the
+request via exit/longjmp). If that callback can return — which is not guaranteed at this
+layer, since `server_error` just forwards to `_current_server->error(...)` — then:
+
+1. `tmp` is freed twice (double-free / heap corruption), and
+2. the server proceeds to accept the authentication with `CVSPROTO_SUCCESS` even though
+   the client violated the protocol framing.
+
+The sibling `sserver_auth_protocol_connect` handles the same situation defensively —
+it frees `tmp` and immediately `return CVSPROTO_FAIL;` (sserver.cpp:493-495), with no
+fall-through. The pserver path lost that `return`, making it rely on `server_error(1)`
+being fatal.
+
+## Suggested fix
+Return after reporting the framing error, mirroring sserver:
+```cpp
+    if (strcmp(tmp, ...) != 0)
+    {
+        server_error(1, "bad auth protocol end: %s", tmp);
+        free(tmp);
+        return CVSPROTO_FAIL;
+    }
+```
+---

--- a/_reports/api-021-service-unison-setstdhandle-race.md
+++ b/_reports/api-021-service-unison-setstdhandle-race.md
@@ -1,0 +1,64 @@
+---
+# cvsservice DoUnisonThread races on process-global std handles across concurrent connections
+- **File:** cvsnt/cvsnt-2.5.05.3744/cvsservice/Service.cpp
+- **Line(s):** 821-838 (esp. 834-838)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** concurrency
+
+## Code
+```cpp
+DWORD CALLBACK DoUnisonThread(LPVOID lpParam)
+{
+    CSocketIOPtr conn = (CSocketIO*)lpParam;
+    CRunFile rf;
+    ...
+    rf.setInput(CRunFile::StandardInput,NULL);
+    rf.setOutput(CRunFile::StandardOutput,NULL);
+    rf.setError(CRunFile::StandardError,NULL);
+
+    SetStdHandle(STD_INPUT_HANDLE,(HANDLE)conn->getsocket());
+    SetStdHandle(STD_OUTPUT_HANDLE,(HANDLE)conn->getsocket());
+    SetStdHandle(STD_ERROR_HANDLE,(HANDLE)conn->getsocket());
+
+    rf.run(NULL);
+    ...
+}
+```
+`CRunFile::run` reads the *process-global* std handles at spawn time
+(cvsapi/win32/RunFile.cpp:167-169):
+```cpp
+si.hStdInput  = (m_inputFn==StandardInput)?GetStdHandle(STD_INPUT_HANDLE):...;
+si.hStdOutput = (m_outputFn==StandardOutput)?GetStdHandle(STD_OUTPUT_HANDLE):...;
+si.hStdError  = (m_errorFn==StandardError)?GetStdHandle(STD_ERROR_HANDLE):...;
+```
+
+## Why this is a bug
+`DoUnisonThread` runs once per accepted Unison connection, each on its own thread
+(`CreateThread(... DoUnisonThread ...)` in ServiceMain). It configures the child to
+inherit the process std handles, then points those *global* handles at this
+connection's socket and spawns `unison.exe`.
+
+`SetStdHandle` mutates state shared by the entire process, and there is no lock around
+the `SetStdHandle`+`run` sequence. If two Unison clients connect close together, the
+interleaving
+
+```
+threadA: SetStdHandle(in/out/err = socketA)
+threadB: SetStdHandle(in/out/err = socketB)
+threadA: rf.run()   // child A inherits socketB (GetStdHandle now returns B)
+threadB: rf.run()   // child B inherits socketB
+```
+
+routes one client's Unison process to another client's socket. That is both a
+correctness failure and a security problem (one authenticated session's data stream is
+handed to a different connection's child process). It can also clobber the service's own
+std handles for other concurrent work.
+
+## Suggested fix
+Serialize the `SetStdHandle`+spawn with a critical section (the code already has
+`g_crit`/`ClientLock`), or better, avoid the global handles entirely: pass the socket to
+the child explicitly (as `DoCvsThread` does with `--win32_socket_io=%ld`), or use
+`CRunFile`'s explicit-handle path so each spawn gets its own inherited handles without
+touching process-global state.
+---

--- a/_reports/api-022-sspi-unix-client-challenge-overflow.md
+++ b/_reports/api-022-sspi-unix-client-challenge-overflow.md
@@ -1,0 +1,52 @@
+---
+# sspi (unix) client: server-controlled length drives tcp_read into fixed challenge struct (remote overflow)
+- **File:** cvsnt/cvsnt-2.5.05.3744/protocols/sspi_unix.cpp
+- **Line(s):** 327, 337-342
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+int ClientAuthenticate(const char *protocol, const char *name, const char *pwd, const char *domain, const char *hostname)
+{
+    tSmbNtlmAuthChallenge challenge;   // fixed struct, sizeof ~= 1076 bytes
+    ...
+    short len;
+    ...
+    if(tcp_read(&len,2)!=2)
+      return 0;
+    if(!len)
+      return 0;
+    if(tcp_read(&challenge,ntohs(len))!=ntohs(len))   // len is server-controlled
+      return 0;
+    buildSmbNtlmAuthResponse(&challenge, &response, ...);
+    ...
+}
+```
+
+## Why this is a bug
+This is the unix `:sspi:` (winbind/NTLM) *client*. During the NTLM handshake the server
+sends a 2-byte length followed by that many bytes of challenge data. The client reads the
+length into `len`, byte-swaps it with `ntohs` (range 0..65535), and then does
+`tcp_read(&challenge, ntohs(len))` into a fixed-size stack struct.
+
+`tSmbNtlmAuthChallenge` is only ~1076 bytes (`ident[8]` + headers + `buffer[1024]` +
+`bufIndex`). There is no check that `ntohs(len) <= sizeof(challenge)`, so a malicious or
+MITM server can specify a length up to 65535 and overflow the struct on the client's
+stack by tens of kilobytes — a remotely triggerable stack buffer overflow against the
+CVS client.
+
+This is the client-side counterpart of the server-side overflow reported in api-009;
+both stem from using an unvalidated on-wire length as the size of a fixed-buffer read.
+
+## Suggested fix
+Clamp the length to the destination size before reading, and check the read:
+```cpp
+unsigned short ulen = ntohs((unsigned short)len);
+if(ulen == 0 || ulen > sizeof(challenge))
+    return 0;
+if(tcp_read(&challenge, ulen) != ulen)
+    return 0;
+```
+---

--- a/_reports/blob-001-compress-stream-zlib-calls-inflate.md
+++ b/_reports/blob-001-compress-stream-zlib-calls-inflate.md
@@ -1,0 +1,34 @@
+# Streaming ZLIB compressor calls inflate() instead of deflate()
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/streaming_compressors.cpp
+- **Line(s):** 218-235 (esp. 226)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+static StreamStatus compress_stream_zlib(z_stream* stream, const char *src, size_t &src_pos, size_t src_size, char *dest, size_t &dest_pos, size_t dest_capacity)
+{
+  while (src_pos < src_size && dest_pos < dest_capacity)
+  {
+    stream->avail_in = (uint32_t)(src_size - src_pos);
+    stream->next_in = (Bytef*)(src + src_pos);
+    stream->avail_out = (uint32_t)(dest_capacity - dest_pos);
+    stream->next_out = (Bytef*)(dest + dest_pos);
+    int result = inflate (stream, Z_NO_FLUSH);   // <-- BUG: this is the COMPRESS path
+    ...
+```
+
+## Why this is a bug
+`compress_stream_zlib` is the ZLIB branch of the public streaming `compress_stream()` (line 259-291, dispatched when `*(StreamType*)ctx == StreamType::ZLIB`). The z_stream held in the ctx was initialized with `deflateInit` in `init_compress_stream` (line 147). Calling `inflate()` on a deflate-initialized stream is invalid: modern zlib's `inflateStateCheck` returns `Z_STREAM_ERROR` (so every streaming ZLIB compression fails), and older zlibs interpret deflate state as inflate state — undefined behavior/possible memory corruption. This is an obvious copy-paste from `decode_stream_zlib` (line 58-75), which is byte-for-byte identical except the error handling.
+
+Note also the paired error-handling logic (lines 229-232) is the copy-pasted inflate logic: `Z_BUF_ERROR` -> Continue, `!= Z_OK` -> Error, which happens to be tolerable for deflate but was never written for it.
+
+Currently nothing in the tree calls streaming compression with `StreamType::ZLIB` (all users pass ZSTD or Unpacked), so the bug is latent — but the function is a public API (`streaming_compressors.h` line 22) and will break the moment anyone compresses a legacy ZLIB blob through it.
+
+## Suggested fix
+```cpp
+int result = deflate(stream, Z_NO_FLUSH);
+```
+and review the result handling for deflate semantics (deflate with Z_NO_FLUSH returns Z_OK on success; Z_BUF_ERROR when no progress is possible, which is a valid Continue).

--- a/_reports/blob-002-split-header-hdrpart-miscalc.md
+++ b/_reports/blob-002-split-header-hdrpart-miscalc.md
@@ -1,0 +1,36 @@
+# decode_stream_blob_data miscomputes header-part size when BlobHeader is split across chunks (OOB write/read)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/streaming_blobs.h
+- **Line(s):** 55-71 (esp. 57-58)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** memory
+
+## Code
+```cpp
+  if (info.dataRead < sizeof(BlobHeader))
+  {
+    size_t hdrPart = (data_length - info.dataRead);            // <-- BUG
+    hdrPart = hdrPart < sizeof(BlobHeader) ? hdrPart : sizeof(BlobHeader);
+    memcpy((char*)&info.hdr + info.dataRead, data, hdrPart);
+    info.dataRead += hdrPart;
+    ...
+    data += hdrPart;
+    data_length -= hdrPart;
+```
+
+## Why this is a bug
+`data`/`data_length` is the *current chunk*; `info.dataRead` is the *cumulative* number of bytes consumed so far. The number of header bytes still needed is `sizeof(BlobHeader) - info.dataRead`, but the code computes `data_length - info.dataRead` (clamped to `sizeof(BlobHeader)`). This only produces the right value when the whole 16-byte header arrives inside the first chunk (`dataRead == 0`). This function is fed directly by network reads (download_blob_to.cpp:390, keyValueServer/proxy/proxy_file_lib.cpp:384, content_addressed_fs.cpp:161), where TCP can legally deliver any chunk size, including < 16 bytes.
+
+Failure scenarios once the first chunk is shorter than 16 bytes (say 10, so `dataRead == 10`):
+
+1. Second chunk `data_length = 20`: `hdrPart = min(20-10, 16) = 10`, but only 6 bytes are needed. `memcpy((char*)&info.hdr + 10, data, 10)` writes 4 bytes past the 16-byte `info.hdr` (into the adjacent `cctx` field), and 4 bytes of real payload are consumed as "header", so decompression starts 4 bytes into the stream and fails / produces corrupt data.
+2. Second chunk `data_length = 3` (< `dataRead`): `hdrPart = 3 - 10` underflows to a huge `size_t`, clamped to 16. `memcpy(&hdr+10, data, 16)` reads 13 bytes past the 3-byte chunk and writes 10 bytes past `info.hdr`. Then `data += 16` points past the buffer and `data_length -= 16` underflows to ~2^64, after which `decompress_stream` walks off the end of the chunk — out-of-bounds read of attacker-influenced length, likely crash.
+3. Second chunk `data_length == dataRead` (e.g. two 8-byte chunks): `hdrPart = 0`; no header bytes are consumed, `dataRead` is then bumped by `data_length` past `sizeof(BlobHeader)` without `init_decompress_blob_stream` ever being called, so `decompress_stream`/`finish_decompress_stream` (in the `DownloadBlobInfo` destructor, line 24-28) operate on an *uninitialized* `cctx` — undefined behavior (interpreting stack garbage as a z_stream / ZSTD_DStream pointer, then freeing it).
+
+## Suggested fix
+```cpp
+size_t hdrPart = sizeof(BlobHeader) - info.dataRead;
+hdrPart = hdrPart < data_length ? hdrPart : data_length;
+```
+(i.e. copy `min(bytes-still-needed, bytes-available-in-this-chunk)`).

--- a/_reports/blob-003-oneshot-decompress-unpacked-returns-error.md
+++ b/_reports/blob-003-oneshot-decompress-unpacked-returns-error.md
@@ -1,0 +1,52 @@
+# One-shot decompress() returns Error for Unpacked data even on success; leaks z_stream on ZLIB error
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/streaming_compressors.cpp
+- **Line(s):** 12-37
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic / error-handling
+
+## Code
+```cpp
+StreamStatus decompress(const char *src, size_t src_size, char *dest, size_t dest_capacity, StreamType type)
+{
+  if (type == StreamType::ZLIB)
+  {
+    z_stream stream = {0};
+    inflateInit(&stream);
+    ...
+    if(inflate(&stream, Z_FINISH)!=Z_STREAM_END)
+      return StreamStatus::Error;          // <-- leak: inflateEnd never called on this path
+    inflateEnd(&stream);
+    return StreamStatus::Finished;
+  }
+  else if (type == StreamType::ZSTD)
+  { ... }
+  else if (type== StreamType::Unpacked)
+  {
+    if (src_size <= dest_capacity)
+      memcpy(dest, src, src_size);         // <-- copies, but then...
+  }
+  return StreamStatus::Error;              // <-- ...always reports Error for Unpacked
+}
+```
+
+## Why this is a bug
+Two defects in the public one-shot `decompress` API (declared in streaming_compressors.h line 13):
+
+1. The `StreamType::Unpacked` branch performs the copy but falls through to `return StreamStatus::Error` — there is no `return StreamStatus::Finished` after the successful memcpy, and the "does not fit" case (`src_size > dest_capacity`) is silently indistinguishable. Any caller handling a `NONE`-magic (uncompressed) blob through this entry point treats a successful copy as a failure.
+2. In the ZLIB branch, when `inflate` does not reach `Z_STREAM_END` the function returns without `inflateEnd(&stream)`, leaking the ~10KB inflate state allocated by `inflateInit` on every failed/truncated decompression. In a long-lived multithreaded server, repeated corrupt/truncated zlib blobs leak memory unboundedly.
+
+No in-tree caller of this exact overload was found (streaming paths are used instead), so impact today is latent, but it is exported API.
+
+## Suggested fix
+```cpp
+  else if (type == StreamType::Unpacked)
+  {
+    if (src_size > dest_capacity)
+      return StreamStatus::Error;
+    memcpy(dest, src, src_size);
+    return StreamStatus::Finished;
+  }
+```
+and in the ZLIB branch call `inflateEnd(&stream)` before the error return.

--- a/_reports/blob-004-compress-stream-wrong-ctx-pointer.md
+++ b/_reports/blob-004-compress-stream-wrong-ctx-pointer.md
@@ -1,0 +1,36 @@
+# One-shot compress_stream reads StreamType from wrong pointer in Unpacked branch
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/streaming_compressors.cpp
+- **Line(s):** 169-215 (esp. 208)
+- **Severity:** low
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+StreamStatus compress_stream(char *ctx_, const char *src, size_t src_size, char *dest, size_t &dest_size)
+{
+  char *ctx = ctx_ + sizeof(StreamType);      // ctx = payload area, ctx_ = where the type tag lives
+  if (*(StreamType*)ctx_ == StreamType::ZLIB)
+  { ... }
+  else if (*(StreamType*)ctx_ == StreamType::ZSTD)
+  { ... }
+  else if (*(StreamType*)ctx == StreamType::Unpacked)   // <-- BUG: reads ctx, not ctx_
+  {
+    if (src_size <= dest_size)
+      memcpy(dest, src, src_size);
+    return StreamStatus::Finished;
+  }
+  return StreamStatus::Error;
+}
+```
+
+## Why this is a bug
+The first two branches correctly test the type tag at `ctx_` (offset 0), but the Unpacked branch tests `ctx` (= `ctx_ + sizeof(StreamType)`), i.e. it interprets the 4 bytes where the z_stream/ZSTD pointer payload would live — which for an Unpacked context are uninitialized stack garbage (init_compress_stream stores nothing there for Unpacked). So a context initialized with `StreamType::Unpacked` only takes the Unpacked branch if that garbage happens to equal 0; otherwise the function returns `StreamStatus::Error` for a perfectly valid context. Conversely, a ZLIB/ZSTD ctx whose payload bytes happen to be 0 can never reach this branch (types already matched earlier), so the failure mode is "valid Unpacked compression randomly fails".
+
+Secondary defect in the same branch: on success `dest_size` is not updated to `src_size`, so the caller cannot learn the output length, and the `src_size > dest_size` overflow case still returns `Finished` without copying anything.
+
+Mitigating factor: this 5-argument overload is not declared in streaming_compressors.h and has no callers in the tree (the 7-argument streaming overload is the used one) — dead code today, but a landmine.
+
+## Suggested fix
+Use `*(StreamType*)ctx_` like the other branches, set `dest_size = src_size` on success, return Error when `src_size > dest_size` — or simply delete this unused overload.

--- a/_reports/blob-005-finish-leaks-temp-file-on-error.md
+++ b/_reports/blob-005-finish-leaks-temp-file-on-error.md
@@ -1,0 +1,38 @@
+# finish() leaks the temp blob file on WRONG_HASH / IO_ERROR / failed-rename paths
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
+- **Line(s):** 182-220 (esp. 195-199, 208-209, 219)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** error-handling / resource-leak
+
+## Code
+```cpp
+PushResult finish(PushData *fp, char *actual_hash_str)
+{
+  ...
+  const int fcloseRet = fclose(fp->fp);
+  fp->fp = nullptr;
+
+  if (fcloseRet != 0)
+    return PushResult::IO_ERROR;                 // <-- temp file left on disk
+
+  ...
+    if (fp->provided_hash[0] && memcmp(fp->provided_hash, final_hash_p, 64) != 0)
+      return PushResult::WRONG_HASH;             // <-- temp file left on disk
+  ...
+  make_blob_dirs(filepath);
+  return blob_fileio_rename_file_if_nexist(...) ? PushResult::OK : PushResult::IO_ERROR;  // <-- on failure, temp file left on disk
+}
+```
+
+## Why this is a bug
+`finish()` takes ownership of the PushData (`std::unique_ptr<PushData> kill(fp);`) and closes the temp file, setting `fp->fp = nullptr`. From that point, no other code path can clean up the temp file:
+
+- `destroy(PushData*)` (line 171-180) only unlinks when `fp->fp` is still non-null, and finish() has already consumed/deleted the object anyway.
+- The successful-dedup path (line 213-216) correctly unlinks; the three failure paths above do not.
+
+So every push that ends in `WRONG_HASH` (client lied about the hash while `allow_trust` is off), `fclose` failure, or a failed rename leaves an orphaned `blob_*` temp file in the blobs tree (or the configured temp dir) forever. In the multithreaded CVS/KV server, a misbehaving or malicious client can repeatedly push bad-hash blobs and fill the server disk with orphaned temp files (each up to the full blob size). WRONG_HASH is precisely the path used to reject forged data, so this is remotely triggerable when trust is disabled.
+
+## Suggested fix
+Unlink on all terminal error paths, e.g. add `blob_fileio_unlink_file(fp->temp_file_name.c_str());` before the `IO_ERROR` returns and the `WRONG_HASH` return (and after a failed `blob_fileio_rename_file_if_nexist`, which on failure due to concurrent push should also unlink and may then be reported as DEDUPLICATED).

--- a/_reports/blob-006-blobe-fileio-pull-ignores-from-offset.md
+++ b/_reports/blob-006-blobe-fileio-pull-ignores-from-offset.md
@@ -1,0 +1,34 @@
+# blobe_fileio_pull ignores the `from` offset and returns the start of the file
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/fileio.cpp
+- **Line(s):** 305-314
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+const char *blobe_fileio_pull(BlobFileIOPullData* fp, uint64_t from, uint64_t &data_pulled)
+{
+  if (!fp)
+    return nullptr;
+  const int64_t left = fp->size - from;
+  if (left < 0)
+    return nullptr;
+  data_pulled = left;
+  return fp->begin;      // <-- BUG: returns start of mapping, not fp->begin + from
+}
+```
+
+## Why this is a bug
+This is the random-access read primitive behind `caddressed_fs::pull()` (content_addressed_fs.cpp:226) and is documented in content_addressed_fs.h:48-50 as "pull allows random access ... pull(PullData*, uint64_t from, ...)". It computes `data_pulled = size - from` (the number of bytes remaining after `from`) but returns `fp->begin`, i.e. the mapping origin, **not** `fp->begin + from`. So a caller asking for the region starting at byte `from` instead receives the first `size-from` bytes of the file.
+
+Reachability: the KV server's `handle_pull` (keyValueServer/serverLib/blob_push_proc.cpp:192-234) derives `from = blob_from_chunk * pull_chunk_size` from a **client-controlled** 32-bit chunk index and then loops `buf = blob_pull_data(readBlob, from, data_pulled); send_exact(socket, buf, data_pulled);`. A client that requests any chunk > 0 (the protocol's resume/random-access feature) is served the wrong file region — bytes `[0, size-from)` instead of `[from, size)`. The honest client library currently always passes `from == 0` (all `blob_pull_from_server(...,0,0,...)` call sites), so the whole-file case happens to work because a single mmap slice covers everything; that is exactly why the bug is latent and dangerous — the moment chunked/resumed pulls are used (or a peer requests a non-zero chunk), data is silently corrupted. The proxy write-through path (proxy_file_lib.cpp:531,679) uses the same primitive.
+
+There is no out-of-bounds read (`data_pulled = size - from <= size`, and the mapping is `size` bytes), so this is a data-correctness defect rather than memory corruption; content-addressed hash validation on the client will reject the mismatched data, turning it into a hard failure of any non-zero-offset pull.
+
+## Suggested fix
+```cpp
+  data_pulled = left;
+  return fp->begin + from;
+```

--- a/_reports/blob-007-mmap-failure-not-checked-map-failed.md
+++ b/_reports/blob-007-mmap-failure-not-checked-map-failed.md
@@ -1,0 +1,51 @@
+# POSIX mmap failure (MAP_FAILED) is not detected; (void*)-1 used as a valid mapping
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/fileio.cpp
+- **Line(s):** 222-230 (mmap), 299-302 (caller check)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** error-handling / portability
+
+## Code
+```cpp
+const void* blob_fileio_os_mmap(const char *filepath, std::uintmax_t flen)
+{
+  int fd = open(filepath, O_RDONLY);
+  if (fd == -1)
+    return nullptr;
+  void *ret = mmap(NULL, flen, PROT_READ, MMAP_FLAGS, fd, 0);
+  close(fd);
+  return ret;                    // on failure mmap returns MAP_FAILED == (void*)-1, NOT nullptr
+}
+...
+BlobFileIOPullData* blobe_fileio_start_pull(const char* filepath, uint64_t &blob_sz)
+{
+  ...
+  const char *begin = (const char *) blob_fileio_os_mmap(filepath, blob_sz);
+  if (!begin)                    // <-- only catches nullptr, misses MAP_FAILED
+    return nullptr;
+  return new BlobFileIOPullData{begin, blob_sz};
+}
+```
+
+## Why this is a bug
+On POSIX, `mmap` returns `MAP_FAILED` (defined as `(void *)-1`), never `NULL`, when it fails (e.g. `ENOMEM`/`EAGAIN` when mapping a very large blob under memory pressure, or a hitting an mmap limit). `blob_fileio_os_mmap` returns that `(void*)-1` straight through, and the caller's `if (!begin)` guard does not catch it, so a `BlobFileIOPullData{ (const char*)-1, blob_sz }` is created and treated as a valid mapping.
+
+Subsequent use dereferences the bogus pointer:
+- `blobe_fileio_pull` returns `fp->begin` (== `(void*)-1`) with `data_pulled = blob_sz`;
+- the KV server's `handle_pull` then does `send_exact(socket, buf, data_pulled)` — reading `blob_sz` bytes starting at address `-1` → out-of-bounds read / SIGSEGV;
+- `get_file_content_hash`/`repack` feed it to `blake3_hasher_update` — same crash.
+
+This is a remotely triggerable server crash (DoS): any PULL/SIZE-driven access to a blob whose mapping fails takes down the connection thread, and repeated large-blob pulls under memory pressure can be induced. The comments elsewhere confirm POSIX is the production platform ("We don't use production servers on windows"). The Windows implementation (line 136-154) correctly returns `nullptr` on failure, so only the POSIX path is affected.
+
+Note also `blob_fileio_os_unmap` receives this pointer on cleanup; `munmap((void*)-1, size)` will just fail with EINVAL, but the primary damage is the earlier dereference.
+
+## Suggested fix
+```cpp
+  void *ret = mmap(NULL, flen, PROT_READ, MMAP_FLAGS, fd, 0);
+  close(fd);
+  if (ret == MAP_FAILED)
+    return nullptr;
+  return ret;
+```
+(and/or check `begin == nullptr || begin == MAP_FAILED` at the call site).

--- a/_reports/blob-008-set-root-null-contract-crash.md
+++ b/_reports/blob-008-set-root-null-contract-crash.md
@@ -1,0 +1,39 @@
+# set_root() dereferences its root argument despite documented nullptr contract
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
+- **Line(s):** 39-50 (esp. 43, 45); contract in content_addressed_fs.h:21
+- **Severity:** low
+- **Confidence:** high
+- **Category:** error-handling
+
+## Code
+```cpp
+void set_root(context *ctx, const char *p)
+{
+  ctx->root_path = dir_for_roots;
+  if (ctx->root_path.length() && ctx->root_path[ctx->root_path.length()-1] != '/' && p[0] != '/')  // p[0] deref
+    ctx->root_path += "/";
+  ctx->root_path += p;   // std::string += (const char*)nullptr is UB
+  ...
+}
+```
+Header contract:
+```cpp
+void set_root(context *ctx, const char*);//if passed root is nullptr, we wil use default root
+```
+
+## Why this is a bug
+`content_addressed_fs.h:21` documents that passing `nullptr` for the root is valid and means "use the default root". The implementation never checks `p` for null: it reads `p[0]` (line 43) and appends `p` to a `std::string` (line 45). Passing `nullptr` therefore dereferences a null pointer / invokes `std::string::operator+=(const char*)` with null — undefined behavior, in practice a crash.
+
+Reachability: `blob_create_ctx(rootBuf)` (blob_file_lib.cpp:8) and `server.cpp:5368` pass `current_parsed_root->directory`; if any of these ever yields null (e.g. an unparsed/removed root) the server crashes. Even absent a current null-passing caller, the exported API's stated contract is simply not honored.
+
+## Suggested fix
+```cpp
+void set_root(context *ctx, const char *p)
+{
+  if (!p)               // honor documented "nullptr -> default root"
+    p = "";             // or restore the previous/default root explicitly
+  ...
+}
+```
+Alternatively, correct the header comment to state that a valid non-null path is required.

--- a/_reports/blob-009-send-blob-file-data-net-unchecked-fopen.md
+++ b/_reports/blob-009-send-blob-file-data-net-unchecked-fopen.md
@@ -1,0 +1,31 @@
+# send_blob_file_data_net: fopen result used without NULL check (crash on unreadable file)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/blob_kv_processor.cpp
+- **Line(s):** 16-19
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** error-handling
+
+## Code
+```cpp
+FILE* rf = fopen(file, "rb");
+fseek(rf, 0, SEEK_END);          // <-- rf may be NULL
+const size_t fsz = ftell(rf);
+fseek(rf, 0, SEEK_SET);
+```
+
+## Why this is a bug
+The return value of `fopen` is used immediately by `fseek`/`ftell`/later `fread(bufIn, 1, sizeof(bufIn), rf)` (line 37) and `fclose(rf)` (line 49) without ever checking for `NULL`. If the file cannot be opened — it was deleted/renamed between being queued and uploaded (the upload queue is asynchronous; see download_blob_to.cpp BackgroundProcessor), a permission error, too many open FDs, or a race with another process — `fopen` returns `NULL` and `fseek(NULL, ...)` dereferences it, crashing the CVS client during commit.
+
+This runs on the upload/commit path (`KVNetworkProcessor::upload` -> `send_blob_file_data_net`), so a missing or locked working-file at commit time takes down the client instead of producing the intended error string.
+
+## Suggested fix
+```cpp
+FILE* rf = fopen(file, "rb");
+if (!rf)
+{
+  output << "Can't open file " << file; err = output.str();
+  return KVRet::Error;
+}
+```
+(returning an error, as every other failure path in this function does).

--- a/_reports/blob-010-ftell-long-truncation-large-files.md
+++ b/_reports/blob-010-ftell-long-truncation-large-files.md
@@ -1,0 +1,27 @@
+# File size obtained via ftell() truncates/erros for >2GB blobs (esp. 32-bit long / Windows)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/blob_kv_processor.cpp
+- **Line(s):** 17-27
+- **Severity:** low
+- **Confidence:** medium
+- **Category:** overflow / portability
+
+## Code
+```cpp
+FILE* rf = fopen(file, "rb");
+fseek(rf, 0, SEEK_END);
+const size_t fsz = ftell(rf);          // ftell returns long
+fseek(rf, 0, SEEK_SET);
+...
+BlobHeader hdr = get_header(blob_binary_compressed ? zstd_magic : noarc_magic, fsz, 0);  // stored in uint64 uncompressedLen
+```
+
+## Why this is a bug
+`ftell` returns `long`. On Windows `long` is 32-bit even in 64-bit builds, and `fseek`/`ftell` are documented not to work beyond 2 GB (they return -1L). For a blob file larger than 2 GB this yields either a negative value or a wrong low-32-bit truncation, which is then widened to `size_t fsz` (becoming a huge value like `SIZE_MAX` when ftell returned -1) and written into `BlobHeader::uncompressedLen` (a `uint64_t` intended to hold the true size).
+
+The actual payload streaming is driven by `fread` until EOF, so the transmitted bytes are still complete; the damage is a corrupted `uncompressedLen` header field for large blobs. Because this module's own comment set and the surrounding subsystem explicitly target LARGE binary files ("allows to transfer up to 4TB"), storing a wrong size for >2GB files is a latent correctness problem for any consumer that trusts `uncompressedLen` (repack bookkeeping, tools, diagnostics).
+
+Note the file-content hashing path uses the mmap-based `blobe_fileio_get_file_size`/`_stat64` (64-bit) correctly; only this streaming-upload helper uses `ftell`.
+
+## Suggested fix
+Use a 64-bit size query: `_ftelli64`/`_fseeki64` on MSVC (or `ftello`/`fseeko` with `_FILE_OFFSET_BITS=64` on POSIX), or reuse `blob_fileio_get_file_size(file)`; also check the size for the error sentinel before use.

--- a/_reports/blob-011-http-err-code-appended-as-char.md
+++ b/_reports/blob-011-http-err-code-appended-as-char.md
@@ -1,0 +1,30 @@
+# HTTP download error message appends status code as a raw char instead of a number
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/blob_http_processor.cpp
+- **Line(s):** 22-27
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+if (!res || res->status != 200)
+{
+  err = res ? httplib::detail::status_message(res->status) : "unknown";
+  err += " err code";
+  err += res ? res->status : -1;   // <-- appends a single char, not the number
+  return false;
+}
+```
+
+## Why this is a bug
+`err` is a `std::string`. `res->status` (and the `-1`) are `int`. `std::string` has no `operator+=(int)`; the expression binds to `operator+=(char)`, so the `int` is converted to a single `char` and that one byte is appended. Instead of `"... err code404"` the message gets `"... err code"` followed by the byte value 404&0xFF (0x94, a non-printable/garbage character), or byte 0xFF for the `-1` (no-response) case.
+
+So every failed HTTP blob download produces a corrupted, misleading error string — exactly when a human is trying to diagnose a download failure. Not a memory-safety issue (a valid char is appended), purely wrong output.
+
+## Suggested fix
+Convert the code to text explicitly, e.g.:
+```cpp
+err += " err code ";
+err += std::to_string(res ? res->status : -1);
+```

--- a/_reports/blob-012-get-session-blob-ref-unchecked-fopen.md
+++ b/_reports/blob-012-get-session-blob-ref-unchecked-fopen.md
@@ -1,0 +1,41 @@
+# get_session_blob_reference_hash: fopen result used without NULL check (TOCTOU crash)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/blob_operations.cpp
+- **Line(s):** 70-80
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** error-handling
+
+## Code
+```cpp
+if (get_file_size(blob_ref_file_name) != session_blob_reference_size)
+  return false;
+unsigned char session_ref_file_content[session_blob_reference_size];
+FILE* fp;
+fp = fopen(blob_ref_file_name, "rb");
+if (fread(&session_ref_file_content[0],1, session_blob_reference_size, fp) != session_blob_reference_size)  // fp may be NULL
+{
+  error(1,errno,"Couldn't read %s", blob_ref_file_name);
+  return false;
+}
+fclose(fp);
+```
+
+## Why this is a bug
+`fopen`'s return value is passed straight to `fread` without a `NULL` check. There is a genuine TOCTOU window: `get_file_size` succeeds, but the file can be removed/renamed/locked before the `fopen` on the next lines (this runs on the client commit path via `RCS_cmp_file` in rcs_checkin.cpp:1491, where working files are live). When `fopen` fails it returns `NULL`, and `fread(buf, 1, n, NULL)` dereferences a null `FILE*` — crash.
+
+Secondary: on the short-read branch the code `return false;` without `fclose(fp)`. Here `error(1, ...)` exits the process (confirmed: error.cpp sets should_exit when status != 0), so the leak is normally moot — but if `error_exit()` is ever configured to unwind rather than hard-exit (server contexts), `fp` leaks. The primary defect is the missing NULL check.
+
+## Suggested fix
+```cpp
+fp = fopen(blob_ref_file_name, "rb");
+if (!fp)
+  return false;
+if (fread(session_ref_file_content, 1, session_blob_reference_size, fp) != session_blob_reference_size)
+{
+  fclose(fp);
+  error(1, errno, "Couldn't read %s", blob_ref_file_name);
+  return false;
+}
+fclose(fp);
+```

--- a/_reports/blob-013-pull-at-once-ignores-decode-failure-uninit-tail.md
+++ b/_reports/blob-013-pull-at-once-ignores-decode-failure-uninit-tail.md
@@ -1,0 +1,49 @@
+# pull_at_once ignores decode errors and returns header-claimed length, exposing uninitialized tail
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/rcs_cvt_kB.cpp
+- **Line(s):** 23-57 (esp. 42-52, 55)
+- **Severity:** low
+- **Confidence:** medium
+- **Category:** error-handling / memory
+
+## Code
+```cpp
+char *dest = nullptr;
+while (at < blob_sz)
+{
+    ...
+    if (!decode_stream_blob_data(info, some, data_pulled, [&](const void *unpacked, size_t sz)
+      {
+        if (!dest)
+          dest = (char*)blob_alloc(info.hdr.uncompressedLen);   // sized from header
+        if (info.realUncompressedSize + sz > info.hdr.uncompressedLen)
+          return false;
+        memcpy(dest+info.realUncompressedSize, unpacked, sz);
+        return true;
+      }
+    ))
+      break;                          // decode failure just breaks
+}
+*decoded = dest;
+sz = info.hdr.uncompressedLen;        // returns CLAIMED size, not bytes actually decoded
+return destroy(pd);                   // returns true regardless of decode success
+```
+
+## Why this is a bug
+`dest` is allocated to `info.hdr.uncompressedLen` (uninitialized `xmalloc`), the loop fills only `info.realUncompressedSize` bytes, and the function then reports `sz = info.hdr.uncompressedLen` as the output length while returning success (`destroy(pd)` is a bool unrelated to decode success). Two consequences:
+
+1. If `decode_stream_blob_data` fails part-way (decompression/format error, truncated blob) the `break` is silent — `pull_at_once` still returns `true` with a partially-filled buffer. The caller `RCS_read_binary_rev_data` (line 73-76) then sets `*inout_data_allocated = 1` and returns success, so corrupt/short data is treated as valid.
+2. Whenever `realUncompressedSize < uncompressedLen` (short or failed decode, or a blob whose header over-states the length), the caller consumes bytes `[realUncompressedSize, uncompressedLen)` of `dest` which were never written — an uninitialized-heap read; on the old-client compatibility path this content is handed back to the client (potential heap-content disclosure).
+
+In normal operation the server writes correct headers (`get_header` uses the true size) so `uncompressedLen == realUncompressedSize`; the defect surfaces on any corrupt/crafted stored blob or mid-stream decode failure, which this "compatibility with old clients" path does not otherwise validate here.
+
+## Suggested fix
+Track and honor the actual decoded size, and propagate failure:
+```cpp
+bool ok = true;
+... if (!decode_stream_blob_data(...)) { ok = false; break; }
+*decoded = dest;
+sz = info.realUncompressedSize;      // actual bytes produced
+bool d = destroy(pd);
+return ok && d && info.realUncompressedSize == info.hdr.uncompressedLen;
+```

--- a/_reports/blob-014-start-push-server-should-stop-not-dereferenced.md
+++ b/_reports/blob-014-start-push-server-should-stop-not-dereferenced.md
@@ -1,0 +1,37 @@
+# start_push_server accept loop tests the should_stop pointer instead of *should_stop
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/serverLib/blob_push_server.cpp
+- **Line(s):** 57
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+bool start_push_server(int portno, int max_connections, volatile bool* should_stop, ...)
+{
+  ...
+  while (!should_stop)                 // tests the POINTER, not *should_stop
+  {
+    intptr_t client_raw_sock = accept(sockfd, ...);
+    ...
+  }
+  raw_close_socket(sockfd);
+  return true;
+}
+```
+
+## Why this is a bug
+`should_stop` is a `volatile bool*`. The accept loop condition `!should_stop` evaluates whether the pointer is null, never dereferencing it, so the intended graceful-shutdown flag `*should_stop` is completely ignored. The correct idiom is used elsewhere in the same subsystem — `blob_push_proc.cpp:421` writes `while (!(should_stop && *should_stop))`.
+
+Consequences:
+- All current callers pass `nullptr` (cafs_server.cpp:55, sample_server.cpp:33, cafs_proxy_server.cpp:66), so `!should_stop` is `true` and the server runs as an unstoppable loop — the stop flag mechanism is dead.
+- If any caller ever passes a **non-null** `should_stop` (the whole point of the parameter, e.g. an embedded/hosted server wanting clean shutdown), `!should_stop` is `false` immediately and the loop body never runs: the server closes its listen socket and returns without ever accepting a single connection. That is the opposite of the intended "run until asked to stop" behavior.
+
+## Suggested fix
+```cpp
+while (!(should_stop && *should_stop))
+{
+  ...
+}
+```

--- a/_reports/blob-015-exchange-session-keys-leaks-decrypt-ctx.md
+++ b/_reports/blob-015-exchange-session-keys-leaks-decrypt-ctx.md
@@ -1,0 +1,37 @@
+# exchange_session_keys frees the wrong cipher context, leaking the decrypt EVP_CIPHER_CTX per handshake
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
+- **Line(s):** 397-422 (esp. 417-421)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** memory
+
+## Code
+```cpp
+EVP_CIPHER_CTX *enc = init_cipher_from_otp(otp_page, true);
+uint8_t encrypted[sizeof(ourDhAuthData)];
+int outLen = 0;
+if (1 != EVP_EncryptUpdate(enc, encrypted, &outLen, ourDhAuthData, sizeof(ourDhAuthData)) || outLen != sizeof(encrypted))
+  return nullptr;
+EVP_CIPHER_CTX_free(enc); enc = NULL;                 // enc freed here
+...
+EVP_CIPHER_CTX *dec = init_cipher_from_otp(otp_page, false);   // new context
+if (1 != EVP_DecryptUpdate(dec, otherDhAuthData, &outLen, encrypted, sizeof(ourDhAuthData)) || outLen != sizeof(encrypted))
+  return nullptr;
+memset(encrypted, 0, sizeof(encrypted));
+EVP_CIPHER_CTX_free(enc); enc = NULL;                 // BUG: frees enc (already NULL); dec is never freed
+return otherDhAuthData;
+```
+
+## Why this is a bug
+On the success path, `dec` (an `EVP_CIPHER_CTX` allocated inside `init_cipher_from_otp` via `EVP_CIPHER_CTX_new`) is never freed: line 421 frees `enc`, which was already freed and set to `NULL` at line 402, so `EVP_CIPHER_CTX_free(enc)` is a harmless no-op while `dec` leaks. It is clearly a copy/paste typo — the line should free `dec`.
+
+`exchange_session_keys` runs once per authenticated connection (server side via `connect_to_client_blob_socket`, client side via `connect_to_server_blob_socket`). Each successful handshake therefore leaks one cipher context plus its underlying AES state. On the long-lived multithreaded CAFS server this is an unbounded per-connection memory leak driven by remote clients.
+
+Secondary defects in the same block: `init_cipher_from_otp` can return `nullptr` (its `EVP_*Init_ex` may fail), but `enc` (line 400) and `dec` (line 418) are passed to `EVP_EncryptUpdate`/`EVP_DecryptUpdate` with no NULL check — a null-context dereference/crash. Also the early `return nullptr` at line 401 leaks `enc`, and at line 419 leaks `dec`.
+
+## Suggested fix
+```cpp
+EVP_CIPHER_CTX_free(dec); dec = NULL;     // free the decrypt context, not enc
+```
+and null-check the results of `init_cipher_from_otp` before use, freeing `enc`/`dec` on every early-return error path.

--- a/_reports/blob-016-available-disk-space-inverted-error-check.md
+++ b/_reports/blob-016-available-disk-space-inverted-error-check.md
@@ -1,0 +1,38 @@
+# available_disk_space inverts the error check and always returns ~0 (disk-full GC never triggers)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/free_disk_space.cpp
+- **Line(s):** 13-20
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+uint64_t available_disk_space(const char *dir)
+{
+  std::error_code ec;
+  const std::filesystem::space_info si = std::filesystem::space(dir, ec);
+  if (!bool(ec))                       // <-- inverted: this is the SUCCESS case
+    return uint64_t(~uint64_t(0));
+  return si.available;
+}
+```
+
+## Why this is a bug
+`std::filesystem::space(dir, ec)` clears `ec` on success and sets it on failure (and on failure sets every `space_info` member to `static_cast<uintmax_t>(-1)`). The guard is backwards:
+
+- On **success**, `ec` is false, `!bool(ec)` is true, so the function returns `~0` (UINT64_MAX) instead of the real `si.available`.
+- On **failure**, `ec` is true, `!bool(ec)` is false, so it returns `si.available`, which the standard already set to `-1` (== `~0`).
+
+Either way the function returns `UINT64_MAX`; it never reports the actual free space.
+
+Impact in the proxy GC (gc_proc_monitor.cpp):
+- Line 35: the emergency trigger `if (avail == 0 || ...)` can never see `avail == 0` (it is always `-1` after the int64 cast), so the "disk is full, free cache now" path is dead. A proxy whose real disk is smaller than the configured cache size can fill the disk with no disk-space-driven GC.
+- Lines 69-71 in `perform_immediate_gc`: `if (space > 0 && space > -needed_sz) return true;` never returns early (`space` is `-1`), so it always runs `free_space` even when the disk has ample room — needless cache eviction.
+
+## Suggested fix
+```cpp
+  if (bool(ec))                        // on error, report "unknown / max"
+    return uint64_t(~uint64_t(0));
+  return si.available;
+```

--- a/_reports/blob-017-connect-timeout-format-string-arg-mismatch.md
+++ b/_reports/blob-017-connect-timeout-format-string-arg-mismatch.md
@@ -1,0 +1,27 @@
+# connect_with_timeout log calls have two %d but pass one argument (varargs UB)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/clientLib/blob_push_pull_client.cpp
+- **Line(s):** 30, 54
+- **Severity:** low
+- **Confidence:** high
+- **Category:** error-handling
+
+## Code
+```cpp
+if (!raw_set_non_blocking(raw_sock, true))
+    blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d (%d)\n", blob_get_last_sock_error());
+...
+if (!raw_set_non_blocking(raw_sock, false))
+    blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d (%d)\n", raw_get_last_sock_error());
+```
+
+## Why this is a bug
+The format string has two `%d` conversions but only one integer argument is supplied. `blob_logmessage` forwards to `vsnprintf` (see blob_kv_processor.cpp:169-178), so the second `%d` reads a variadic argument that was never passed — undefined behavior. In practice it prints a garbage integer, but depending on ABI/arg registers it can read an indeterminate value or, in the worst case, fault.
+
+These are on the connect-timeout error path (setting the socket non-blocking failed), so they are reached only under socket errors, but the defect is a real format/argument mismatch.
+
+## Suggested fix
+Supply a second argument or drop the extra conversion, e.g.:
+```cpp
+blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d\n", blob_get_last_sock_error());
+```

--- a/_reports/blob-018-handle-pull-oversends-partial-range.md
+++ b/_reports/blob-018-handle-pull-oversends-partial-range.md
@@ -1,0 +1,43 @@
+# handle_pull sends the whole remaining blob for a partial range request (protocol desync / over-send)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/serverLib/blob_push_proc.cpp
+- **Line(s):** 217-234 (esp. 220, 229)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+int64_t sizeLeft = blob_sz - from;
+sizeLeft = request_sz == 0 ? sizeLeft : std::min((int64_t)request_sz, sizeLeft);   // announced count
+...
+memcpy_to(to, &sizeLeft, sizeof(sizeLeft));   // TAKE header tells client sizeLeft bytes
+...
+while (sizeLeft > 0)
+{
+    uint64_t data_pulled;
+    const char *buf = blob_pull_data(readBlob, from, data_pulled);   // data_pulled = blob_sz - from (whole remaining)
+    ...
+    from += data_pulled;
+    sizeLeft -= data_pulled;
+    if (!send_exact(socket, buf, data_pulled))                       // sends data_pulled, NOT capped to sizeLeft
+    ...
+}
+```
+
+## Why this is a bug
+For a bounded pull (`request_sz != 0`, the protocol's "pull by 1mb chunks" feature — see blob_push_protocol.h:40,47), the server correctly announces `sizeLeft = min(request_sz, blob_sz-from)` in the TAKE response, but then reads with `blob_pull_data`, whose mmap backend (`blobe_fileio_pull`) always returns `data_pulled = blob_sz - from` (the entire remainder). The `send_exact(socket, buf, data_pulled)` sends that entire remainder, which is larger than the `sizeLeft` the client was told to read.
+
+The client (`blob_pull_from_server`) reads exactly the announced `sz` via `recv_lambda(sockfd, sz, ...)`, leaving the surplus bytes in the socket stream. The next command the client sends is then parsed against leftover blob bytes — the encrypted/framed protocol desynchronizes, effectively corrupting the connection.
+
+Reachability: all in-tree callers currently pass `request_sz == 0` (whole-file), so `sizeLeft == blob_sz-from == data_pulled` and the surplus is zero — the bug is latent. But the server processes an untrusted, client-supplied `request_sz` and the protocol explicitly advertises partial pulls, so any client using a non-zero size (a resumed/1MB-chunked pull, a third-party client) triggers the over-send. This compounds with the `blobe_fileio_pull` offset bug (blob-006): partial/random-access pulls are wholesale broken.
+
+## Suggested fix
+Cap each send to the outstanding `sizeLeft`:
+```cpp
+uint64_t toSend = (uint64_t)std::min<int64_t>(sizeLeft, (int64_t)data_pulled);
+from += toSend;
+sizeLeft -= toSend;
+if (!send_exact(socket, buf, toSend)) { ... }
+```
+(and fix `blobe_fileio_pull` to honor `from`).

--- a/_reports/blob-019-base-repo-trailing-slash-off-by-one.md
+++ b/_reports/blob-019-base-repo-trailing-slash-off-by-one.md
@@ -1,0 +1,28 @@
+# base_repo trailing-slash check indexes the NUL terminator (always true, yields "//")
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
+- **Line(s):** 248-251
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+base_repo = repo;
+if (base_repo[0] != '/')
+  base_repo = "/" + base_repo;
+if (base_repo[base_repo.length()] != '/')   // <-- indexes size(), i.e. the '\0'
+  base_repo += "/";
+```
+
+## Why this is a bug
+`base_repo[base_repo.length()]` reads the character at index `size()`, which for `std::string` is the terminating `'\0'` (defined, but never `'/'`). The condition is therefore **always true**, so the block always appends `'/'`. The clearly-intended check is on the last character, `base_repo[base_repo.length()-1]`, exactly as the analogous code does in content_addressed_fs.cpp:46 (`root_path[root_path.length()-1] != '/'`) and proxy_file_lib.cpp:46 (`cache_folder[cache_folder.length() - 1] != '/'`).
+
+Consequence: when the configured repo already ends in `/` (or is empty, becoming `"/"` after the first `if`), a second slash is appended, producing `"//"`. `base_repo` is returned by `getRoot()` and sent to the blob KV server as the CVS root, which the server turns verbatim into the blob storage path (`set_root` does not collapse `//`). A root of `/repo//` maps to a different directory string than `/repo/`, so the client can look for blobs under the wrong root and fail to find them.
+
+## Suggested fix
+```cpp
+if (base_repo[base_repo.length()-1] != '/')
+  base_repo += "/";
+```
+(guard against an empty string if that is possible).

--- a/_reports/blob-020-atomic-wrapper-assignment-missing-return.md
+++ b/_reports/blob-020-atomic-wrapper-assignment-missing-return.md
@@ -1,0 +1,33 @@
+# atomic_wrapper copy-assignment operator has no return statement (UB)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
+- **Line(s):** 48
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+template <typename T>
+struct atomic_wrapper
+{
+  std::atomic<T> _a;
+  atomic_wrapper():_a(){}
+  atomic_wrapper(const std::atomic<T> &a):_a(a.load()){}
+  atomic_wrapper(const atomic_wrapper &other):_a(other._a.load()){}
+  atomic_wrapper &operator=(const atomic_wrapper &other) {_a.store(other._a.load());}  // <-- no return
+  operator T() {return T(_a);}
+  atomic_wrapper(const T& other) { _a = other; }
+  atomic_wrapper& operator=(const T& other) { _a = other; return *this; }
+};
+```
+
+## Why this is a bug
+`operator=(const atomic_wrapper&)` is declared to return `atomic_wrapper&` but its body has no `return` statement. Flowing off the end of a non-void function is undefined behavior if the caller uses the returned reference (the sibling `operator=(const T&)` on the next line correctly does `return *this;`). Compilers warn (`-Wreturn-type`), and with optimization the missing return can yield a garbage reference.
+
+`atomic_wrapper<bool> failed` is a member of `DownloadURL`, which is stored in `std::vector<DownloadURL> roundRobin.urls`. Any operation that copy-*assigns* a `DownloadURL` (as opposed to copy-constructs it) invokes this operator; if its result is ever read, behavior is undefined. It is latent today because the vector is only `push_back`-grown (copy/move construction) and assignments discard the result, but it is a real defect.
+
+## Suggested fix
+```cpp
+atomic_wrapper &operator=(const atomic_wrapper &other) { _a.store(other._a.load()); return *this; }
+```

--- a/_reports/blob-021-sample-pushfile-chunk-size-arithmetic.md
+++ b/_reports/blob-021-sample-pushfile-chunk-size-arithmetic.md
@@ -1,0 +1,35 @@
+# Sample cafs_client PUSHFILE computes wrong chunk size (fsz - at - hdrSize), breaking file push
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/sample/cafs_client.cpp
+- **Line(s):** 131-138
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+const size_t blob_sz = fsz + hdrSize;
+...
+int64_t pushed = blob_push_to_server(client, blob_sz, ht, hash, [&](uint64_t at, uint64_t &data_pulled) {
+    if (at < hdrSize)
+    {
+      data_pulled = hdrSize-at;
+      return ((const char*)&hdr) + at;
+    }
+    data_pulled = fsz - at - hdrSize;             // <-- wrong
+    return ((const char*)data) + (at-hdrSize);
+});
+```
+
+## Why this is a bug
+The producer callback must, for a stream offset `at` into the `blob_sz = fsz + hdrSize` byte stream, return the number of contiguous bytes available from `at`. For `at >= hdrSize` that count is `blob_sz - at = fsz + hdrSize - at = fsz - (at - hdrSize)`. The code instead computes `fsz - at - hdrSize`, which is smaller by `2*hdrSize`.
+
+Walking the push: after the header (`at = hdrSize`), it reports `data_pulled = fsz - 2*hdrSize` instead of `fsz`, so the file body is chopped short and the offsets desync; the total bytes fed to `blob_push_to_server` never reach `blob_sz`. The server-side hash of the (truncated/misframed) data will not match the declared hash, so `pushfile` is rejected.
+
+Note the `pushblob` path uses `hdrSize == 0`, for which `fsz - at - 0 == fsz - at` is correct — so only `pushfile` is broken, which is why the error is easy to miss. This is demonstration/sample code (built by build_client_cafs.cmd), so production impact is limited, but it is a genuine off-by arithmetic defect and a misleading example.
+
+## Suggested fix
+```cpp
+data_pulled = fsz - (at - hdrSize);   // == blob_sz - at
+return ((const char*)data) + (at - hdrSize);
+```

--- a/_reports/blob-022-sample-server-wont-compile.md
+++ b/_reports/blob-022-sample-server-wont-compile.md
@@ -1,0 +1,35 @@
+# sample_server.cpp does not compile: redeclared `pc`, undefined `secret`, wrong start_push_server args
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/keyValueServer/sample/sample_server.cpp
+- **Line(s):** 9, 18, 33
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+int main(int argc, const char **argv)
+{
+  const int pc = 1;                    // line 9
+  ...
+  const char *encryption_secret = 0;
+  int pc = 1;                          // line 18: redeclaration of pc in the same scope
+  ...
+  const bool result = start_push_server(port, max_pending, nullptr, secret, encryption_secret);  // line 33
+}
+```
+
+## Why this is a bug
+Three compile errors in this sample:
+1. `pc` is declared twice in the same function scope (`const int pc = 1;` at line 9 and `int pc = 1;` at line 18) — a redefinition error.
+2. `secret` (line 33) is never declared; the only similar variable is `encryption_secret`.
+3. `start_push_server`'s signature is `(int, int, volatile bool*, const char* encryption_secret, CafsServerEncryption encryption)`. The call passes `secret` where the `const char*` secret is expected and passes `encryption_secret` (a `const char*`) where the `CafsServerEncryption` enum is expected — type-mismatched arguments (and the `encryption` value is never computed here at all, unlike cafs_server.cpp).
+
+The file therefore cannot build as-is; it appears to be stale sample code that was never updated to the current `start_push_server` API (compare the working cafs_server.cpp:55). Low impact (demonstration only), but it is broken.
+
+## Suggested fix
+Remove the duplicate `const int pc = 1;`, and call e.g.:
+```cpp
+CafsServerEncryption encryption = encryption_secret ? CafsServerEncryption::All : CafsServerEncryption::Local;
+const bool result = start_push_server(port, max_pending, nullptr, encryption_secret, encryption);
+```

--- a/_reports/core-001-join-file-frees-global-options.md
+++ b/_reports/core-001-join-file-frees-global-options.md
@@ -1,0 +1,43 @@
+# join_file frees global `options` instead of local `t_options` on "no difference" merge path
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+- **Line(s):** 3204-3208 (the `xfree(options)` at 3207); compare cleanup at 3281 (`xfree (t_options)`)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** typo / memory
+
+## Code
+```cpp
+    else
+	status = RCS_merge (finfo->rcs, vers->srcfile->path, finfo->file,
+			t_options, (char*)(rev1?rev1:"0"), rev2, conflict_3way, &mode);
+
+	if(status == 3)
+	{
+		//cvs_output ("No difference between revisions ", 0);
+		...
+		xfree(rev1);
+		xfree(rev2);
+		xfree(backup);
+		xfree(options);   // <-- BUG: frees the file-scope static `options`, not `t_options`
+		return;
+	}
+```
+
+For reference, the normal exit path of the same function correctly does:
+```cpp
+    xfree (backup);
+	xfree (t_options);       // line 3281
+	baserev_update(finfo, vers, T_NEEDS_MERGE);
+```
+
+## Why this is a bug
+`t_options` is the local copy (`t_options = xstrdup(vers->options);` at line 3065) that this function owns and must free. `options` is the file-scope static (`static const char *options;` line 83) that holds the `-k` option for the *entire* update/checkout run; it is either allocated once by `RCS_check_kflag()` in `update()` or aliased directly from the caller's `xoptions` in `do_update()`/`rcs_update_fileproc()`.
+
+When `RCS_merge` returns 3 ("no difference between revisions" — a CVSNT/Gaijin-added status; see the parallel handling in `merge_file()` at line 3380) during a multi-file `cvs update -j`, this path:
+1. Frees the memory `options` points to and nulls the static (xfree is `free + set NULL`). Every *subsequent* file processed in the same update loses its sticky `-k` option — files after the first "no difference" join are checked out/merged with default keyword expansion instead of e.g. `-kb`. For a fork whose whole purpose is large *binary* files, silently dropping `-kb` mid-run can corrupt working files.
+2. If `do_update()` was called from `checkout`/`switch` with a caller-owned `xoptions` string, the caller still holds a pointer to the freed block → later use-after-free/double-free in the caller.
+3. Leaks `t_options` (never freed on this path).
+
+## Suggested fix
+Replace `xfree(options);` with `xfree(t_options);` in the `status == 3` early-return block.

--- a/_reports/core-002-checkout-file-resurrect-frees-rcs-node-version.md
+++ b/_reports/core-002-checkout-file-resurrect-frees-rcs-node-version.md
@@ -1,0 +1,51 @@
+# checkout_file frees RCS delta-owned version string when resurrecting during a join
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+- **Line(s):** 1630-1641 (aliasing), 1812-1821 (the free)
+- **Severity:** medium
+- **Confidence:** medium
+- **Category:** memory
+
+## Code
+```cpp
+	file_is_dead = RCS_isdead (vers_ts->srcfile, vers_ts->vn_rcs);
+	if(file_is_dead && resurrect)
+	{
+		Node *p = findnode(finfo->rcs->versions, vers_ts->vn_rcs);
+		RCSVers *vers = (RCSVers *) p->data;
+
+		file_is_dead = 0;
+		adding = 1;
+		vn_rcs = vers->version;          // <-- aliases string owned by the RCSVers node
+	}
+	else
+		vn_rcs = vers_ts->vn_rcs;
+...
+		/* fix up the vers structure, in case it is used by join */
+		if (join_rev1)
+		{
+			TRACE(3,"fix up the vers structure, in case it is used by join.");
+			if (vers_ts->vn_user != NULL)
+				xfree (vers_ts->vn_user);
+			if (vn_rcs != NULL)
+				xfree (vn_rcs);          // <-- frees RCSVers::version in the resurrect case
+			vers_ts->vn_user = xstrdup (xvers_ts->vn_rcs);
+			vers_ts->vn_rcs = xstrdup (xvers_ts->vn_rcs);
+		}
+```
+
+## Why this is a bug
+Upstream CVSNT freed `vers_ts->vn_rcs` here (a string owned by the `Vers_TS`), then replaced it. The Gaijin resurrect feature introduced the local alias `vn_rcs`, which in the `file_is_dead && resurrect` case points at `RCSVers::version` — the revision-number string owned by the in-memory RCS delta list (`finfo->rcs->versions`). Freeing it:
+
+1. Leaves the RCS node with a dangling `version` pointer. The RCS structure is used afterwards (e.g. by `join_file` via `vers->srcfile`, by `RCS_*` lookups, and finally by `freercsnode`, which frees `RCSVers::version` again) → use-after-free / double free.
+2. Leaks the real `vers_ts->vn_rcs` string, which is overwritten two lines later without being freed.
+
+Trigger path: `checkout_file` called with `resurrect != 0` while `join_rev1` is set and the requested revision is dead. `resurrect=1` callers are add.cpp:607 and update.cpp:897 (`resurrect = is_rcs`, i.e. the `cvsrcs` emulation, where `rcs_update_fileproc` can set `join_rev1` from its `xjoin_rev1` argument). The combination is narrow, which is why severity is medium rather than high, but when hit it corrupts the shared RCS structure and typically crashes or double-frees at `freercsnode` time.
+
+## Suggested fix
+Free the `Vers_TS`-owned string explicitly and never the alias:
+```cpp
+if (vers_ts->vn_rcs != NULL)
+    xfree (vers_ts->vn_rcs);
+```
+(and keep `vn_rcs` purely as a read-only alias for the checkout revision).

--- a/_reports/core-003-bound-merge-by-bugid-null-deref.md
+++ b/_reports/core-003-bound-merge-by-bugid-null-deref.md
@@ -1,0 +1,58 @@
+# bound_merge_by_bugid dereferences NULL when the bug's earliest change is the first revision
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+- **Line(s):** 2680-2689
+- **Severity:** medium
+- **Confidence:** medium
+- **Category:** logic / memory
+
+## Code
+```cpp
+	if(!startnode)
+	{
+		TRACE(3,"bound_merge_by_bugid: no bug changes found");
+		return false;
+	}
+	xfree(rev1);
+	xfree(rev2);
+	endnode = previous_version(rcs->versions,(RCSVers*)endnode->data);
+	rev1=xstrdup(endnode->key);          // <-- endnode may be NULL here
+	rev2=xstrdup(startnode->key);
+```
+
+`previous_version()` explicitly returns NULL when there is no predecessor:
+```cpp
+static Node *previous_version(List *versions, RCSVers *vers)
+{
+	if(numdots(vers->version)==1) /* Main branch */
+	{
+		if(vers->next)
+			node = findnode(versions,vers->next);
+		else
+			node=NULL;               // revision 1.1 has no ->next
+	}
+	else
+	{
+		...
+		if(p==versions->list)
+			node=NULL;
+		...
+	}
+	return node;
+}
+```
+
+## Why this is a bug
+`bound_merge_by_bugid` (used by `cvs update -j ... -B <bugid>`) walks backward from `rev2` collecting revisions carrying the bug id, then rewrites the merge bounds as (predecessor-of-earliest-bug-rev, latest-bug-rev). If the earliest revision containing the bug id is the first revision of the file (trunk 1.1, or the first revision reached when the backward walk exhausts the list — which happens whenever `rev1` is not an ancestor of `rev2`, e.g. a two-tag `-j T1 -j T2 -B bug` merge with tags on diverged branches), `previous_version()` returns NULL and `endnode->key` dereferences a NULL pointer, crashing the client or, worse, the server process performing the merge.
+
+Note also that `findnode(versions, vers->next)` inside `previous_version` can return NULL for a corrupt/trimmed RCS file, giving the same crash.
+
+## Suggested fix
+```cpp
+Node *prev = previous_version(rcs->versions,(RCSVers*)endnode->data);
+if (prev == NULL)
+    rev1 = xstrdup(endnode->key);   /* or treat as "merge from the beginning" */
+else
+    rev1 = xstrdup(prev->key);
+```
+(choosing semantics deliberately: with no predecessor the merge base should be the earliest revision itself, mirroring the `rev1?rev1:"0"` handling in join_file).

--- a/_reports/core-004-commit-sends-bare-i-argument.md
+++ b/_reports/core-004-commit-sends-bare-i-argument.md
@@ -1,0 +1,32 @@
+# commit client sends bare "i" instead of "-i" for ignore-keywords option
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
+- **Line(s):** 574-575
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** typo
+
+## Code
+```cpp
+	if(commit_keep_edits)
+		send_arg("-e");
+
+	if(slide_tags)
+		send_arg("-T");
+
+	if(ignore_keywords)
+		send_arg("i");        // <-- missing '-'; every sibling sends "-X"
+```
+
+## Why this is a bug
+When the user runs `cvs commit -i` (the "ignore keyword differences" option, still accepted by the client's getopt string `"+cnlRm:M:fF:Db:B:eTi"` at line 401 even though it is commented out of the usage text), the client sends the literal argument `i` to the server instead of `-i`.
+
+On the server, commit's option string starts with `+` (POSIX mode: stop option parsing at the first non-option argument). The bare `i` therefore:
+1. is never interpreted as the ignore-keywords option — the feature silently does nothing remotely; and
+2. terminates option parsing, so every argument the client sends *after* it (`-l`, `-f`, `-n`, `-c`, `--`) is treated as a file name to commit rather than as an option. The commit then fails with "nothing known about `i'" / "nothing known about `-l'" etc., or in the worst case operates on a real working file that happens to be named `i`.
+
+## Suggested fix
+```cpp
+	if(ignore_keywords)
+		send_arg("-i");
+```

--- a/_reports/core-005-fixaddfile-leaves-really-quiet-set.md
+++ b/_reports/core-005-fixaddfile-leaves-really-quiet-set.md
@@ -1,0 +1,52 @@
+# fixaddfile fails to restore really_quiet (and leaks) when the RCS file is unparseable
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
+- **Line(s):** 2038-2061
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic / error-handling
+
+## Code
+```cpp
+void fixaddfile (const char *file, const char *repository)
+{
+    RCSNode *rcsfile;
+    char *rcs;
+    int save_really_quiet;
+
+    rcs = locate_rcs (file, repository);
+	if(isfile(rcs))
+	{
+		save_really_quiet = really_quiet;
+		really_quiet = 1;
+		if ((rcsfile = RCS_parsercsfile (rcs)) == NULL)
+		{
+			if (unlink_file (rcs) < 0)
+				error (0, errno, "cannot remove %s", rcs);
+		}                              // <-- really_quiet not restored, rcs not freed
+		else
+		{
+			freercsnode (&rcsfile);
+			really_quiet = save_really_quiet;
+			xfree (rcs);
+		}
+	}                                  // <-- rcs also leaks when !isfile(rcs)
+}
+```
+
+## Why this is a bug
+Upstream CVS/CVSNT restores `really_quiet` and frees `rcs` unconditionally after the if/else. In this refactor the restore and free were moved *into the else branch only*. `fixaddfile` is called on the failure paths of `cvs add`/`cvs commit` of added files (`checkaddfile` failure, `finaladd` failure). If the half-created RCS file cannot be parsed (exactly the situation `fixaddfile` exists to clean up), the global `really_quiet` remains 1 for the remainder of the process. In server mode a single failed add then silently suppresses the normal output (`M`/`U` lines, "new revision" messages, etc.) for every subsequent file in the same commit/session, making the client appear to succeed with no feedback. `rcs` also leaks on both non-else paths.
+
+## Suggested fix
+Move `really_quiet = save_really_quiet;` and `xfree (rcs);` out of the else branch so they run on all paths (as in upstream):
+```cpp
+    if ((rcsfile = RCS_parsercsfile (rcs)) == NULL)
+    {
+        if (unlink_file (rcs) < 0)
+            error (0, errno, "cannot remove %s", rcs);
+    }
+    else
+        freercsnode (&rcsfile);
+    really_quiet = save_really_quiet;
+    xfree (rcs);
+```

--- a/_reports/core-006-rcs-checkout-options-passed-as-nametag.md
+++ b/_reports/core-006-rcs-checkout-options-passed-as-nametag.md
@@ -1,0 +1,45 @@
+# Keyword-expansion options passed in the nametag slot of RCS_checkout (remove_file / import delete path)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/commit.cpp (and same pattern in src/import.cpp)
+- **Line(s):** commit.cpp 1848-1856; import.cpp 1909-1916
+- **Severity:** low
+- **Confidence:** high
+- **Category:** logic / typo
+
+## Code
+commit.cpp, `remove_file()`:
+```cpp
+	char *real_rev = RCS_branch_head(finfo->rcs,rev?corev:NULL);
+	options = RCS_getexpand(finfo->rcs, real_rev);
+
+    /* check something out.  Generally this is the head. ... */
+    bool is_ref = false;
+    retcode = RCS_checkout (finfo->rcs, finfo->file, rev ? corev : NULL,
+			    options, (char *) NULL, RUN_TTY,      // <-- options in the *nametag* slot
+			    (RCSCHECKOUTPROC) NULL, (void *) NULL, NULL, &is_ref);
+```
+
+The declaration (src/rcs.h:358, definition rcs_checkin.cpp:106):
+```cpp
+int RCS_checkout (RCSNode *rcs, const char *workfile, const char *rev, const char *nametag,
+                  const char *options, const char *sout, RCSCHECKOUTPROC pfn, void *callerdat,
+                  mode_t *pmode, bool *is_ref);
+```
+
+import.cpp has the identical copy-pasted call at 1914-1916.
+
+## Why this is a bug
+The 4th parameter of `RCS_checkout` is `nametag` (the symbolic tag used to expand `$Name$`), the 5th is `options` (the `-k` expansion mode). Upstream passed `(char*) NULL, (char*) NULL` here. The Gaijin change fetches the per-revision expansion mode via `RCS_getexpand()` — clearly intending it to control checkout expansion — but passes it as `nametag` and leaves `options` NULL.
+
+Consequences when committing a file removal (`cvs remove` + `cvs ci`) or when `import` marks a file dead:
+1. The intended explicit expansion mode is not applied. (It mostly self-heals because `RCS_checkout` falls back to `RCS_getexpand(rcs, rev)` internally when options is NULL, but for a branch removal `real_rev` and the checked-out rev can differ, so the wrong revision's kopt can be used.)
+2. The kopt string (e.g. `kv`, `B`, `z9`) is used as the *tag name* for `$Name$` keyword expansion, so the temporary working file — whose content becomes the base for the dead revision check-in — gets `$Name: kv $` (or similar) baked into it for any file using the `$Name$` keyword.
+
+## Suggested fix
+Swap the arguments so the expansion mode lands in the options slot:
+```cpp
+    retcode = RCS_checkout (finfo->rcs, finfo->file, rev ? corev : NULL,
+			    (char *) NULL, options, RUN_TTY,
+			    (RCSCHECKOUTPROC) NULL, (void *) NULL, NULL, &is_ref);
+```
+(same fix in import.cpp:1914).

--- a/_reports/core-007-commit-fileproc-lock-leak-on-error.md
+++ b/_reports/core-007-commit-fileproc-lock-leak-on-error.md
@@ -1,0 +1,60 @@
+# commit_fileproc error paths skip do_unlock_file, leaving the file write-locked on the lock server
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
+- **Line(s):** 1374-1378, 1407-1413, 1420-1424 (the `goto out` sites); 1548-1550 (unlock placed before the label)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** concurrency / error-handling
+
+## Code
+```cpp
+	if(!commit_keep_edits)
+		err += notify_do ('C', finfo->file, getcaller (), ...);
+
+	do_unlock_file(ci->lockId);      // line 1548
+
+out:                                     // line 1550
+	xfree(options);
+    if (err != 0 ...)
+```
+Error paths that jump past the unlock:
+```cpp
+				int status = RCS_checkout (finfo->rcs, NULL, bra, ...);
+				if (status > 0)
+				{
+					err = 1;
+					goto out;        // lock ci->lockId never released
+				}
+...
+			if (lock_RCS (finfo->file, finfo->rcs, ci->rev, finfo->repository) != 0)
+			{
+				unlockrcs (finfo->rcs);
+				err = 1;
+				goto out;            // same
+			}
+...
+		if (checkaddfile (...) != 0)
+		{
+		    fixaddfile (finfo->file, finfo->repository);
+		    err = 1;
+		    goto out;                // same
+		}
+```
+The lock was acquired per-file in `check_fileproc` (lines 1114-1126):
+```cpp
+			ci->lockId = do_lock_file(f, finfo->repository, 0, 0);
+			...
+				ci->lockId = do_lock_file(f, finfo->repository, 1, 1);   // write lock, waiting
+```
+
+## Why this is a bug
+`do_unlock_file(ci->lockId)` sits *above* the `out:` label, so every `goto out` error path (failed `lock_RCS`, failed `checkaddfile`, failed slide-tags checkout) returns without releasing the advisory lock this process took on `<file>,v` via the CVSNT lock server. The lock is only implicitly dropped when `Lock_Cleanup()` closes the lock-server connection after the *entire* commit recursion finishes. During a large multi-directory commit where one file fails early, that file (and the failing commit continues processing all remaining directories) stays write-locked for the rest of the operation, blocking other users' commits and (for write locks) reads of that file for an unbounded time. Note the failure of one file does not abort the recursion — `commit_fileproc` returns err and processing continues — so the window can be minutes on big trees.
+
+## Suggested fix
+Move `do_unlock_file(ci->lockId);` below the `out:` label (guarding against the T_UPTODATE/early-return cases where `ci` is valid), e.g.:
+```cpp
+out:
+	do_unlock_file(ci->lockId);
+	xfree(options);
+```
+(`ci` is always valid at any `goto out`, which all occur after `ci = (struct commit_info *) p->data;`).

--- a/_reports/core-008-pretag-proc-uninitialized-ret.md
+++ b/_reports/core-008-pretag-proc-uninitialized-ret.md
@@ -1,0 +1,56 @@
+# pretag_proc returns uninitialized value when trigger library has no pretag handler
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
+- **Line(s):** 604-621
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic / error-handling (uninitialized variable)
+
+## Code
+```cpp
+static int pretag_proc(void *params, const trigger_interface *cb)
+{
+	pretag_params_t *args = (pretag_params_t *)params;
+	int ret;                                  // <-- not initialized
+
+	TRACE(1,"pretag_proc(%s,%s,%s,%c)",...);
+
+	if(cb->pretag)
+	{
+		pretag_list_size=pretag_list_count=0;
+		walklist(tlist, pretag_list_proc, NULL);
+		ret = cb->pretag(cb,args->message,args->directory,pretag_list_count,pretag_list,pretag_version_list,args->tag_type,args->action,args->tag);
+		xfree(pretag_list);
+		xfree(pretag_version_list);
+	}
+
+	return ret;                               // <-- garbage when cb->pretag == NULL
+}
+```
+
+Compare the equivalent commit trigger in commit.cpp:1232, which correctly starts with `int ret = 0;`:
+```cpp
+static int precommit_proc(void *param, const trigger_interface *cb)
+{
+	int ret = 0;
+	...
+}
+```
+
+## Why this is a bug
+`run_trigger` invokes `pretag_proc` for every loaded trigger/audit library. Any library that does not implement the `pretag` entry point (a perfectly normal configuration — e.g. a library providing only `postcommand` or `loginfo` hooks) makes `pretag_proc` return whatever happens to be in the stack slot of `ret`. In `check_filesdoneproc` (line 596) a positive return is treated as failure:
+
+```cpp
+	if ((n = run_trigger(&args, pretag_proc)) > 0)
+    {
+        error (0, 0, "Pre-tag check failed");
+        err += n;
+    }
+```
+
+so `cvs tag`/`cvs rtag` can nondeterministically fail with "Pre-tag check failed" (or silently succeed when it should not, if a real failure gets masked by a negative garbage value) depending on stack contents. This is exactly the class of bug that appears only in release builds and specific call paths.
+
+## Suggested fix
+```cpp
+	int ret = 0;
+```

--- a/_reports/core-009-tag-alias-plus-branch-double-free.md
+++ b/_reports/core-009-tag-alias-plus-branch-double-free.md
@@ -1,0 +1,52 @@
+# cvs tag/rtag with -A -b double-frees the revision string (rev aliases version)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
+- **Line(s):** rtag_fileproc 740/767 with 816-830; tag_fileproc 1131 with 1188-1198 and 1214-1218
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** memory
+
+## Code
+rtag_fileproc:
+```cpp
+    rev = (!alias_branch && branch_mode) ? RCS_magicrev (rcsfile, version) : version;
+    ...
+    retcode = RCS_settag(rcsfile, symtag, rev, current_date);
+    ...
+    if (branch_mode)
+		xfree (rev);          // frees; sets only `rev` to NULL
+    xfree (version);          // <-- same pointer freed again when alias_branch && branch_mode
+```
+tag_fileproc has the identical pattern:
+```cpp
+    rev = (!alias_branch && branch_mode) ? RCS_magicrev (vers->srcfile, version) : version;
+    ...
+    if (branch_mode)
+	xfree (rev);
+    ...
+    if (nversion != NULL)
+    {
+        xfree (nversion);     // <-- version == nversion on the -r path: double free
+    }
+    freevers_ts (&vers);      // <-- or frees vers->vn_user again on the no -r path
+```
+
+## Why this is a bug
+`rev` receives a *fresh* allocation from `RCS_magicrev` only when `!alias_branch && branch_mode`. When **both** `-A` (alias_branch) and `-b` (branch_mode) are given — a combination the option parser does not reject (`cvstag()` only rejects mixing `-M` with `-A`) — `rev` is a mere alias of `version`, yet the cleanup code still executes `if (branch_mode) xfree (rev);` *and* separately frees `version`/`nversion` (or lets `freevers_ts` free `vers->vn_user`, which `version` aliases in `tag_fileproc` when no `-r` was given). `xfree` NULLs only the variable it is passed, so the second free operates on an already-freed pointer:
+
+- `cvs rtag -A -b -r <branch> <tag> <module>`: `xfree(rev)` then `xfree(version)` → double free per file.
+- `cvs tag -A -b -r <branch> <tag>`: `xfree(rev)` then `xfree(nversion)` → double free per file.
+- `cvs tag -A -b <tag>` (no `-r`; the "-A requires -r" rule is only documented, never enforced): `xfree(rev)` frees `vers->vn_user` in place; `freevers_ts(&vers)` then frees it again.
+
+Heap corruption in the server process (these fileprocs run server-side), repeated once per file being tagged.
+
+## Suggested fix
+Track ownership explicitly, e.g.:
+```cpp
+    int rev_allocated = (!alias_branch && branch_mode);
+    rev = rev_allocated ? RCS_magicrev (rcsfile, version) : version;
+    ...
+    if (rev_allocated)
+        xfree (rev);
+```
+or reject the `-A -b` combination in `cvstag()` the way `-A -M` is rejected.

--- a/_reports/core-010-send-blob-file-direct-unchecked-fopen.md
+++ b/_reports/core-010-send-blob-file-direct-unchecked-fopen.md
@@ -1,0 +1,45 @@
+# send_blob_file_direct never checks fopen result before fread/fclose
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+- **Line(s):** 5775-5817 (fopen at 5784, use at 5790, fclose at 5805)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** error-handling
+
+## Code
+```cpp
+bool send_blob_file_direct(const char *file, char *hash_encoded, bool blob_binary_compressed)
+{
+  size_t fsz = get_file_size(file);
+  ...
+  char bufIn[128<<10];
+  FILE* rf = fopen(file, "rb");            // <-- result never checked
+  std::vector<char> blob;blob.resize(fsz); size_t dataWritten = 0;
+  StreamStatus st = compress_lambda(
+    [&](const char *&src, size_t &src_pos, size_t &src_size)
+      {...
+       src_size = fread(bufIn, 1, sizeof(bufIn), rf);   // <-- fread(NULL FILE*)
+       update_blob_hash(hctx, bufIn, src_size);
+       return ferror(rf) ? StreamStatus::Error : ...    // <-- ferror(NULL)
+      },
+    ...);
+  if (st != StreamStatus::Finished)
+    error(1,0, "Can't send binary blob for %s", file);
+  fclose(rf);                              // <-- fclose(NULL)
+```
+
+## Why this is a bug
+`fopen` can legitimately fail here: the working file can be deleted or exclusively locked (very common on Windows, which this fork targets) between the moment commit classifies the file and the moment the blob is streamed, or the process can be out of FILE handles. `fread`/`ferror`/`fclose` on a NULL `FILE*` is undefined behavior and crashes on the MSVC CRT (invalid parameter handler) — the client dies mid-commit with no diagnostic instead of the graceful "file disappeared during commit" message that its sibling `finish_send_blob_file()` (line 5823-5827) produces for exactly this scenario.
+
+Note also `blob.resize(fsz)` right below pre-allocates the entire file size in RAM; for the multi-GB files this fork exists to handle, an allocation failure raises `std::bad_alloc` which nothing catches (straight `std::terminate`), another abrupt-death path in the same function.
+
+## Suggested fix
+```cpp
+  FILE* rf = fopen(file, "rb");
+  if (!rf)
+  {
+    error (0, errno, "cannot open %s for blob transfer", file);
+    return false;
+  }
+```
+(and consider capping the initial `blob.resize()` / catching bad_alloc).

--- a/_reports/core-011-send-modified-size-truncated-4gb.md
+++ b/_reports/core-011-send-modified-size-truncated-4gb.md
@@ -1,0 +1,37 @@
+# send_modified announces file size with "%lu" — silently truncates >4GB files on Windows, desyncing the protocol
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+- **Line(s):** 5251-5255 (also the receive-side counterpart: `int size = atoi(size_string)` at 1513/1522 and 2374/2379)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow / integer
+
+## Code
+```cpp
+    		send_to_server ("Modified ", 0);
+    		send_to_server (file, 0);
+    		send_to_server ("\n", 1);
+    		send_to_server (mode_string, 0);
+    		send_to_server ("\n", 1);
+    		sprintf (tmp, "%lu\n", (unsigned long) newsize);   // <-- unsigned long is 32-bit on Win64
+    		send_to_server (tmp, 0);
+
+    		if (newsize > 0)
+    			send_to_server_untranslated(buf, newsize);     // <-- sends the full 64-bit size
+```
+Contrast with the blob path a few hundred lines later, which was fixed correctly:
+```cpp
+  sprintf(tmp, "%llu\n", (unsigned long long) (dataWritten + sizeof(hdr)));   // line 5813
+```
+
+## Why this is a bug
+This fork exists specifically to handle very large binary files, and the platform is Windows, where `unsigned long` is 32 bits even in x64 builds. `newsize` is a `size_t` holding the full file size (the file is read wholesale into `buf`; `wnt_stat` correctly reports 64-bit `st_size`, win32.cpp:2270).
+
+A file larger than 4 GiB that goes through the legacy `Modified` path — any large file *not* marked with the new `-kB` (KFLAG_BINARY_DELTA) option, e.g. an old-style `-kb` binary, or any file when the server lacks `Blob-ref-transfer` — is announced with `newsize mod 2^32` bytes but transmitted with all `newsize` bytes. The server consumes the truncated count as file data and then **interprets the remaining gigabytes of raw file content as CVS protocol commands**. Best case the connection errors out with "unrecognized request"; worst case byte sequences that happen to look like valid requests get executed, corrupting the working session. There is no error message pointing at the actual cause.
+
+The receive side has the matching bug: `int size = atoi (size_string);` (lines 1513-1522, annotated `//since we use atoi`) makes a client updating such a file break at 2 GiB (`atoi` overflow is UB; typically INT_MAX or negative, and `size_t(size)` of a negative value is astronomically large — see line 1720 `size_t sizeLeft = size_t(size);`).
+
+## Suggested fix
+- Send: `sprintf (tmp, "%llu\n", (unsigned long long) newsize);`
+- Receive: parse with `strtoull` into a `size_t`/`uint64_t` in `update_entries`, `update_blob_ref_entries`, `handle_mbinary`, `read_counted_file`, and `proxy_updated`/`proxy_file`.
+- Alternatively, refuse (with a clear error) to send >4GiB files through the non-blob path.

--- a/_reports/core-012-serve-entry-extra-null-deref.md
+++ b/_reports/core-012-serve-entry-extra-null-deref.md
@@ -1,0 +1,39 @@
+# serve_entry_extra dereferences NULL when EntryExtra arrives before any Entry
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+- **Line(s):** 2370-2376
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** memory / security (remote DoS)
+
+## Code
+```cpp
+/* This must be sent directly after the Entry line above to work properly */
+static void serve_entry_extra(char *arg)
+{
+    struct an_entry *p = entries;
+
+	xfree(p->entry_extra);        // <-- p is NULL if no Entry was sent first
+	p->entry_extra = xstrdup(arg);
+}
+```
+
+## Why this is a bug
+`entries` is the global head of the entry list, populated by `serve_entry`/`serve_is_modified`. `serve_entry_extra` assumes an `Entry` request was received immediately before, but performs no NULL check. The `EntryExtra` request is registered as a normal, non-essential request (server.cpp:4925), so a client — or a malformed/malicious one — can send `EntryExtra` as the very first entry-related request in a directory. `entries` is then NULL and `p->entry_extra` dereferences a NULL pointer, crashing the server process for that connection.
+
+Every other `serve_*` handler in this file carefully checks its allocations and returns via `error()`; this one was written assuming well-behaved ordering. Because the server is reachable by any authenticated (and in anonymous-readonly setups, effectively unauthenticated) client, this is a trivially triggerable remote crash.
+
+## Suggested fix
+```cpp
+static void serve_entry_extra(char *arg)
+{
+    struct an_entry *p = entries;
+    if (p == NULL)
+    {
+        error (1, 0, "protocol error: EntryExtra without preceding Entry");
+        return;
+    }
+    xfree(p->entry_extra);
+    p->entry_extra = xstrdup(arg);
+}
+```

--- a/_reports/core-013-server-receive-file-size-int-overflow.md
+++ b/_reports/core-013-server-receive-file-size-int-overflow.md
@@ -1,0 +1,40 @@
+# Server receive path uses int/atoi for file size — >2GB uploads overflow (large-binary fork)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+- **Line(s):** serve_modified 1992/2035/2044-2045; receive_file 1731; receive_partial_file 1656; serve_binary_transfer 2085/2119/2140-2141
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow / integer
+
+## Code
+```cpp
+static void serve_modified (char *arg)
+{
+    int size, status;               // <-- int
+    ...
+	size = atoi (size_text);        // <-- atoi: UB / overflow past INT_MAX
+    ...
+    if (size >= 0)
+		receive_file (size, arg, !(serve_file_kopt(arg).flags&(KFLAG_BINARY|KFLAG_ENCODED)));
+}
+
+static void receive_file (int size, char *file, bool check_textfile)   // int size
+...
+static void receive_partial_file (int size, int file, ...)             // int size
+{
+    while (size > 0) { ... size -= nread; }
+}
+```
+
+## Why this is a bug
+The entire non-blob upload path types the file size as `int` and parses it with `atoi`. This fork's whole reason for existing is very large binary files, and while the new blob path (`serve_blob`, line 1812) correctly uses `uint64_t size = atoll(...)`, the legacy `Modified` path any client falls back to — and `serve_binary_transfer` — still use 32-bit `int`.
+
+Consequences for a `Modified` upload of a file ≥ 2 GiB:
+- `atoi` on a value > INT_MAX is undefined behavior; in practice it yields INT_MAX or a negative number.
+- If it comes back negative, `if (size >= 0)` is false, so `receive_file` is skipped entirely: the server never reads the file bytes off the socket, then treats the multi-GB file body as a stream of protocol requests (protocol desync / possible mis-execution), or the connection wedges.
+- If it comes back positive-but-truncated (`size mod 2^32` when it happens to land positive), the server writes only the truncated prefix and again leaves gigabytes of file data in the socket to be parsed as commands.
+
+This is the server-side mirror of the client-side truncation reported in core-011; the two together mean a >2GB non-blob commit cannot work and actively corrupts the protocol stream in both directions.
+
+## Suggested fix
+Thread a 64-bit unsigned size through `serve_modified`, `serve_binary_transfer`, `receive_file`, and `receive_partial_file` (parse with `strtoull`, like `serve_blob` uses `atoll`), or explicitly reject non-blob transfers above a safe size with a clear protocol error.

--- a/_reports/core-014-server-updated-blob-ref-created-dead-condition.md
+++ b/_reports/core-014-server-updated-blob-ref-created-dead-condition.md
@@ -1,0 +1,44 @@
+# server_updated: "Blob-ref-created" branch is dead code (vers==NULL && vers->ts_user) — inverted test
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+- **Line(s):** 4504-4510
+- **Severity:** high
+- **Confidence:** high
+- **Category:** logic / typo
+
+## Code
+```cpp
+    else if (updated == SERVER_BLOB_REF)
+    {
+		if ((vers == NULL && vers->ts_user == NULL) && supported_response ("Blob-ref-created"))
+			buf_output0(buf_to_net,"Blob-ref-created ");
+		else
+			buf_output0(buf_to_net,"Blob-ref ");
+	}
+```
+Compare the correct parallel logic for SERVER_UPDATED a few lines above (4489-4494):
+```cpp
+		assert (vers != NULL);
+		if (vers->ts_user == NULL)
+			buf_output0(buf_to_net,"Created ");
+		else
+			buf_output0(buf_to_net,"Update-existing ");
+```
+
+## Why this is a bug
+The test `(vers == NULL && vers->ts_user == NULL)` is self-contradictory: if `vers == NULL` is true, then evaluating `vers->ts_user` dereferences a NULL pointer; if `vers` is non-NULL, the `&&` short-circuits to false. So the condition is **false in every non-crashing case** — the `"Blob-ref-created "` response is dead code and the server always emits `"Blob-ref "`.
+
+This is the blob-reference feature that is the entire point of this Gaijin fork. The intended logic (mirroring the SERVER_UPDATED case) is "if this is a newly-created file (`vers->ts_user == NULL`) and the client understands `Blob-ref-created`, send that; otherwise send `Blob-ref`." Because the condition is inverted/broken:
+
+- The client always receives `Blob-ref` (handled by `handle_updated_blobs_refs`, existp = `UPDATE_ENTRIES_EXISTING_OR_NEW`) instead of `Blob-ref-created` (handled by `handle_created_blobs_refs`, existp = `UPDATE_ENTRIES_NEW`).
+- `UPDATE_ENTRIES_NEW` is what makes the client refuse to overwrite an untracked local file of the same name ("move away X; it is in the way"). With the create signalled as EXISTING_OR_NEW, a checkout/update that creates a blob-backed binary file can silently clobber a user's pre-existing local file of that name instead of warning.
+
+Also, should `vers` ever legitimately be NULL on this path, the expression crashes the server outright.
+
+## Suggested fix
+```cpp
+		if (vers != NULL && vers->ts_user == NULL && supported_response ("Blob-ref-created"))
+			buf_output0(buf_to_net,"Blob-ref-created ");
+		else
+			buf_output0(buf_to_net,"Blob-ref ");
+```

--- a/_reports/core-015-server-updated-size-unsigned-long-truncation.md
+++ b/_reports/core-015-server-updated-size-unsigned-long-truncation.md
@@ -1,0 +1,31 @@
+# server_updated uses 32-bit `unsigned long` size and "%lu" — truncates >4GB checkouts on Windows
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+- **Line(s):** 4385 (declaration), 4395/4417 (assignment), 4556 (buf_read_file), 4567 (sprintf "%lu")
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow / integer
+
+## Code
+```cpp
+	struct buffer_data *list, *last;
+	unsigned long size;                          // <-- 32-bit on LLP64 (Win64)
+	...
+	    size = buf_length (filebuf);
+	...
+	    size = sb.st_size;                       // <-- off_t (64-bit) truncated into unsigned long
+	...
+			status = buf_read_file (f, size, &list, &last);   // reads truncated count
+	...
+		char text[16];
+		sprintf(text,"%lu\n",size);              // announces truncated count
+		buf_output0(buf_to_net,text);
+```
+
+## Why this is a bug
+This is the server→client mirror of the size-truncation problems reported in core-011 (client send) and core-013 (server receive). On Windows x64 (LLP64, the platform this fork targets) `unsigned long` is 32 bits, but `sb.st_size` is a 64-bit `off_t` (see win32.cpp `_statcore`: `buf->st_size = (((off_t)nFileSizeHigh)<<32)+nFileSizeLow`).
+
+When the server checks out / updates a file larger than 4 GiB through the normal (non-blob) `Updated`/`Created`/`Merged`/`Rcs-diff` path, `size` wraps to `st_size mod 2^32`. The server then both announces the truncated length and only streams that many bytes via `buf_read_file(f, size, ...)`. The client (which also parses the count with `atoi`, core-011) receives a silently truncated file — data loss on the working copy with no error on either side. For a fork whose reason to exist is very large binary files, checking one out over any client/server transport that falls back to the classic file path corrupts it.
+
+## Suggested fix
+Type `size` as `uint64_t` (or `size_t`), print it with a 64-bit-correct format (`"%" PRIu64` / `"%llu"` with a suitably sized buffer — note `text[16]` is also too small for a 20-digit 64-bit value plus newline), and make `buf_read_file` take a 64-bit length. Coordinate with the client-side `strtoull` fix from core-011.

--- a/_reports/core-016-scratch-entry-duplicate-entrieslog-line.md
+++ b/_reports/core-016-scratch-entry-duplicate-entrieslog-line.md
@@ -1,0 +1,44 @@
+# Scratch_Entry/Rename_Entry write a duplicate un-prefixed (implicit-Add) line into Entries.Log
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
+- **Line(s):** write_ent_ex_proc 120-135 (the `fputentent(entfile,...)` at 129); callers Scratch_Entry 257-258, Rename_Entry 299-300 & 310-311, Register 422-423
+- **Severity:** low
+- **Confidence:** medium
+- **Category:** logic
+
+## Code
+```cpp
+static int write_ent_ex_proc (Node *node, void *closure)
+{
+    Entnode *entnode = (Entnode *) node->data;
+    if (closure != NULL && entnode->type != ENT_FILE)
+	*(int *) closure = 1;
+    if (fputentent(entfile, entnode))          // <-- writes the Entries line to entfile
+		error (1, errno, "cannot write %s", entfilename);
+    if (fputententex(entexfile, entnode))      // writes the Entries.Extra line to entexfile
+		error (1, errno, "cannot write %s", entexfilename);
+    return (0);
+}
+```
+Scratch_Entry appends to `CVSADM_ENTLOG` (entfile) like this:
+```cpp
+    if (fprintf (entfile, "R ") < 0) ...
+    if (fprintf (entexfile, "R ") < 0) ...
+    write_ent_proc (node, NULL);      // entfile gets: "R /user/vn/ts/opts/td\n"
+    write_ent_ex_proc (node, NULL);   // entfile ALSO gets a second: "/user/vn/ts/opts/td\n"
+```
+
+## Why this is a bug
+`write_ent_ex_proc` writes the plain Entries line to `entfile` **and** the extra line to `entexfile`. That is correct for the full-rewrite path (`write_entries` walks only `write_ent_ex_proc`). But the incremental log-append paths (`Scratch_Entry`, `Rename_Entry`, `Register`) call **both** `write_ent_proc` (which already wrote the entry to `entfile`) and `write_ent_ex_proc`, so every such operation appends a **second, command-prefix-less copy** of the entry to `Entries.Log`.
+
+When `Entries.Log` is later replayed (`fgetentent` with a `cmd`), a line whose second character is not a space is treated as an implicit **Add** (`if (l[1] != ' ') *cmd = 'A';`, entries.cpp:473). So for `Scratch_Entry` the log records:
+```
+R /user/...      (remove)
+/user/...        (implicit ADD of the very file just removed)
+```
+Replaying this removes then re-adds the file — the scratch is undone.
+
+In normal operation this is masked because `write_entries` runs at command end, rewrites `CVSADM_ENT` from the in-memory list, and unlinks `Entries.Log` before it can be replayed. But if the process terminates between the `Scratch_Entry` and the closing `write_entries` (fatal `error()`, signal, crash, `kill`), the stale `Entries.Log` survives and the **next** command's `Entries_Open` replays the bogus Add, resurrecting a scratched entry (and, for `Rename_Entry`, resurrecting the old name). It also doubles the size of every Entries.Log write.
+
+## Suggested fix
+Give the incremental paths a helper that writes only the Entries.Extra line (e.g. a `write_entex_only_proc` calling just `fputententex(entexfile,...)`), and use `write_ent_proc` + that helper in `Scratch_Entry`/`Rename_Entry`/`Register`, leaving `write_ent_ex_proc` (both files) only for the `write_entries` full rewrite.

--- a/_reports/core-017-rcs-checkin-static-diffopts-strcat-overflow.md
+++ b/_reports/core-017-rcs-checkin-static-diffopts-strcat-overflow.md
@@ -1,0 +1,53 @@
+# RCS_checkin strcats encoding onto a static diffopts buffer every call — accumulates and overflows
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/rcs_checkin.cpp
+- **Line(s):** 1022-1029 (context-diff path) and 1247-1254 (unified-diff path)
+- **Severity:** high
+- **Confidence:** high
+- **Category:** overflow
+
+## Code
+```cpp
+	else if(kf.flags&KFLAG_ENCODED && !server_active)
+	{
+		static char __diffopts[64] = "-a -n --binary-output --encoding=";
+		strcat(__diffopts,kf.encoding.encoding);      // <-- appends to a *static* buffer
+		if(kf.encoding.bom)
+			strcat(__diffopts," --bom");
+		diffopts = __diffopts;
+	}
+```
+and the near-identical block at 1247-1254:
+```cpp
+		else if(kf.flags&KFLAG_ENCODED && !server_active)
+		{
+			static char __diffopts[64] = "-a -u --binary-output --encoding=";
+			strcat(__diffopts,kf.encoding.encoding);
+			if(kf.encoding.bom)
+				strcat(__diffopts," --bom");
+			diffopts = __diffopts;
+		}
+```
+
+## Why this is a bug
+`__diffopts` is a **static** buffer initialized once to the ~33-char base string. Each time this branch runs, `strcat` appends the file's encoding name (and optionally `" --bom"`) to whatever the buffer already holds from the previous call. The base string is never restored, so the appended text accumulates:
+
+- 1st encoded file: `"...--encoding=UTF-8"`
+- 2nd encoded file: `"...--encoding=UTF-8UTF-8"`
+- 3rd: `"...--encoding=UTF-8UTF-8UTF-8"` ...
+
+Two failure modes:
+1. **Wrong diff options** from the second encoded file onward — the `--encoding=` value becomes a concatenation of every prior encoding, so `diff_exec` is invoked with a garbage encoding argument, corrupting the delta/diff produced for a committed unicode file.
+2. **Static buffer overflow**: the 64-byte buffer overruns after a few accumulations (base 33 + repeated encodings), a classic out-of-bounds write into adjacent static storage.
+
+`RCS_checkin` is called once per file, so committing several `-k`-encoded (unicode) files in a single `cvs commit` against a **local** repository (`server_active` is false — this branch is guarded by `!server_active`) reaches both modes within one process. The same static is also shared between the two blocks' respective buffers (each block has its own static, but each accumulates independently).
+
+## Suggested fix
+Rebuild the string from scratch each call into a local (non-static) buffer with a bounds-checked format, e.g.:
+```cpp
+	char diffbuf[128];
+	snprintf(diffbuf, sizeof diffbuf, "-a -n --binary-output --encoding=%s%s",
+	         kf.encoding.encoding, kf.encoding.bom ? " --bom" : "");
+	diffopts = diffbuf;   /* ensure lifetime spans the diff_exec call */
+```
+(or `strcpy` the base into the static before each `strcat`, and enlarge the buffer). Apply to both locations.

--- a/_reports/core-018-client-overwrite-existing-never-reset-C.md
+++ b/_reports/core-018-client-overwrite-existing-never-reset-C.md
@@ -1,0 +1,95 @@
+# `update -C` silently disables the "in the way" guard for the whole run (client_overwrite_existing never reset)
+
+- **File:** cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+- **Line(s):** 37, 5434-5448, 1544, 2406 (and update.cpp:376)
+- **Severity:** medium
+- **Confidence:** high
+- **Category:** logic
+
+## Code
+```cpp
+// client.cpp:37 — process-global, one instance
+int client_overwrite_existing;
+
+// update.cpp:376 — initialized once before the send phase
+client_overwrite_existing = case_sensitive;
+
+// client.cpp:5434-5448 — send_fileproc(), for a locally MODIFIED tracked file under -C
+if (args->backup_modified)
+{
+    if (backup_local_files)
+    {
+        char *bakname = backup_file (filename, vers->vn_user);
+        if (! really_quiet)
+            printf ("(Locally modified %s moved to %s)\n", filename, bakname);
+        xfree (bakname);
+    }
+    client_overwrite_existing = 1;      // <-- set to 1, never reset anywhere
+}
+
+// client.cpp:1544 (and identical at 2406 for the blob path) — receive phase guard
+if (data->existp == UPDATE_ENTRIES_NEW && !client_overwrite_existing && isfile (filename))
+{
+    error (0, 0, "move away %s; it is in the way", short_pathname);
+    ... discard downloaded file, set failure_exit = 1 ...
+}
+```
+
+## Why this is a bug
+`client_overwrite_existing` is a single process-global (client.cpp:37). Its
+only assignments are the one-time init from `case_sensitive` (update.cpp:376,
+normally 0) and the set-to-1 at client.cpp:5447. **Nothing ever sets it back
+to 0.**
+
+During `cvs update -C`, the entire client send-phase recursion
+(`send_files`) completes before any server response is processed. In that send
+phase, `send_fileproc` runs the block above for every *locally modified tracked*
+file and sets `client_overwrite_existing = 1`. So as soon as **one** tracked
+file in the tree is locally modified, the flag latches to 1 for the rest of the
+invocation.
+
+Then in the receive phase, the guard at client.cpp:1544 (inline content) and
+client.cpp:2406 (blob-ref) — which is meant to refuse to overwrite an
+*untracked* local file that happens to sit where a newly-added repository file
+will be created (`Created` / `Blob-ref-created`, `existp == UPDATE_ENTRIES_NEW`)
+— is `!client_overwrite_existing`, now false. The guard is skipped, the
+"move away X; it is in the way" protection is gone, and the untracked local
+file is silently overwritten with the repository copy.
+
+Failure scenario: a developer runs `cvs update -C` in a tree where (a) they
+have one locally-modified tracked file (correctly reverted by `-C`), and (b) an
+unrelated, never-added local file `foo.bin` happens to share a name with a file
+just added to the repository in that directory. `foo.bin` is silently replaced.
+Without the modified tracked file, the same `foo.bin` would instead be preserved
+and reported as "move away foo.bin; it is in the way".
+
+Two things make this clearly unintended rather than a deliberate `-C` semantic:
+1. It is triggered as a **side effect of an unrelated file** being modified —
+   the untracked-file guard's behavior depends on whether some *other* file in
+   the run happened to be dirty.
+2. It is **inconsistent with the server/local code path**, where `-C`
+   (`toss_local_changes`) is not consulted in the `T_CONFLICT`/"in the way"
+   branch at all (classify.cpp:107-114, update.cpp T_CONFLICT case), so a local
+   or direct-repository `update -C` does *not* overwrite untracked in-the-way
+   files. Only the networked client does, and only by accident.
+
+The documented meaning of `-C` (update.cpp:137: "Overwrite locally modified
+files with clean repository copies") is about modified *tracked* files, not
+untracked ones.
+
+## Suggested fix
+Make the overwrite decision per-file instead of via a latched global. Either
+carry an "overwrite this file" bit through `struct send_data` / the response
+handler for the specific files being reverted, or, at minimum, reset
+`client_overwrite_existing` back to its initial value after the send phase so
+the receive-phase guard is not disabled by an unrelated modified file:
+
+```cpp
+// after send_files() returns in update.cpp (remote branch), before reading responses:
+client_overwrite_existing = case_sensitive;
+```
+
+Note this interacts with the case-insensitive branch at client.cpp:1539/2402,
+which *relies* on `client_overwrite_existing` being set to allow a
+case-differing overwrite; a correct fix should preserve that path (e.g. a
+separate flag for the case-fold overwrite vs. the untracked-in-the-way guard).

--- a/_reports/perf-analysis.md
+++ b/_reports/perf-analysis.md
@@ -1,0 +1,268 @@
+# G-CVSNT Performance Analysis: per-file / per-directory costs in `update`, `tag`, branch
+
+Code base: `D:\G-CVSNT\cvsnt\cvsnt-2.5.05.3744\` (all paths below relative to that root; line numbers from current working tree).
+
+---
+
+## Executive summary
+
+The time of `cvs update` / `cvs tag` on huge trees is dominated by **fixed per-file overheads on the server**, plus one large per-file overhead on Windows clients. Ranked by expected impact:
+
+1. **Lockserver round-trips: 2 per file for update, ~6 per file for tag.** Every `RCS_parse` of every `,v` file takes a lock from the lockserver over a socket and releases it when the RCSNode is freed (`src/rcs.cpp:905`, `src/rcs.cpp:766-767`; enabled by default, `src/main.cpp:551-560,587-591`). One synchronous send+recv per Lock and per Unlock (`src/lock.cpp:228-251,291,377`). Nothing is batched. For N=300k files that is 600k+ synchronous RTs on update; tag does it twice (two recursion passes) plus a write-lock pair inside `RCS_rewrite`.
+2. **Full `,v` header parse per file, every time, no cache.** `RCS_parsercsfile_i` unconditionally calls `RCS_reparsercsfile`, which parses *every delta header* of the file (`src/rcs.cpp:326-352`, delta loop at `src/rcs.cpp:533`, `getdelta` at `src/rcs.cpp:6148`). The comment at `src/rcs.cpp:336-340` still claims lazy parsing, but the code isn't lazy any more. Cost is proportional to the number of revisions per file even when the answer is "up to date". There is no cache anywhere (no hits for "cache" in `src/rcs.cpp`).
+3. **Tag rewrites the whole `,v` and then re-parses it.** `RCS_rewrite` writes full admin + raw-copies the whole body to `,file,`, renames, then does a *complete re-parse* of the file it just wrote (`src/rcs.cpp:7154-7201`, reparse at 7199-7200) — the re-parse result is immediately thrown away by the tag file-proc. Tag also runs **two full recursion passes** (permission/`check_fileproc` pass + tag pass), each re-parsing every file (`src/tag.cpp:409` and `:431`).
+4. **Windows stat() opens every file.** Default `use_ntea=1` (`windows-NT/win32.cpp:362-363`) makes every `CVS_STAT`/`CVS_LSTAT` of an existing file do `CreateFile(FILE_READ_EA)` + `NtQueryEaFile` + `CloseHandle` on top of `GetFileAttributesEx` (`windows-NT/win32.cpp:2203-2213, 1946-1986`). The client stats every working file once per update (`src/vers_ts.cpp:389`). ~4 kernel calls (incl. a file open that AV filters intercept) × N files.
+5. **Server "fake sandbox" materialization/deletion is O(M·depth) filesystem ops** — `dirswitch`+`create_adm_p`+`mkdir_p` per `Directory` request (`src/server.cpp:1304-1500, 705-, 892-`), and the final `rm -rf` of the temp dir happens **before** the compressed-stream shutdown trailer is sent (`src/server.cpp:5100-5121`), i.e. partially on the client-visible critical path.
+6. **No parallelism anywhere on the server path** (recursion is strictly sequential); the only existing parallelism is the client-side blob transfer pool (≤8 threads, persistent connections — already good, `src/download_blob_to.cpp:236-299`).
+
+There is **no per-file client↔server network round-trip** — both request and response phases are fully streamed/buffered. The per-file round trips are server↔lockserver (and client↔blob-server for changed `-kB` files, but those are parallel and pipelined per-thread).
+
+---
+
+## 1. Update path costs (N files, M directories, almost nothing changed)
+
+### 1.1 Client, send phase (per file)
+
+Driven by `send_files` → `start_recursion` → `send_fileproc` (`src/client.cpp:5909-5980, 5297`).
+
+| Operation | Where | Cost |
+|---|---|---|
+| Entries lookup | `Version_TS` → `findnode_fn` (`src/vers_ts.cpp:132-134`) | O(1) hash |
+| **stat of working file** | `src/vers_ts.cpp:389` `time_stamp` → `CVS_LSTAT` | 1 lstat; on Windows = `GetFileAttributesEx` + `CreateFile` + `NtQueryEaFile` + `CloseHandle` (`windows-NT/win32.cpp:2135, 2203-2213, 1947-1986` — `use_ntea` default on, `:363`) |
+| `Entry /name/ver/ts.../` line | `src/client.cpp:5322-5355` | ~80-150 B to buffer |
+| `EntryExtra` line (cvsnt ext.) | `src/client.cpp:5358-5377` | ~60 B |
+| `Unchanged name` line | `src/client.cpp:5452-5461` | ~15 B |
+| md5 re-check when only timestamp differs | `src/client.cpp:5400-5421` | full file read + MD5 (only for touched-but-identical files with md5 stored in `Entries.Extra`) |
+
+If a file is genuinely modified: `Is-modified` (update passes `SEND_NO_CONTENTS`? No — update does *not* set SEND_NO_CONTENTS; it sends contents for modified text files via `send_modified`, `src/client.cpp:5432`, but for `-kB` blob files it sends only `Blob-ref-transfer` + blake3 hash because update passes `SEND_NO_BLOBS_CONTENT`, `src/update.cpp:410`, `src/client.cpp:5098, 5223-5243`; computing that hash reads the whole local file).
+
+Per directory (client): `send_dirent_proc` does `isdir(dir/CVS)` + `Name_Repository` (reads `CVS/Repository`) (`src/client.cpp:5539-5559`); the recursion additionally reads `CVS/Entries`, `CVS/Entries.Extra`, `CVS/Entries.Log` (`src/entries.cpp:843-917`), `CVS/Tag` (`ParseTag`, `src/entries.cpp:1140`), `CVS/Root` per directory (`src/recurse.cpp:639,1177`), and `open_directory` does 2 `isfile` probes (`CVS/Rename`, `CVS/Repository.Virtual`, `src/mapping.cpp:1136,1177`). If `Entries.Log` exists, Entries is fully rewritten at open (`src/entries.cpp:938-942`).
+
+**No round trips**: all requests are appended to a buffered stream; the single flush + `update\n` happens once (`src/update.cpp:444`).
+
+### 1.2 Server, request phase (per file / per directory)
+
+* Per `Directory` request (`serve_directory` → `dirswitch`, `src/server.cpp:1563, 1304-1500`):
+  * `server_write_entries()` — drains queued Entry lines into the temp sandbox `CVS/Entries` + `CVS/Entries.Extra` (append-open, fprintf per file, close) (`src/server.cpp:2489-2540`).
+  * `mkdir_p(dir)` — one mkdir attempt per path component (`src/server.cpp:892-930`).
+  * `create_adm_p` — walks from the deepest component **up to the root**, doing mkdir + `isfile(CVS/Repository)` (+ creates on first visit) per level (`src/server.cpp:705-`).
+  * `chdir`, `mkdir CVS`, write `CVS/Repository`, touch `CVS/Entries`, touch `CVS/Entries.Extra` (`src/server.cpp:1407-1499`).
+  * Net: **O(depth) syscalls + ~6 file ops per directory**, ~M·(depth+6) total.
+* Per `Entry` request: O(1) malloc + prepend (`src/server.cpp:2336-2367`).
+* Per `Unchanged`/`Is-modified` request: linear scan of the per-directory entry list (`src/server.cpp:2224-2246, 2263-2293`) — but the just-prepended Entry is at the head, so with the standard client ordering (Entry immediately followed by Unchanged) it's O(1). Worst case (non-adjacent ordering) is O(F²) per directory.
+
+### 1.3 Server, command phase (per file)
+
+`serve_update` → `do_cvs_command(update)` → `do_update` → `start_recursion(update_fileproc, …, readlock=1, dosrcs=1)` (`src/update.cpp:651-654`).
+
+Per file (`do_file_proc`, `src/recurse.cpp:884-970`):
+
+1. `map_filename` — in-memory modules2/rename lookup, several MAX_PATH strcpy/snprintf (`src/recurse.cpp:894`, `src/mapping.cpp:658-681, 464-`). Cheap but nonzero CPU.
+2. **`RCS_parse`** (`src/recurse.cpp:915`):
+   * `CVS_FOPEN` of `name,v`; on miss, second attempt in `Attic/` (`src/rcs.cpp:267-289`).
+   * **lockserver `Lock Read` round trip** (`src/rcs.cpp:905` → `do_lock_file` → `do_lock_server` send+recv, `src/lock.cpp:362-367, 291, 228-251`). Enabled by default (`LockServer=localhost:2402`, `src/main.cpp:551-560`; forced `127.0.0.1:2402` for the server at `:587-591`). On Linux a Unix socket is used (`src/lock.cpp:184-187`); on Windows it's TCP loopback.
+   * **Full admin parse including every delta header**: `RCS_parsercsfile_i` → `RCS_reparsercsfile` unconditionally (`src/rcs.cpp:341-351`); the `while ((vnode = getdelta(…)))` loop at `src/rcs.cpp:533-544` reads/allocates version, date, author, state, branches, next, kopt, … for **every revision** (`getdelta`, `src/rcs.cpp:6148-`). I/O is buffered in `RCSBUF_BUFSIZE` chunks (`src/rcs.cpp:864`), but bytes-read ≈ size of the whole delta-header section per file, and heap churn ≈ number of revisions.
+3. `Classify_File` → `Version_TS` (`src/update.cpp:719`, `src/classify.cpp:41`):
+   * `RCS_getversion` (tag/branch resolution over in-memory lists, symbols parsed once per node via `translate_symtag`, `src/rcs.cpp:1902, 3217`).
+   * `RCS_getproplist` ×2, `RCS_getfilename`, `RCS_getrevtime`, `RCS_getexpand` (`src/vers_ts.cpp:296-316`).
+   * `time_stamp_server` → `CVS_LSTAT` of the (nonexistent for unchanged files) temp-sandbox file (`src/vers_ts.cpp:411-441`) — on a Windows server a *failed* stat costs up to 4 failed probes (`GetFileAttributesEx`→`FindFirstFile`→`CreateFile`→`GetFileAttributes`, `windows-NT/win32.cpp:2126-2179`).
+   * With `AtomicCheckouts=1` (off by default, `src/main.cpp:548-549`): an extra lockserver `Version` round trip per file in `RCS_getbranch`/`RCS_head` (`src/rcs.cpp:2542-2548, 2817-2823`).
+4. `T_UPTODATE` → nothing is emitted (`src/update.cpp:779-781`).
+5. `freercsnode` → **lockserver `Unlock` round trip** (`src/rcs.cpp:753-774`, unlock at 766-767).
+6. `cvs_flushout()` per file (`src/recurse.cpp:967`) → non-blocking `buf_flush(stdout_buf,0)` (`src/server.cpp:6740-6758`) — cheap when nothing pending.
+
+Per directory (server):
+
+* `Reader_Lock` — **no-op when lockserver enabled** (`src/lock.cpp:704-708`); with `LockServer=none` it creates+removes `#cvs.lock` dir plus a read-lock file per repo dir (`src/lock.cpp:695-780, 1064-1148`).
+* `update_predirent_proc` calls **`open_directory` twice** (`src/update.cpp:1145-1146`; the code itself says `/* This should be made more efficient. FIXME */` at `:1144`), then `do_dir_proc` opens it a **third** time (`src/recurse.cpp:1265`). Each `open_directory` tries `RCS_parse(".directory_history", repo)` and, if that file exists, does `RCS_getversion` + a full `RCS_checkout` of the mapping content (+ its own lockserver lock/unlock) (`src/mapping.cpp:1009-1124`, checkout at 1113); plus 2 `isfile` probes (`src/mapping.cpp:1136,1177`). Also `Entries_Open_Dir` + `upgrade_entries` (`src/update.cpp:1148-1150`).
+* `Find_Names`: `Entries_Open` of the sandbox + `readdir` of the repository dir + `readdir` of `Attic` + sort (`src/find_names.cpp:55-121`).
+* `WriteTag` per dir → writes sandbox `CVS/Tag` and emits `Set-sticky`/`Clear-sticky` to the client (`src/entries.cpp:1056-1121`, response at 1117-1119); plus one `E Updating <dir>` message per dir (`src/update.cpp:1346-1354`).
+* `fileattr_startdir` is lazy/cheap (`src/fileattr.cpp:32-42`); `fileattr.xml` is only read if something asks (`fileattr_read` on demand). But `checkout_file` *does* ask per checked-out file (`fileattr_getroot` + XPath at `src/update.cpp:1724-1731`), so directories containing any updated file pay one fileattr read + per-file XPath evaluation.
+
+### 1.4 Server → client response phase
+
+* For up-to-date files: **zero bytes**.
+* For changed text files: `Update-existing`/`Created` + mode + size + contents, all appended to `buf_to_net` (`src/server.cpp:4356-4610`), streamed; flushes happen per-command, not per file (`serve_noop`/final `ok`, `src/server.cpp:4078-4088`).
+* For changed `-kB` files: `RCS_checkout` of the head returns the 71-byte blob ref without touching blob content (`is_ref` plumbing: `src/update.cpp:1676-1682`, `src/rcs_checkin.cpp:129-142`, `src/rcs_cvt_kB.cpp:59-88`), server sends `Blob-ref` (`src/server.cpp:4429-4453, 4504-4510`).
+
+### 1.5 Client, response phase (per changed file)
+
+* `call_in_directory` caches open Entries per directory (`last_entries`, `src/client.cpp:909-916, 1158`); on each directory *change*: chdir to top + chdir to dir + `Entries_Open` + `Find_Directories` (readdir) (`src/client.cpp:929-1180`).
+* Text file: write `_new_<file>` temp, close, `rename_file`, `utime`, `Register` (`src/client.cpp:1689-1807, 1974, 2092`).
+* **`Register` appends to `CVS/Entries.Log` *and* `CVS/Entries.Extra.Log` with `fopen`/`fclose` per call** — 2 opens + 2 writes + 2 closes per updated file (`src/entries.cpp:394-429`). At directory close, if a log exists, Entries and Entries.Extra are each fully rewritten to `.Bak` + renamed, and both logs unlinked (`src/entries.cpp:141-231, 965-981`).
+* Blob (`-kB`) file: `update_blob_ref_entries` → `add_download_queue` (`src/client.cpp:2301-2470`) → background pool: ≤8 threads (`min(8, hw_concurrency-1)`, `src/download_blob_to.cpp:241`; override `CVS_BLOB_DOWNLOAD_THREADS` / `blob_concurrency_download_level`, `src/client.cpp:2177-2180`), each with a **persistent** `BlobSocket` reused across files (`src/blob_kv_processor.cpp:78-160`, member `client`, `start()` reuses), round-robin over public/private proxy URLs with fallback to master (`src/download_blob_to.cpp:186-228, 253-283`). Per task: unlink old file, fopen temp, streamed pull + zstd decode + blake3 verify, rename, chmod, utime, 2× `get_file_size` (`src/download_blob_to.cpp:366-474`). Downloads overlap the whole command; joined at process end (`wait_threads`, `src/main.cpp:1716-1717`).
+* Windows rename = `MoveFileEx` + 2×`GetFileAttributes` + `SetFileAttributes` (`windows-NT/filesubr.cpp:669-758`). No fsync on this path (fsync exists only in `copy_file`, `src/filesubr.cpp:135` etc.).
+
+### 1.6 Round-trip / streaming verdict
+
+* Client↔server: fully streamed both ways; exactly one logical round trip per command. Confirmed by buffered `send_to_server` and single `get_responses_and_close` (`src/update.cpp:444-446`), buffered responses (`src/server.cpp:4356-`).
+* Server↔lockserver: **2 synchronous round trips per file** (the dominant per-file latency), plus 1 per directory-history file.
+* Client↔blob server: 1 request per changed `-kB` file, but on 8 parallel persistent connections and off the critical path until final join.
+
+---
+
+## 2. Tag / branch path costs (`cvs tag NAME`, `cvs tag -b`, `rtag`)
+
+Driver: `cvstag` → `rtag_proc` (`src/tag.cpp:128-309, 315-447`). `lock_for_write=1` for the whole command (`src/tag.cpp:282,305`) — so *every* `RCS_parse` takes a **write** lock from the lockserver (`src/rcs.cpp:35, 905`).
+
+Per file, in order:
+
+1. **Pass 1 (check):** `start_recursion(check_fileproc, …, dosrcs=1)` (`src/tag.cpp:409-412`) → full `RCS_parse` (all delta headers) + lockserver **Write-Lock** RT; `check_fileproc` does `Version_TS` + up to 2 `RCS_getversion` (`src/tag.cpp:452-567`); node freed → **Unlock** RT. Results are stored only as (file, version-string) in `mtlist` for the pretag trigger — the parsed RCS data is thrown away.
+2. `lock_tree_for_write` (`src/tag.cpp:426`): no-op with lockserver (`src/lock.cpp:1239-1240`); with `LockServer=none` it is a **third full recursion** over the tree plus `Writer_Lock` creating a master-lock dir + write-lock file in *every* repo directory and scanning each directory for read locks (`src/lock.cpp:1232-1249, 851-945, 952-1024`).
+3. **Pass 2 (tag):** `start_recursion(tag_fileproc/rtag_fileproc, …, dosrcs=1)` (`src/tag.cpp:431-434`) → *second* full `RCS_parse` + Write-Lock/Unlock RT pair.
+4. `tag_fileproc` (`src/tag.cpp:903-1221`): `Version_TS`, `RCS_getversion` for the new rev and for the existing tag (`:961, 1135`); **fast-path**: if the tag already points at the same rev and isn't a branch, returns without writing (`src/tag.cpp:1147-1154`; same in rtag at `:781-786`).
+5. `RCS_settag` — pure in-memory symbol list edit (`src/rcs.cpp:4786-4840`). Branch mode adds `RCS_magicrev` (scans versions list, `src/tag.cpp:1131`).
+6. **`RCS_rewrite`** (`src/tag.cpp:1204`, rtag `:748, 811`, delete `:1048`, `src/rcs.cpp:7154-7201`):
+   * `rcs_internal_lockfile`: **another lockserver Write-Lock RT** (`src/rcs.cpp:7057`) + `unlink` + `CVS_OPEN(O_CREAT|O_EXCL)` of `,file,` **in the repository directory** (`src/rcs.cpp:7072-7083`).
+   * `RCS_putadmin` (rewrites all symbols — cost scales with number of tags/branches already on the file) + `RCS_putdtree` (every delta header) + `RCS_putdesc` (`src/rcs.cpp:7169-7171`).
+   * `RCS_copydeltas`: with no new delta and nothing outdated, `actions==0` so the per-delta parse loop is skipped and the **entire remaining body is raw-copied in 8 KB blocks** (`src/rcs.cpp:6822-6828, 6903-6941`) — i.e. tag still reads and writes the *whole* `,v` (unavoidable for an in-place header edit, but it is sequential fread/fwrite, no fsync; flushes only, `src/rcs.cpp:7179,7185`).
+   * `rename_file(,file, → file,v)` (`src/rcs.cpp:7113`); on Windows ≈5 syscalls (`windows-NT/filesubr.cpp:669-758`).
+   * `do_unlock_file` — **Unlock RT** (`src/rcs.cpp:7115`).
+   * **`free_rcsnode_contents` + `RCS_reparsercsfile`** — a full re-parse of the file just written (`src/rcs.cpp:7199-7200`). For tag the caller immediately frees the node (`freevers_ts`/`do_file_proc`), so this parse is 100% wasted work.
+7. `history_write` per file (`src/tag.cpp:1196`) — append to `CVSROOT/history`.
+
+Per directory: `tag_dirproc` prints `Tagging <dir>` and **also tags the `.directory_history,v` pseudo-file** (parse + settag + full rewrite) when present (`src/tag.cpp:1227-1260`, `get_directory_finfo` `src/mapping.cpp:1490`).
+
+val-tags: the old "scan the whole repository to validate a tag" is **disabled** (early return with comment "val-tags sucks…", `src/tag.cpp:1398-1403`); `add_to_valtags` runs **once per rtag/tag invocation**, not per file (`src/tag.cpp:440-444, 1517-1611`, `myndbm` open/fetch/store once). ✔ not a hotspot.
+
+**Totals per tagged file (lockserver mode): 3 write-lock + 3 unlock round trips, 3 full `,v` parses (2 passes + post-rewrite reparse), 1 full-file read+write + rename.** Nothing is parallel — strictly sequential single thread. No fsync (crash-safety relies on `,file,`+rename).
+
+---
+
+## 3. Existing optimizations found (upstream cvsnt + Gaijin)
+
+| # | What | Evidence |
+|---|---|---|
+| 1 | `-kB` blob references: `,v` stores a 71-byte `blake3:<hex64>` ref; content lives in the content-addressed store | `src/sha_blob_reference.h:6-13`; write path `src/rcs_cvt_kB.cpp:91-106` |
+| 2 | Server never touches blob content on update; sends `Blob-ref` response | `src/update.cpp:1676-1682`, `src/server.cpp:4429-4453`, `src/rcs_cvt_kB.cpp:59-88` |
+| 3 | **Parallel client blob downloads**: ≤8 worker threads, `concurrent_queue`, per-thread persistent sockets, URL round-robin/fallback, background overlap with protocol phase | `src/download_blob_to.cpp:54-299` (threads `:241,297-299`), `src/blob_kv_processor.cpp:78-160`, join at `src/main.cpp:1716-1717` |
+| 4 | Parallel client blob uploads before commit; server-side dedup via `blob_size_on_server`; local "already sent" cache | `src/client.cpp:5874-5898`, `src/commit.cpp:650-651`, `src/blob_kv_processor.cpp:139-156`, `src/download_blob_to.cpp:475-502` |
+| 5 | Update never uploads `-kB` contents: `SEND_NO_BLOBS_CONTENT` → client sends only the blake3 hash (`Blob-ref-transfer`) | `src/update.cpp:410`, `src/client.cpp:5098, 5223-5243` |
+| 6 | MD5-in-Entries.Extra: touched-but-identical files are detected client-side and sent as `Unchanged` (avoids content upload) | `src/client.cpp:5400-5421` |
+| 7 | `--blob_zero` "hot proxy" mode (write zero-length files instead of blob contents) | `src/update.cpp:157,187-190`, `src/download_blob_to.cpp:392` |
+| 8 | val-tags repository scan disabled; val-tags updated once per run | `src/tag.cpp:1398-1403, 440-444` |
+| 9 | Lockserver replaces per-directory physical lock files (per-dir `Reader_Lock`/`lock_tree_for_write` become no-ops) — but introduces per-*file* round trips | `src/lock.cpp:704-708, 1239-1240` vs `src/rcs.cpp:905` |
+| 10 | Linux lockserver connection via Unix domain socket ("way faster") | `src/lock.cpp:184-187` |
+| 11 | Tag/rtag "already tagged at this rev" early-out avoids the `,v` rewrite when re-applying a tag | `src/tag.cpp:1147-1154, 781-786` |
+| 12 | Whole-protocol zstd/gzip stream compression | `src/server.cpp:4795-4841` |
+| 13 | `RCS_copydeltas` raw-copies the body when only the header changed (tag case) | `src/rcs.cpp:6822-6828, 6903-6941` |
+| 14 | fileattr is lazy — no read unless something queries it | `src/fileattr.cpp:32-42, 58-87` |
+| 15 | Head-revision checkout reads only the first deltatext (no delta walking for trunk head) | `src/rcs.cpp:4331-4394` |
+
+**Notable absences**: no cache of parsed RCS data (grep "cache" in `src/rcs.cpp` → nothing); no server-side parallelism; no lockserver batching; `RCS_parse` is not lazy despite the comment (`src/rcs.cpp:336-349`); the tag command parses every file 3×.
+
+---
+
+## 4. Blob pulls during update (Q4 answers)
+
+* **Parallel: yes.** Default `min(8, hw_concurrency-1)` threads (`src/download_blob_to.cpp:241`), configurable via `CVS_BLOB_DOWNLOAD_THREADS` env or `blob_concurrency_download_level` (`src/client.cpp:2106, 2177-2180`).
+* **Connection reuse: yes.** Each worker owns a `KVNetworkProcessor` whose `BlobSocket client` persists across all its tasks; `start()` only reconnects when invalid (`src/blob_kv_processor.cpp:83, 100-106, 157`). Failover reconnects to the next URL (`attemptReconnect`, `:84-99`).
+* Downloads start as soon as `Blob-ref` responses arrive and are joined only at process exit (`src/main.cpp:1716-1717`) → good overlap with the server's response stream.
+* Weakness: hard cap of 8 threads regardless of link/latency (`:241`); each queue item does 1 request per blob (no request pipelining inside a connection, though streaming makes big blobs fine; many *small* blobs pay 1 RTT each ÷ 8 threads).
+
+---
+
+## 5. Improvement proposals
+
+Compat rule respected: old clients must keep working. Everything below is server-side or client-local, or gated by `Valid-requests`/`Valid-responses` negotiation.
+
+| # | Proposal | Speeds up | Impact | Risk | 
+|---|---|---|---|---|
+| P1 | Eliminate per-file lockserver RTs for reads (directory-granular session read lock) | update, checkout, status, log | Very high (removes 2 RTs/file) | Low–Med |
+| P2 | Batch lockserver ops for tag (per-directory write lock; or pipelined Lock/Unlock) | tag, rtag, branch | Very high (removes ~6 RTs/file) | Low–Med |
+| P3 | Restore lazy `,v` parsing (skip delta-header loop until needed) | update, tag pass 1, ls/status | High (CPU+I/O ∝ revision count → ∝ 1) | Med |
+| P4 | Per-directory head/state cache keyed by `,v` (size,mtime) | update HEAD & `-r tag` of unchanged trees | Very high (skip open+parse entirely) | Med |
+| P5 | Skip the post-rewrite re-parse in `RCS_rewrite` for callers that discard the node | tag, rtag, admin | Med-high (1 of 3 parses gone) | Low |
+| P6 | Merge tag's two recursion passes / reuse pass-1 parse results | tag, rtag | Med-high (1 of remaining 2 parses gone) | Med |
+| P7 | Parallelize server file loop per directory (thread pool) | tag first; optionally update classification | High on multi-core servers | Med-High |
+| P8 | Windows: default `nontea` stat (skip `CreateFile`+`NtQueryEaFile` per stat) | client update/commit on Windows; Windows servers | High on Windows clients | Low |
+| P9 | Client: keep `Entries.Log` handles open per directory (batch `Register`) | checkout/update with many changed files | Med | Low |
+| P10 | Server: reorder temp-sandbox deletion after stream shutdown (or background it); consider `Noop`-less sandbox reuse | all remote commands | Low-Med (tail latency) | Low |
+| P11 | Cache `open_directory` result across the 3 calls per directory | update on repos with `.directory_history` files | Med | Low |
+| P12 | Protocol: per-directory manifest hash to skip unchanged directories wholesale | update of mostly-unchanged trees | Very high (turns O(N) into O(M)) | High (new protocol, needs P4-style cache) |
+| P13 | Blob pool: raise/auto-tune thread cap; per-connection pipelining for small blobs | update with many changed small `-kB` files | Med | Low |
+
+### P1 — kill per-file lockserver round trips on read paths
+
+* **Change**: `rcsbuf_open` (`src/rcs.cpp:903-936`) currently always calls `do_lock_file(filename, NULL, lock_for_write, 1)`. Add a "directory lease" mode: when `lock_for_write==0`, take **one** lockserver Read lock for the whole repository directory at `Reader_Lock` time (`src/recurse.cpp:806`, `src/lock.cpp:695`) — the lockserver protocol already namespaces objects by directory (`Lock Read|dir/obj`, `src/lock.cpp:291`) — and make `do_lock_file` return that lease id (refcounted) for files inside the current locked directory; `do_unlock_file` just decrements. Release at `Lock_Cleanup_Directory` (`src/lock.cpp:568-575`).
+* **Why safe**: classic CVS semantics are per-directory read locks anyway (that's exactly what `Reader_Lock` does in non-lockserver mode); per-file read locks are *stronger than needed*. Writers (commit/tag) still take per-file write locks that conflict with the directory read lease.
+* **Caveat**: `RCS_getbranch`/`RCS_head` assert `rcs->rcsbuf.lockId` (`src/rcs.cpp:2531, 2815`) and use it for `do_lock_version` under `atomic_checkouts` — keep a real (shared) id so the asserts hold; `do_lock_version` only fires when `atomic_checkouts` is on.
+* **Impact**: for N=300k, removes ~600k synchronous loopback RTs. Even at 50 µs each this is ~30 s; on Windows TCP loopback with a busy lockserver it is often minutes.
+
+### P2 — lockserver batching for tag/branch
+
+* Same lease idea with Write granularity per directory: take one `Lock Write|dir` before iterating a directory's files in the tag pass; per-file `rcs_internal_lockfile`/`rcsbuf_open` reuse it. Files in a directory are tagged back-to-back, so the hold time doesn't change materially vs. today's sequential loop.
+* Alternative (less invasive, smaller win): make `do_lock_file`/`do_unlock_file` pipelined — send `Unlock` without waiting for the reply (fire-and-forget with lazy error check on next command), halving RTs. `lock_server_command` (`src/lock.cpp:228-251`) is a strict send+recv today.
+* Files: `src/lock.cpp` (`do_lock_file`, `do_unlock_file`, new lease bookkeeping), `src/rcs.cpp:905, 7057`.
+
+### P3 — lazy delta parsing in `RCS_parse`
+
+* **Change**: split `RCS_reparsercsfile` (`src/rcs.cpp:361-565`) so `RCS_parsercsfile_i` (`:326-352`) stops after the admin keys (head/branch/expand/symbols/properties) — i.e. break out at the first revision key instead of running the `getdelta` loop (`:533-544`). Parse deltas on first access via a `PARTIAL` flag checked in `RCS_getversion`/`RCS_gettag`/`RCS_isdead`/`RCS_getrevtime`/`RCS_getbranch`/`findnode(rcs->versions,…)` call sites (this is exactly how upstream CVS 1.11/1.12 works — the comment at `:336-340` documents the intended design).
+* **What still forces a delta parse today** in the unchanged-file path: `RCS_getversion(HEAD)`→`RCS_getbranch` walks `versions` only when a branch is set; `RCS_isdead` looks up the target rev; `RCS_getrevtime` needs the delta date (`src/vers_ts.cpp:300`); `RCS_getexpand` needs per-rev kopt (`src/rcs.cpp:3691`). For trunk-HEAD classification only the *head* delta is needed — parse deltas until the head's node is seen, then stop (head is the first delta in the file). That makes the common case O(1 delta) instead of O(all deltas).
+* **Impact**: server CPU + read volume drops by the average delta-header-section size; biggest for old files with hundreds of revisions. Helps update, tag pass 1, `cvs ls`, status.
+* **Risk**: medium — audit every direct `rcs->versions` access (`grep -n "->versions" src/*.cpp`), Attic edge cases; sanity suite exists.
+
+### P4 — per-directory RCS state cache (mtime-validated)
+
+* **Change**: a single cache file per repository directory (e.g. `CVSREP/.rcs_state` or alongside `fileattr.xml`), containing per `,v`: `name, size, mtime64, head_rev, head_kopt, head_date, dead_flag, symbols_digest (+ optionally full symbol list)`. On update: after `readdir` (`find_rcs`, `src/find_names.cpp:88`), `stat` each `,v` (one stat, already nearly free vs. today's open+parse+2 lock RTs); if (size,mtime) match the cache entry and classification only needs head/kopt (HEAD update, or `-r tag` with cached symbol), skip `RCS_parse` completely for `T_UPTODATE` decisions (`vn_rcs == entry version && ts unchanged`, `src/classify.cpp:263-305`). Any miss/mismatch → normal path, then update the cache (write once per directory at `filesdone` time, temp+rename).
+* Cache writes must happen under the directory write lock or be advisory-only (safe: a stale/absent cache only costs the old slow path). Invalidation = (size,mtime64) of the `,v`; tag/commit rewrite the file via rename so mtime+size always change.
+* **Impact**: unchanged file cost becomes ~1 stat + hash lookup; combined with P1 this collapses the server per-file cost by an order of magnitude. Also accelerates `-r BRANCH` updates (symbols in cache).
+* **Risk**: medium — correctness depends on strict invalidation; use mtime with 100 ns resolution + size + (on Unix) inode; keep a global "cache generation" kill-switch in CVSROOT/config.
+
+### P5 — don't re-parse after `RCS_rewrite` when the result is discarded
+
+* **Change**: add `bool want_reparse=true` to `RCS_rewrite` (`src/rcs.cpp:7154`); `tag_fileproc`/`rtag_fileproc`/`rtag_delete` pass `false` (they free the node right after: `src/tag.cpp:1204-1218, 748-750, 893`). Leave `true` for commit paths that keep using the node.
+* **Impact**: removes 1 of the 3 full parses per tagged file — pure win, ~zero risk (the state after `free_rcsnode_contents` without reparse must simply never be touched; assert `refcount==1`).
+
+### P6 — single-pass tag (or carry pass-1 results into pass 2)
+
+* Options: (a) when no `pretag` trigger is configured and `check_uptodate` is off, skip the check pass entirely and do permission checks + tlist building inside the tag pass (`rtag_proc`, `src/tag.cpp:408-434`); (b) keep two passes but cache `(file → RCSNode)` from pass 1 in a per-directory map keyed by `,v` path, reusing nodes in pass 2 (their lock is a write lock already; keep it held between passes — note this lengthens lock hold time). (a) is simpler and safe: triggers are per-directory (`check_filesdoneproc`, `src/tag.cpp:569-602`), so when `cb->pretag` exists the two-pass structure must stay.
+* **Impact**: halves the remaining parse+lock cost of tag when no pretag trigger is installed.
+
+### P7 — parallelize the server-side per-file loop
+
+* The per-file work in tag (parse → settag → rewrite → rename) touches independent files; ordering constraints are only: output (`cvs_output`, already mutex-guarded, `src/server.cpp:6413-6414`), `history_write` append, and lockserver commands (socket shared — needs a mutex or per-thread connections).
+* **Sketch**: in `do_recursion` (`src/recurse.cpp:826` `walklist(filelist, do_file_proc, …)`), when `frame->fileproc == tag_fileproc/rtag_fileproc` (or a new `FILEPROC_PARALLEL` capability flag), collect nodes and feed them to a pool of ~4-8 threads reusing the existing `concurrent_queue.h`. Thread-unsafe globals to audit: `tag_set_ok`, statics in `tag.cpp`, `rcs_lockfile/rcs_lockfd` statics (`src/rcs.cpp:218-219` — must become per-thread), `lock_server_socket` (per-thread connections or mutex), `error()` buffers. This is the riskiest proposal but the only one that scales tag wall-time with cores/disk queue depth.
+* For update, a cheaper variant: overlap "classify next file" (parse) with "send previous file" using a 2-stage pipeline; classification is read-only.
+
+### P8 — Windows stat cost (client & Windows servers)
+
+* Default `use_ntea=1` makes every stat of an existing file open it (`windows-NT/win32.cpp:362-363, 2203-2213, 1947`). The EA only carries a fake Unix mode; working-copy flows only need mtime/size/readonly.
+* **Change**: flip the default to no-EA for the *client* role (keep opt-in via `CVSNT=ntea`), or add a fast path in `wnt_stat`/`wnt_lstat` that skips `GetUnixFileModeNtEA` when the caller only needs timestamps (e.g. a `CVS_LSTAT_FAST` used by `time_stamp`, `src/vers_ts.cpp:389,487`). Note: today users can already set env `CVSNT=nontea` (parsed at `windows-NT/win32.cpp:383-395`) — an immediate zero-code mitigation worth documenting.
+* **Impact**: removes a `CreateFile`+`NtQueryEaFile`+`CloseHandle` per file per update on Windows clients (AV/filter drivers make CreateFile the most expensive syscall in the whole client). Risk: executable-bit fidelity for cygwin interop — acceptable default change for a Windows-only game studio.
+
+### P9 — batch client Entries.Log writes
+
+* `Register` reopens/closes both log files per file (`src/entries.cpp:394-429`). `call_in_directory` already keeps `last_entries` open across responses for the same directory (`src/client.cpp:909-916`) — keep `FILE*` handles for `Entries.Log`/`Entries.Extra.Log` in the same struct, append per Register, close on directory switch / `Entries_Close`. 6 syscalls/file → amortized ~0.
+* Files: `src/entries.cpp` (Register/Scratch_Entry/Rename_Entry), lifecycle tied to `Entries_Close` (`:965-981`).
+
+### P10 — server sandbox lifecycle
+
+* `server_cleanup` deletes the whole temp sandbox **before** `buf_shutdown(buf_to_net)` sends the compression trailer (`src/server.cpp:5100-5121`) — clients (and scripts timing `cvs update`) wait for the `rm -rf` of M×~5 files. Reorder: shutdown/flush `buf_to_net` first, then delete; or spawn the deletion detached.
+* Longer term: for `Entry`+`Unchanged`-only directories the sandbox brings no information the in-memory entries list didn't already have — the per-dir `CVS/*` files are written and re-read within the same process (`dirswitch` writes, `Entries_Open` reads back). An in-memory VFS for the sandbox (or trusting the entries list directly) would remove O(M·depth) mkdir/create plus the re-read, but it is a larger refactor of `server.c`'s "fake working directory" design.
+
+### P11 — cache `open_directory`
+
+* `update_predirent_proc` opens/closes the directory-version state twice back-to-back and `do_dir_proc` a third time (`src/update.cpp:1145-1156`, `src/recurse.cpp:1265`); each open re-parses and re-checks-out `.directory_history,v` when present (`src/mapping.cpp:1056-1119`). Memoize by `(repository, tag, date, version)` within `directory_data` for the current directory, or plumb the already-open handle from predirent into do_dir_proc. The FIXME at `src/update.cpp:1144` acknowledges this.
+
+### P12 — protocol: directory manifest short-circuit (the big one, needs negotiation)
+
+* **Idea**: client sends per directory a digest of its entries state (`Manifest <dir> <blake3(entries-lines + tag/date)>`) instead of N `Entry`+`Unchanged` pairs (still sending them for modified files only). Server computes/caches the same digest for (directory, tag/date, head state) — cheap once P4's cache exists — and answers "directory up to date" without touching a single `,v`.
+* Gains: request phase shrinks from O(N) lines to O(M); server command phase skips whole directories; `rm -rf` sandbox shrinks.
+* Compat: strictly opt-in via `Valid-requests` (old client never sends it; old server never advertises it; the client only sends when advertised — mirrors existing `supported_request("EntryExtra")` pattern, `src/client.cpp:5358`).
+* Risk: high (protocol + cache correctness under concurrent commits — digest must be validated under the directory read lease from P1).
+
+### P13 — blob pool tuning
+
+* Raise the hard cap of 8 (`src/download_blob_to.cpp:241`) for LAN servers (make it a first-class config, not just env), and consider issuing the next request before fully draining the previous response on a connection (simple pipelining) for many-small-blob workloads. Connection setup already amortized; risk low.
+
+---
+
+## Suggested order of attack
+
+1. **P8** (env `CVSNT=nontea` today; flip default in a patch) — instant Windows client win, trivially safe.
+2. **P5** (no reparse after tag rewrite) + **P11** (open_directory memo) — small, contained patches.
+3. **P1/P2** (lockserver leasing/batching) — biggest architectural win for both update and tag; touches `lock.cpp` + 2 call sites in `rcs.cpp`.
+4. **P3** (lazy parse) then **P4** (mtime cache) — server CPU/I-O; P4 builds on the invariants P3 clarifies.
+5. **P6/P7** (single-pass + parallel tag) — after locks are batched, parallelism gives tag near-linear scaling.
+6. **P12** (manifest protocol) — end-game for "nothing changed" updates; needs P1+P4 foundations.

--- a/cvsnt/build-windows.py
+++ b/cvsnt/build-windows.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+build-windows.py -- build G-CVSNT on Windows without requiring a Visual Studio
+                    installation (works with a bare MSVC toolchain + Windows SDK,
+                    e.g. Gaijin devtools packages), or from a VS developer prompt.
+
+It is a small, self-contained driver that parses the .vcxproj files of the
+cvsnt.sln solution and invokes cl.exe / ml64.exe / rc.exe / lib.exe / link.exe
+directly, so no MSBuild is needed.
+
+Usage (bare toolchain, Gaijin devtools):
+    python build-windows.py --vc D:\\devtools\\vc2019_16.11.34 --sdk D:\\devtools\\win.sdk.100
+
+Usage (from a "x64 Native Tools Command Prompt for VS"):
+    python build-windows.py
+
+Options:
+    --config Release|Debug   (default Release)
+    --platform x64|Win32     (default x64)
+    --projects a,b,c         build only the named projects (see PROJECTS below)
+    --with-optional          also build optional projects (control panel, plink, ...)
+    --jobs N                 parallel compilations (default: cpu count)
+
+Output goes to <srcroot>\\Release<platform>\\ exactly like the Visual Studio build.
+"""
+
+import argparse
+import hashlib
+import multiprocessing.dummy
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+
+def _ver_key(d):
+    """Sort key for Windows SDK version dir names (10.0.22621.0) by numeric
+    components, so 10.0.10240.0 sorts after 10.0.9xxx rather than before."""
+    return [int(x) if x.isdigit() else -1 for x in d.split(".")]
+
+NS = {"m": "http://schemas.microsoft.com/developer/msbuild/2003"}
+SRCROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cvsnt-2.5.05.3744")
+
+# Core projects, in dependency order: (name, vcxproj path relative to SRCROOT)
+PROJECTS = [
+    # static libraries
+    ("zlib",            r"zlib\win32\zlib.vcxproj"),
+    ("pcre",            r"pcre\pcre.vcxproj"),
+    ("libxml2",         r"libxml\win32\libxml2.vcxproj"),
+    ("zstd",            r"zstd\zstd.vcxproj"),
+    ("blake3",          r"blake3\blake3.vcxproj"),
+    ("ca_blobs_fs",     r"ca_blobs_fs\ca_blobs_fs.vcxproj"),
+    ("blob_sockets",    r"keyValueServer\blob_sockets\blob_sockets.vcxproj"),
+    ("clientLib",       r"keyValueServer\clientLib\clientLib.vcxproj"),
+    ("gnulib",          r"lib\gnulib.vcxproj"),
+    ("libdiff",         r"diff\libdiff.vcxproj"),
+    ("cvsdelta",        r"cvsdelta\cvsdelta.vcxproj"),
+    ("cvsgui",          r"cvsgui\cvsgui.vcxproj"),
+    ("crypt",           r"ufc-crypt\crypt.vcxproj"),
+    ("mdnsclient",      r"mdnsclient\mdnsclient.vcxproj"),
+    # core DLLs
+    ("cvsapi",          r"cvsapi\cvsapi.vcxproj"),
+    ("cvstools",        r"cvstools\cvstools.vcxproj"),
+    ("xml_xdiff",       r"xdiff\xml_xdiff.vcxproj"),
+    ("sqlite_database", r"cvsapi\db\sqlite\sqlite_database.vcxproj"),
+    ("odbc_database",   r"cvsapi\db\odbc\odbc_database.vcxproj"),
+    ("mdns_mini",       r"cvsapi\mdns\mini\mdns_mini.vcxproj"),
+    # protocols
+    ("plink",           r"plink\plink.vcxproj"),
+    ("server_protocol", r"protocols\server_protocol.vcxproj"),
+    ("pserver",         r"protocols\pserver_protocol.vcxproj"),
+    ("sserver",         r"protocols\sserver_protocol.vcxproj"),
+    ("sspi",            r"protocols\sspi_protocol.vcxproj"),
+    ("ext",             r"protocols\ext_protocol.vcxproj"),
+    ("ssh",             r"protocols\ssh_protocol.vcxproj"),
+    ("enum",            r"protocols\enum_protocol.vcxproj"),
+    ("fork",            r"protocols\fork_protocol.vcxproj"),
+    # triggers (plugins)
+    ("info_triggers",   r"triggers\info_triggers.vcxproj"),
+    ("audit_trigger",   r"triggers\audit_trigger.vcxproj"),
+    ("email_trigger",   r"triggers\email_trigger.vcxproj"),
+    ("script_trigger",  r"triggers\script_trigger.vcxproj"),
+    ("checkout_trigger",r"triggers\checkout_trigger.vcxproj"),
+    # executables
+    ("genbuild",        r"genbuild\genbuild.vcxproj"),
+    ("libsuid",         r"windows-NT\setuid\libsuid\libsuid.vcxproj"),
+    ("setuid",          r"windows-NT\setuid\setuid\setuid.vcxproj"),
+    ("cvsservice",      r"cvsservice\cvsservice.vcxproj"),
+    ("cvslock",         r"lockservice\lockservice.vcxproj"),
+    ("cvsnt",           r"cvsnt.vcxproj"),
+]
+
+OPTIONAL_PROJECTS = [
+    ("gserver",         r"protocols\gserver_protocol_ad.vcxproj"),
+    ("mdns_apple",      r"cvsapi\mdns\apple\mdns_apple.vcxproj"),
+    ("co",              r"rcs\co.vcxproj"),
+    ("rcsdiff",         r"rcs\rcsdiff.vcxproj"),
+    ("rlog",            r"rcs\rlog.vcxproj"),
+    ("cvsdiag",         r"windows-NT\cvsdiag\cvsdiag.vcxproj"),
+    ("extnt",           r"extnt\extnt.vcxproj"),
+    ("su",              r"su\su.vcxproj"),
+    ("genkey",          r"genkey\genkey.vcxproj"),
+    ("postinst",        r"postinst\postinst.vcxproj"),
+    ("uninsthlp",       r"uninsthlp\uninsthlp.vcxproj"),
+]
+
+
+def find_sdk_ver(sdk):
+    best = None
+    for d in sorted(os.listdir(os.path.join(sdk, "include")), key=_ver_key):
+        if os.path.isfile(os.path.join(sdk, "include", d, "um", "windows.h")) and \
+           os.path.isdir(os.path.join(sdk, "lib", d, "um")):
+            best = d
+    return best
+
+
+TOOLS = {"cl": "cl.exe", "ml64": "ml64.exe", "rc": "rc.exe",
+         "lib": "lib.exe", "link": "link.exe", "mc": "mc.exe", "midl": "midl.exe"}
+
+# Per-project fixups the .vcxproj files don't express cleanly
+OVERRIDES = {
+    "genbuild": {"subsystem": "Windows"},   # uses WinMain
+    # clientLib calls into blob_sockets, but only the .sln (not the .vcxproj)
+    # expresses the dependency
+    "cvsnt": {"extra_ref": ["blob_sockets"]},
+    "cvsservice": {"extra_ref": ["blob_sockets"]},
+}
+
+# Code generation steps (message compiler / MIDL) that MSBuild runs as custom
+# build tools. (produced-file, cwd-relative-to-SRCROOT, command builder)
+def _mc_servicemsg(env, plat):
+    d = os.path.join(SRCROOT, "cvsapi", "win32")
+    run_tool([TOOLS["mc"], "ServiceMsg.mc"], d, env, "mc ServiceMsg.mc")
+    # cvsservice includes it relative to its own dir as well
+    import shutil
+    for f in ("ServiceMsg.h", "ServiceMsg.rc"):
+        src = os.path.join(d, f)
+        if os.path.isfile(src):
+            shutil.copy2(src, os.path.join(SRCROOT, "cvsservice", f))
+
+def _midl_trigger(env, plat):
+    d = os.path.join(SRCROOT, "cvstools")
+    run_tool([TOOLS["midl"], "/nologo", "/env", "x64" if plat == "x64" else "win32",
+              "/h", "trigger_h.h", "/iid", "trigger_i.c",
+              "/tlb", os.path.join("win32", "trigger.tlb"),
+              os.path.join("win32", "trigger.idl")], d, env, "midl trigger.idl")
+
+def _midl_server(env, plat):
+    d = os.path.join(SRCROOT, "triggers")
+    run_tool([TOOLS["midl"], "/nologo", "/env", "x64" if plat == "x64" else "win32",
+              "/h", "Server_h.h", "/iid", "Server_i.c", "/tlb", "script_trigger.tlb",
+              "server.idl"], d, env, "midl server.idl")
+
+PRE_STEPS = {
+    "cvsapi":     [(r"cvsapi\win32\ServiceMsg.h", _mc_servicemsg)],
+    "cvsservice": [(r"cvsservice\ServiceMsg.h", _mc_servicemsg)],
+    "cvstools":   [(r"cvstools\trigger_h.h", _midl_trigger),
+                   (r"cvstools\win32\trigger.tlb", _midl_trigger)],
+    "info_triggers":  [(r"triggers\Server_h.h", _midl_server)],
+    "audit_trigger":  [(r"triggers\Server_h.h", _midl_server)],
+    "email_trigger":  [(r"triggers\Server_h.h", _midl_server)],
+    "script_trigger": [(r"triggers\Server_h.h", _midl_server),
+                       (r"triggers\script_trigger.tlb", _midl_server)],
+    "checkout_trigger": [(r"triggers\Server_h.h", _midl_server)],
+}
+
+
+BUILT = {}          # normalized vcxproj path -> (type, output file, import lib)
+BUILT_BY_NAME = {}  # project name -> (type, output file, import lib)
+
+
+def run_tool(cmd, cwd, env, what):
+    r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd)
+    if r.returncode != 0:
+        sys.stderr.write("FAILED(%s):\n%s\n%s\n" % (what, r.stdout, r.stderr))
+        raise RuntimeError(what)
+
+
+def setup_env(args):
+    """Compose PATH/INCLUDE/LIB for a bare toolchain, unless cl.exe is already usable.
+    Resolves TOOLS to absolute paths (Windows CreateProcess ignores child-env PATH)."""
+    env = os.environ.copy()
+    if args.vc:
+        vc = os.path.abspath(args.vc)
+        sdk = os.path.abspath(args.sdk)
+        sdkver = args.sdk_ver or find_sdk_ver(sdk)
+        if not sdkver:
+            sys.exit("error: no usable Windows SDK version under %s" % sdk)
+        host = "Hostx64"
+        tgt = "x64" if args.platform == "x64" else "x86"
+        vcbin = os.path.join(vc, "bin", host, tgt)
+        sdkbin_ver = sorted((d for d in os.listdir(os.path.join(sdk, "bin"))
+                             if os.path.isfile(os.path.join(sdk, "bin", d, tgt, "rc.exe"))),
+                            key=_ver_key)
+        if not sdkbin_ver:
+            sys.exit("error: rc.exe not found under %s\\bin" % sdk)
+        sdkbin = os.path.join(sdk, "bin", sdkbin_ver[-1], tgt)
+        env["PATH"] = os.pathsep.join([vcbin, sdkbin, env.get("PATH", "")])
+        env["INCLUDE"] = os.pathsep.join([
+            os.path.join(vc, "include"),
+            os.path.join(vc, "atlmfc", "include"),
+            os.path.join(sdk, "include", sdkver, "ucrt"),
+            os.path.join(sdk, "include", sdkver, "um"),
+            os.path.join(sdk, "include", sdkver, "shared"),
+            os.path.join(sdk, "include", sdkver, "winrt"),
+        ])
+        env["LIB"] = os.pathsep.join([
+            os.path.join(vc, "lib", tgt),
+            os.path.join(vc, "atlmfc", "lib", tgt),
+            os.path.join(sdk, "lib", sdkver, "ucrt", tgt),
+            os.path.join(sdk, "lib", sdkver, "um", tgt),
+        ])
+        for k, exe in TOOLS.items():
+            p = os.path.join(vcbin, exe)
+            if not os.path.isfile(p):
+                p = os.path.join(sdkbin, exe)
+            TOOLS[k] = p
+        print("using VC: %s" % vc)
+        print("using SDK: %s (%s, rc from %s)" % (sdk, sdkver, sdkbin_ver[-1]))
+    else:
+        # expect a developer prompt
+        import shutil
+        for k, exe in TOOLS.items():
+            p = shutil.which(exe)
+            if not p:
+                sys.exit("error: %s not on PATH. Run from a VS developer prompt "
+                         "or pass --vc/--sdk (see --help)." % exe)
+            TOOLS[k] = p
+    return env
+
+
+def cond_matches(node, cfg):
+    c = node.get("Condition")
+    if not c:
+        return True
+    m = re.search(r"==\s*'([^']*)'", c)
+    return bool(m) and m.group(1) == cfg
+
+
+def text(node, default=""):
+    return (node.text or default).strip() if node is not None else default
+
+
+class Project(object):
+    def __init__(self, name, path, args):
+        self.name = name
+        self.vcxproj = os.path.join(SRCROOT, path)
+        self.dir = os.path.dirname(self.vcxproj)
+        self.cfg = "%s|%s" % (args.config, args.platform)
+        self.args = args
+        self.macros = {
+            "SolutionDir": SRCROOT + "\\",
+            "ProjectDir": self.dir + "\\",
+            "ProjectName": os.path.splitext(os.path.basename(path))[0],
+            "Configuration": args.config,
+            "Platform": args.platform,
+        }
+        self.parse()
+
+    def expand(self, s):
+        s = re.sub(r"%\(\w+\)", "", s or "")
+        for k, v in self.macros.items():
+            s = s.replace("$(%s)" % k, v)
+        s = re.sub(r"\$\(\w+\)", "", s)  # unknown macros -> empty
+        return s
+
+    def parse(self):
+        root = ET.parse(self.vcxproj).getroot()
+        self.type = "Application"
+        self.charset = ""
+        for pg in root.findall("m:PropertyGroup", NS):
+            if pg.get("Label") == "Configuration" and cond_matches(pg, self.cfg):
+                self.type = text(pg.find("m:ConfigurationType", NS), self.type)
+                self.charset = text(pg.find("m:CharacterSet", NS), self.charset)
+        self.outdir = os.path.join(SRCROOT, self.args.config + self.args.platform) + "\\"
+        self.intdir = os.path.join(SRCROOT, "tmp", self.args.config + self.args.platform,
+                                   self.macros["ProjectName"]) + "\\"
+        def absdir(p):
+            return p if os.path.isabs(p) else os.path.join(self.dir, p)
+        for pg in root.findall("m:PropertyGroup", NS):
+            if cond_matches(pg, self.cfg):
+                od = text(pg.find("m:OutDir", NS))
+                if od:
+                    self.outdir = absdir(self.expand(od))
+                nd = text(pg.find("m:IntDir", NS))
+                if nd:
+                    self.intdir = absdir(self.expand(nd))
+                tn = text(pg.find("m:TargetName", NS))
+                if tn:
+                    self.macros["TargetName"] = self.expand(tn)
+        self.macros.setdefault("TargetName", self.macros["ProjectName"])
+        self.macros["OutDir"] = self.outdir
+        self.macros["IntDir"] = self.intdir
+        self.macros["TargetDir"] = self.outdir
+
+        self.includes, self.defines, self.cl_extra = [], [], []
+        self.libs, self.libdirs, self.link_extra = [], [], []
+        self.deffile = self.outfile = self.implib = ""
+        self.runtime = "MultiThreadedDLL" if self.args.config == "Release" else "MultiThreadedDebugDLL"
+        self.eh = "Sync"
+        self.subsystem = "Console"
+        for idg in root.findall("m:ItemDefinitionGroup", NS):
+            if not cond_matches(idg, self.cfg):
+                continue
+            clc = idg.find("m:ClCompile", NS)
+            if clc is not None:
+                inc = self.expand(text(clc.find("m:AdditionalIncludeDirectories", NS)))
+                self.includes += [i for i in inc.split(";") if i.strip()]
+                de = self.expand(text(clc.find("m:PreprocessorDefinitions", NS)))
+                self.defines += [d for d in de.split(";") if d.strip()]
+                rt = text(clc.find("m:RuntimeLibrary", NS))
+                if rt:
+                    self.runtime = rt
+                eh = text(clc.find("m:ExceptionHandling", NS))
+                if eh:
+                    self.eh = eh
+                if text(clc.find("m:TreatWChar_tAsBuiltInType", NS)) == "false":
+                    self.cl_extra.append("/Zc:wchar_t-")
+                if text(clc.find("m:CompileAs", NS)) == "CompileAsC":
+                    self.cl_extra.append("/TC")
+                if text(clc.find("m:CompileAs", NS)) == "CompileAsCpp":
+                    self.cl_extra.append("/TP")
+            lnk = idg.find("m:Link", NS)
+            if lnk is not None:
+                ad = self.expand(text(lnk.find("m:AdditionalDependencies", NS)))
+                self.libs += [l for l in ad.split(";") if l.strip()]
+                ld = self.expand(text(lnk.find("m:AdditionalLibraryDirectories", NS)))
+                self.libdirs += [d for d in ld.split(";") if d.strip()]
+                df = self.expand(text(lnk.find("m:ModuleDefinitionFile", NS)))
+                if df:
+                    self.deffile = df
+                of = self.expand(text(lnk.find("m:OutputFile", NS)))
+                if of:
+                    self.outfile = of
+                il = self.expand(text(lnk.find("m:ImportLibrary", NS)))
+                if il:
+                    self.implib = il
+                ss = text(lnk.find("m:SubSystem", NS))
+                if ss and ss != "NotSet":
+                    self.subsystem = ss
+            lib = idg.find("m:Lib", NS)
+            if lib is not None:
+                of = self.expand(text(lib.find("m:OutputFile", NS)))
+                if of:
+                    self.outfile = of
+
+        self.refs = []
+        for ig in root.findall("m:ItemGroup", NS):
+            for pr in ig.findall("m:ProjectReference", NS):
+                f = pr.get("Include")
+                if f:
+                    self.refs.append(os.path.normcase(os.path.normpath(
+                        os.path.join(self.dir, f))))
+
+        self.sources, self.masm, self.rc = [], [], []
+        for ig in root.findall("m:ItemGroup", NS):
+            for it in ig.findall("m:ClCompile", NS):
+                f = it.get("Include")
+                if not f:
+                    continue
+                excluded = False
+                for ex in it.findall("m:ExcludedFromBuild", NS):
+                    if cond_matches(ex, self.cfg) and text(ex) == "true":
+                        excluded = True
+                if not excluded:
+                    self.sources.append(os.path.join(self.dir, f))
+            for it in ig.findall("m:MASM", NS):
+                f = it.get("Include")
+                excluded = False
+                for ex in it.findall("m:ExcludedFromBuild", NS):
+                    if cond_matches(ex, self.cfg) and text(ex) == "true":
+                        excluded = True
+                if f and not excluded:
+                    self.masm.append(os.path.join(self.dir, f))
+            for it in ig.findall("m:ResourceCompile", NS):
+                f = it.get("Include")
+                if f:
+                    self.rc.append(os.path.join(self.dir, f))
+
+        if not self.outfile:
+            ext = {"Application": ".exe", "DynamicLibrary": ".dll", "StaticLibrary": ".lib"}[self.type]
+            self.outfile = os.path.join(self.outdir, self.macros["TargetName"] + ext)
+
+    def cl_flags(self):
+        f = ["/nologo", "/c", "/W3", "/Z7", "/bigobj",
+             {"MultiThreadedDLL": "/MD", "MultiThreadedDebugDLL": "/MDd",
+              "MultiThreaded": "/MT", "MultiThreadedDebug": "/MTd"}[self.runtime]]
+        if self.args.config == "Release":
+            f += ["/O2", "/Oy-", "/GF", "/Gy"]
+        else:
+            f += ["/Od", "/RTC1"]
+        if self.eh in ("Sync", "SyncCThrow"):
+            f.append("/EHsc")
+        elif self.eh == "Async":
+            f.append("/EHa")
+        if self.charset == "Unicode":
+            f += ["/DUNICODE", "/D_UNICODE"]
+        elif self.charset == "MultiByte":
+            f += ["/D_MBCS"]
+        f += ["/D" + d for d in self.defines]
+        f += ["/D_CRT_SECURE_NO_WARNINGS", "/D_CRT_NONSTDC_NO_WARNINGS",
+              "/D_WINSOCK_DEPRECATED_NO_WARNINGS"]
+        for i in self.includes:
+            p = i if os.path.isabs(i) else os.path.join(self.dir, i)
+            f.append("/I" + os.path.normpath(p))
+        f += self.cl_extra
+        return f
+
+    def _obj_name(self, src):
+        # Disambiguate sources that share a basename across directories so their
+        # .obj files (C and MASM alike) do not overwrite each other.
+        stem = os.path.splitext(os.path.basename(src))[0]
+        tag = hashlib.md5(os.path.normcase(os.path.abspath(src)).encode()).hexdigest()[:8]
+        return os.path.join(self.intdir, "%s_%s.obj" % (stem, tag))
+
+    def build(self, env, jobs):
+        os.makedirs(self.intdir, exist_ok=True)
+        os.makedirs(self.outdir, exist_ok=True)
+        os.makedirs(os.path.dirname(os.path.join(self.dir, self.outfile)), exist_ok=True)
+        for produced, step in PRE_STEPS.get(self.name, []):
+            if not os.path.isfile(os.path.join(SRCROOT, produced)):
+                step(env, self.args.platform)
+        sso = OVERRIDES.get(self.name, {}).get("subsystem")
+        if sso:
+            self.subsystem = sso
+        self.libs += OVERRIDES.get(self.name, {}).get("extra_libs", [])
+        objs = []
+        flags = self.cl_flags()
+
+        def compile_one(src):
+            obj = self._obj_name(src)
+            cmd = [TOOLS["cl"]] + flags + ["/Fo" + obj, src]
+            r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=self.dir)
+            return src, obj, r
+
+        pool = multiprocessing.dummy.Pool(jobs)
+        failed = False
+        for src, obj, r in pool.map(compile_one, self.sources):
+            if r.returncode != 0:
+                sys.stderr.write("FAILED: %s\n%s\n%s\n" % (src, r.stdout, r.stderr))
+                failed = True
+            else:
+                objs.append(obj)
+        pool.close()
+        pool.join()
+        if failed:
+            return False
+
+        for src in self.masm:
+            obj = self._obj_name(src)
+            cmd = [TOOLS["ml64"], "/nologo", "/c", "/Fo" + obj, src]
+            r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=self.dir)
+            if r.returncode != 0:
+                sys.stderr.write("FAILED(masm): %s\n%s\n%s\n" % (src, r.stdout, r.stderr))
+                return False
+            objs.append(obj)
+
+        res_files = []
+        for src in self.rc:
+            res = os.path.join(self.intdir,
+                               os.path.splitext(os.path.basename(src))[0] + ".res")
+            cmd = [TOOLS["rc"], "/nologo",
+                   "/d", "NDEBUG" if self.args.config == "Release" else "_DEBUG",
+                   "/i", os.path.dirname(src), "/i", SRCROOT,
+                   "/fo", res, src]
+            r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=self.dir)
+            if r.returncode != 0:
+                sys.stderr.write("FAILED(rc): %s\n%s\n%s\n" % (src, r.stdout, r.stderr))
+                return False
+            res_files.append(res)
+
+        machine = "/MACHINE:X64" if self.args.platform == "x64" else "/MACHINE:X86"
+        if self.type == "StaticLibrary":
+            cmd = [TOOLS["lib"], "/nologo", machine, "/OUT:" + self.outfile] + objs
+        else:
+            cmd = [TOOLS["link"], "/nologo", machine, "/DEBUG", "/INCREMENTAL:NO",
+                   "/OUT:" + self.outfile]
+            if self.type == "DynamicLibrary":
+                cmd.append("/DLL")
+                implib = self.implib or os.path.join(self.outdir, self.macros["TargetName"] + ".lib")
+                if not os.path.isabs(implib):
+                    implib = os.path.join(self.dir, implib)
+                os.makedirs(os.path.dirname(implib), exist_ok=True)
+                cmd.append("/IMPLIB:" + implib)
+            else:
+                cmd.append("/SUBSYSTEM:" + self.subsystem.upper())
+            if self.deffile:
+                cmd.append("/DEF:" + os.path.join(self.dir, self.deffile))
+            for d in self.libdirs:
+                p = d if os.path.isabs(d) else os.path.join(self.dir, d)
+                cmd.append("/LIBPATH:" + os.path.normpath(p))
+            cmd.append("/LIBPATH:" + self.outdir)  # import libs of already-built DLLs/static libs
+            # emulate MSBuild's LinkLibraryDependencies: link outputs of referenced projects
+            reflibs = []
+            entries = [BUILT.get(r) for r in self.refs]
+            entries += [BUILT_BY_NAME.get(n) for n in
+                        OVERRIDES.get(self.name, {}).get("extra_ref", [])]
+            for built in entries:
+                if not built:
+                    continue
+                btype, boutfile, bimplib = built
+                if btype == "StaticLibrary":
+                    reflibs.append(boutfile)
+                elif btype == "DynamicLibrary" and bimplib and os.path.isfile(bimplib):
+                    reflibs.append(bimplib)
+            cmd += objs + res_files + self.libs + reflibs
+            cmd += ["kernel32.lib", "user32.lib", "gdi32.lib", "advapi32.lib",
+                    "shell32.lib", "ole32.lib", "oleaut32.lib", "uuid.lib",
+                    "ws2_32.lib", "version.lib", "shlwapi.lib", "secur32.lib",
+                    "comdlg32.lib", "winspool.lib"]
+            cmd += self.link_extra
+        r = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=self.dir)
+        if r.returncode != 0:
+            sys.stderr.write("FAILED(link) %s:\n%s\n%s\n" % (self.name, r.stdout, r.stderr))
+            return False
+        implib = self.implib or os.path.join(self.outdir, self.macros["TargetName"] + ".lib")
+        if not os.path.isabs(implib):
+            implib = os.path.join(self.dir, implib)
+        out_abs = self.outfile if os.path.isabs(self.outfile) else \
+            os.path.normpath(os.path.join(self.dir, self.outfile))
+        BUILT[os.path.normcase(os.path.normpath(self.vcxproj))] = (self.type, out_abs, implib)
+        BUILT_BY_NAME[self.name] = (self.type, out_abs, implib)
+        print("  -> %s" % self.outfile)
+        return True
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vc", help=r"MSVC root (contains bin\Hostx64, include, lib), e.g. D:\devtools\vc2019_16.11.34")
+    ap.add_argument("--sdk", help=r"Windows 10 SDK root (contains include\<ver>, lib\<ver>), e.g. D:\devtools\win.sdk.100")
+    ap.add_argument("--sdk-ver", help="SDK version to use (default: newest complete)")
+    ap.add_argument("--config", default="Release", choices=["Release", "Debug"])
+    ap.add_argument("--platform", default="x64", choices=["x64", "Win32"])
+    ap.add_argument("--projects", help="comma separated subset of project names")
+    ap.add_argument("--with-optional", action="store_true")
+    ap.add_argument("--jobs", type=int, default=os.cpu_count() or 4)
+    args = ap.parse_args()
+    if bool(args.vc) != bool(args.sdk):
+        sys.exit("error: --vc and --sdk must be used together")
+
+    env = setup_env(args)
+    everything = PROJECTS + OPTIONAL_PROJECTS
+    todo = PROJECTS + (OPTIONAL_PROJECTS if args.with_optional else [])
+    if args.projects:
+        names = [n.strip() for n in args.projects.split(",")]
+        todo = [p for p in todo if p[0] in names]
+    # pre-register outputs of projects built in earlier runs so ProjectReference
+    # linking works for partial --projects builds
+    todo_names = {n for n, _ in todo}
+    for name, relpath in everything:
+        if name in todo_names:
+            continue
+        try:
+            p = Project(name, relpath, args)
+        except Exception:
+            continue
+        out_abs = p.outfile if os.path.isabs(p.outfile) else \
+            os.path.normpath(os.path.join(p.dir, p.outfile))
+        if os.path.isfile(out_abs):
+            implib = p.implib or os.path.join(p.outdir, p.macros["TargetName"] + ".lib")
+            if not os.path.isabs(implib):
+                implib = os.path.join(p.dir, implib)
+            BUILT[os.path.normcase(os.path.normpath(p.vcxproj))] = (p.type, out_abs, implib)
+            BUILT_BY_NAME[name] = (p.type, out_abs, implib)
+
+    results = {}
+    for name, relpath in todo:
+        print("=== %s (%s) ===" % (name, relpath))
+        try:
+            ok = Project(name, relpath, args).build(env, args.jobs)
+        except Exception as e:
+            sys.stderr.write("EXCEPTION in %s: %r\n" % (name, e))
+            ok = False
+        results[name] = ok
+
+    print("\n==== summary ====")
+    for name, _ in todo:
+        print("%-18s %s" % (name, "OK" if results.get(name) else "FAILED"))
+    sys.exit(0 if all(results.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# G-CVSNT documentation
+
+G-CVSNT is Gaijin Entertainment's fork of [CVSNT](https://en.wikipedia.org/wiki/CVSNT)
+2.5.05, re-versioned as **CVSNT 3.5.x**, modified to handle very large amounts of
+binary data (game development assets). The headline change is that binary file
+content is moved out of the RCS `,v` files into a **content-addressed blob
+store** keyed by BLAKE3 hashes, served by a dedicated, very simple TCP
+key-value server with optional caching proxies — while remaining
+protocol-compatible with standard CVS/CVSNT clients for everything else.
+
+| Document | Contents |
+|----------|----------|
+| [architecture.md](architecture.md) | Components, client/server protocol, how a command flows through the system |
+| [gaijin-modifications.md](gaijin-modifications.md) | What this fork changes compared to stock CVSNT 2.5.05 |
+| [blob-storage.md](blob-storage.md) | The content-addressed store, blob server, proxies, configuration |
+| [source-layout.md](source-layout.md) | Map of the source tree |
+| [performance.md](performance.md) | Why update/tag/branch scale with file count, and what can be improved |
+| [../HOWTOBUILD.md](../HOWTOBUILD.md) | Building on Windows / Linux / macOS |
+| [adr/ADR.md](adr/ADR.md) | Architecture decision records |
+| [../_reports/README.md](../_reports/README.md) | Code-audit findings index (62 bugs) + performance analysis |
+
+Related upstream docs inside the source tree:
+
+* `cvsnt/cvsnt-2.5.05.3744/keyValueServer/readme.md` — blob server library internals
+* `cvsnt/cvsnt-2.5.05.3744/doc/` — original CVS/CVSNT manuals (texinfo)
+* `cvsnt/cvsnt-2.5.05.3744/README`, `INSTALL`, `NEWS` — original upstream files

--- a/docs/adr/1.1-new-update-switches-client-only-or-negotiated.md
+++ b/docs/adr/1.1-new-update-switches-client-only-or-negotiated.md
@@ -1,0 +1,38 @@
+# New `update` switches must be client-consumed-only or `Valid-requests`-negotiated
+
+- **Status:** accepted
+- **Date:** 2026-08-27
+
+**Context.** The G-CVSNT client and server run the *same* `update()` option
+parser (`src/update.cpp:181`): the client forwards options as `Argument` lines
+(`src/client.cpp:5027`) and the server re-parses them via `serve_argument`
+(`src/server.cpp:2848`) + `do_cvs_command("update", update)`. Research
+established two asymmetric failure modes (`src/server.cpp:5408` vs
+`src/error.cpp:30`): an unknown *request keyword* at the server's main loop is
+soft — it replies `error  unrecognized request` and keeps serving — but an
+unknown *option letter* inside a recognized command is **fatal**: `update`'s
+`getopt_long` `default:` calls `usage()` → `error_exit()`, which under
+`server_active` terminates the whole server process.
+
+**Decision.** Any new `update` switch added by this initiative must be either
+(a) **client-consumed-only** — parsed by the client and never placed on the
+wire as an `Argument`, so an old or new server never sees it; or (b) forwarded
+to the server **only after `supported_request()` confirms** a matching
+negotiated capability advertised in the server's `Valid-requests` list
+(the pattern already used for `-u`/`update-patches` at `src/update.cpp:392`).
+A new switch must never be unconditionally forwarded.
+
+**Why.** Gaijin runs mixed client/server versions across a large fleet; a
+client that unconditionally forwarded a new `-exc`/`--no-sharp`/etc. option
+would fatally abort every older server it talked to, turning a convenience
+feature into an outage. Client-only handling ships the two receive-phase
+features (rename-aside, `.#` suppression) with zero protocol risk. Server-side
+exclusion (`-exc` pruning the recursion server-side, reusing
+`ignore_directory`/`dir_ign_list`) genuinely needs the server to know the
+exclusion set, so it must ride a negotiated capability and degrade to
+client-side filtering when the server is too old.
+
+**Consequences.** Rename-aside and `.#`-suppression are pure client changes.
+`-exc` splits into a always-available client-side filter plus an optional
+negotiated server-side prune; the plan must specify the fallback behavior when
+the capability is absent.

--- a/docs/adr/ADR.md
+++ b/docs/adr/ADR.md
@@ -1,0 +1,13 @@
+# ADR Index
+
+## Accepted
+
+- [1.1 New update switches client-only or negotiated](./1.1-new-update-switches-client-only-or-negotiated.md) — 2026-08-27
+
+## Deprecated
+
+(none)
+
+## Superseded
+
+(none)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,124 @@
+# Architecture
+
+All paths below are relative to `cvsnt/cvsnt-2.5.05.3744/`.
+
+## Big picture
+
+```
+                ┌───────────────────────────── client machine ─────────────────────────────┐
+                │  cvs.exe / cvs                                                           │
+                │   ├─ cvsapi.dll   (sockets, codepages, filename mapping, DB drivers)     │
+                │   ├─ cvstools.dll (settings, trigger/COM glue)                           │
+                │   ├─ protocols\*.dll  :pserver: :sserver: :sspi: :ssh: :ext: :fork: ...  │
+                │   └─ keyValueServer clientLib + blob_sockets (static)  ──────────────┐   │
+                └────────────┬──────────────────────────────────────────────────────── │ ──┘
+                             │ CVS wire protocol (TCP 2401, zlib/zstd compressed)      │ blob push/pull
+                             ▼                                                         ▼ (TCP 2403, parallel)
+                ┌─────────── server ───────────┐                       ┌────────────────────────────┐
+                │ cvsservice / xinetd → cvs    │                       │  blob server (keyValue-    │
+                │  server mode ("server" cmd)  │                       │  Server sample / proxy)    │
+                │  ├─ RCS ,v files (text +     │                       │  storage: blobs/xx/yy/hash │
+                │  │   blob refs for -kB)      │◄── shared repo disk ─►│  (zlib/zstd packed, mmap)  │
+                │  ├─ cvslock (lockserver)     │                       └────────────────────────────┘
+                │  └─ triggers\*.dll, scripts  │
+                └──────────────────────────────┘
+```
+
+Everything except binary file *content* moves over the classic CVS
+client/server protocol. Content of `-kB` (binary) files is stored and
+transferred as **content-addressed blobs**: the RCS `,v` file holds only a
+77-byte reference `blake3:<64 hex chars>`, and clients exchange the actual
+bytes with the blob server directly (see [blob-storage.md](blob-storage.md)).
+
+## Components
+
+### cvs (`cvsnt.vcxproj` → `cvs.exe`, `src/`)
+
+One binary is both the command-line client and the server (`cvs server`,
+launched per-connection by cvsservice on Windows or xinetd/inetd on Unix).
+Notable source files:
+
+* `src/main.cpp` — command table, global options (including Gaijin additions:
+  `--blob_url <url>` to override the blob server, `-j <n>` blob download
+  concurrency, `-F <file>` to read command arguments from a file)
+* `src/client.cpp` / `src/server.cpp` — the two halves of the wire protocol.
+  Requests are lines like `Directory`, `Entry`, `Modified`, `Unchanged`,
+  `Argument`, terminated by a command (`update`, `ci`, `tag` …); responses are
+  `Checked-in`, `Updated`, `Mod-time`, `Mode`, plus Gaijin's `Blob-ref`
+  (`update_blob_ref`), `Blob-url`, `Blob-OTP` extensions
+* `src/update.cpp`, `checkout.cpp`, `commit.cpp`, `tag.cpp`, … — one file per
+  command; each runs over the tree via `src/recurse.cpp`
+  (`start_recursion`), which calls per-directory and per-file callbacks
+* `src/rcs.cpp`, `rcs_checkin.cpp` — RCS `,v` parsing/rewriting (the server's
+  storage format)
+* `src/vers_ts.cpp`, `entries.cpp` — join of `CVS/Entries` (client state) with
+  RCS state (`Version_TS`)
+* `src/classify.cpp` — decides per file what update action is needed
+* `src/lock.cpp` — repository read/write locks (filesystem lock files or the
+  separate `cvslock` lock daemon)
+* `src/blob_operations.cpp`, `download_blob_to.cpp`, `blob_kv_processor.cpp`,
+  `blob_http_processor.cpp`, `zstd_buffer.cpp`, `sha_blob_reference.h` — the
+  blob client machinery (see [blob-storage.md](blob-storage.md))
+
+### cvsapi (`cvsapi/` → `cvsapi.dll` / `libcvsapi`)
+
+Platform abstraction: sockets with SSL, codepage/Unicode translation,
+filename mapping, protocol library loading, the `CGlobalSettings`
+configuration store (registry on Windows, `/etc/cvsnt/PServer` on Unix),
+pluggable database drivers (`cvsapi/db/sqlite`, `odbc`) used by auditing etc.
+
+### cvstools (`cvstools/` → `cvstools.dll`)
+
+Higher-level shared services: trigger library loading (`TriggerLibrary.cpp`,
+COM `trigger.idl` on Windows so triggers can be written as COM objects),
+server info/mapping helpers.
+
+### Protocols (`protocols/` → `protocols/*.dll` / `*.so`)
+
+Each access method is a plugin implementing `protocol_interface`:
+`pserver` (classic password server), `sserver` (SSL), `sspi` (NTLM/Kerberos on
+Windows), `ext` (external command), `ssh` (built-in ssh via bundled plink on
+Windows), `gserver` (GSSAPI), `fork` (local), `enum` (enumeration helper).
+The client picks one from the `CVSROOT` string (`:pserver:user@host:/cvs`).
+
+### Server-side plugins (`triggers/` → `triggers/*.dll`)
+
+Pre/post command hooks (`info_triggers` implements the classic
+`CVSROOT/loginfo`, `commitinfo`, … scripts; `audit` writes to a database;
+`email` sends notifications; `script` runs user scripts / COM on Windows).
+Interface: `cvstools/TriggerLibrary` / `triggers/server.idl`.
+
+### Services (Windows)
+
+* `cvsservice/` → `cvsservice.exe` — the NT service that listens on port 2401
+  (and 2402 for lockserver) and spawns `cvs.exe server` per connection
+* `lockservice/` → `cvslock.exe` — the lock daemon (`cvslockd` on Unix);
+  advisory read/write locks per repository path so concurrent commands don't
+  need lock files on disk
+* `control-panel`, `cvsntcpl/` — configuration UI
+
+### Repository format
+
+A repository is a directory tree of RCS `,v` files plus the administrative
+module `CVSROOT/` (config, `passwd`, trigger scripts, `history`, `val-tags`).
+G-CVSNT adds `blobs/` (content-addressed store, see
+[blob-storage.md](blob-storage.md)) and keeps everything else stock, so
+standard CVSNT tooling still understands the text parts of the repository.
+
+## Command flow example: `cvs update`
+
+1. Client walks the working copy (`src/client.cpp`: `send_files`), sending for
+   every directory a `Directory` request and for every file `Entry` +
+   (`Unchanged` | `Modified` | `Is-modified`) based on `CVS/Entries`
+   timestamps.
+2. Server (`src/server.cpp`: `serve_*`) reconstructs the state, takes read
+   locks, and runs the same `update()` code a local CVS would
+   (`src/update.cpp` with `server_active`), using `src/classify.cpp` per file.
+3. For text files needing update it sends `Updated`/`Merged`/`Patched` +
+   contents (zlib/zstd-compressed); for `-kB` files it sends the blob
+   reference (`Blob-ref`) instead of the content.
+4. Client applies responses, rewrites `CVS/Entries`, and enqueues blob
+   downloads to a background thread pool (`src/download_blob_to.cpp`, up to 8
+   threads, round-robin over blob proxy URLs) which fetches missing blobs
+   directly from the blob server and writes the working files.
+5. `wait_threads()` joins the pool before cvs exits.

--- a/docs/blob-storage.md
+++ b/docs/blob-storage.md
@@ -1,0 +1,86 @@
+# Blob storage: content-addressed store, blob server, proxies
+
+Paths relative to `cvsnt/cvsnt-2.5.05.3744/`.
+
+## Reference format
+
+A blob reference is exactly 71 bytes:
+
+```
+blake3:<64 hex chars of the BLAKE3-256 hash>
+```
+
+(`src/sha_blob_reference.h`: `HASH_TYPE_REV_STRING`, `blob_reference_size`).
+Only the `:` at offset 6 is structurally required by the key-value protocol,
+so other 6-letter hash names (historically `sha256:`) fit the same framing
+(`keyValueServer/readme.md`). A *session* blob reference (used on commit)
+appends an 8-byte crypt magic (`session_blob_reference_size`).
+
+## On-disk store (`ca_blobs_fs/`)
+
+* Layout: `<root>/blobs/<xx>/<yy>/<64-hex-hash>` where `xx`,`yy` are the
+  first two hash bytes in hex (`content_addressed_fs.h`).
+* Each blob file starts with a small header naming the packing (none / zlib /
+  zstd), followed by the (possibly compressed) content
+  (`ca_blobs_fs/ca_blob_format.h`, `streaming_compressors.h/.cpp`).
+* Push is streaming with hash verification (`start_push`/`stream_push`/
+  `finish`); trusting the client-provided hash is allowed by default (worst
+  case is a garbage blob that GC removes — overwriting an existing blob is
+  not possible, so history cannot be corrupted this way).
+* Pull is mmap-based with random access (`start_pull`/`pull`).
+* Blobs are immutable; garbage collection and repacking are offline tools
+  (`tools/gc-blobs.cpp`, `tools/repack-blobs.cpp`).
+
+## The key-value server (`keyValueServer/`)
+
+A deliberately tiny TCP protocol (default port **2403**) with commands for
+check/size/push/pull of hash-keyed blobs. Properties:
+
+* `serverLib/` spawns a thread per connection in a loop
+  (`blob_push_server.cpp`); storage behind it is 8 link-time functions
+  (`blob_server_func_deps.h`) — the production implementation maps them to
+  `ca_blobs_fs`, the sample one is `sample/`.
+* `clientLib/` is what `cvs` links (via `src/blob_kv_processor.cpp`).
+* `proxy/` (`cafs_proxy`) is a **write-through caching proxy**: reads are
+  served from its local cache, writes go through to the master; the cache is
+  not populated by writes. Deploy proxies close to the users (per-office),
+  keep one master next to the repository.
+* There is also an HTTP pull transport (`src/blob_http_processor.cpp`,
+  bundled `src/httplib.h`) so blobs can be served by a plain HTTP server /
+  CDN; URLs starting with `http://` select it.
+
+## How clients learn the URLs
+
+Order of precedence (`src/client.cpp: get_download_source`,
+`src/download_blob_to.cpp: BackgroundProcessor::init`):
+
+1. `--blob_url url` on the cvs command line (also multi-URL
+   `url1|url2|...`, `host@port` syntax; `def` selects the master sent by the
+   server).
+2. `Blob-url` / `Blob-OTP` response lines sent by the CVS server during
+   handshake, configured server-side in the `PServer` settings:
+   `BlobURL`, `BlobURL0..31` (plain), `BlobEncryptedURL0..31` (requires OTP
+   encryption), `BlobOTP` (shared secret for time-based OTP pages)
+   (`src/server.cpp: send_blob_private_blob_urls_to_client`,
+   `send_blob_otp_to_client`).
+
+At run time the client builds a URL list: *public* proxies, then *private*
+proxies, then the master (always last). Up to 8 worker threads
+(`min(8, cores-1)`, overridable with `-j N`) each hold their own connection
+and pick URLs round-robin with a random per-run shuffle; a failing server is
+marked dead and the next one is tried, falling back to the master
+(`src/download_blob_to.cpp: RoundRobin, fail()`).
+
+## Operational notes
+
+* Downloads happen *during* update in the background; before overwriting a
+  working file the old one is deleted so an aborted update shows the file as
+  modified rather than silently stale (`download_blob_to.cpp:100`).
+* The OTP mechanism derives a rotating secret from `BlobOTP` + time page
+  (`blob_gen_totp_secret`), so proxies can authenticate/encrypt blob traffic
+  without CVS accounts.
+* Migration of an existing repository: run `cvtblob`
+  (`tools/convert_to_blob.cpp`) over the `,v` tree to move `-kB` revision
+  data into the store and rewrite the `,v` files as references; `,v` backups
+  and idempotency are handled by the tool. `rcs_cvt_kB.cpp` implements the
+  in-server conversion path.

--- a/docs/gaijin-modifications.md
+++ b/docs/gaijin-modifications.md
@@ -1,0 +1,126 @@
+# Gaijin modifications vs. stock CVSNT 2.5.05
+
+The fork identifies itself as `CVSNT 3.5.x (Gan + [Gaijin -kB/-kBz patch])`
+(`version_no.h`, `version_fu.h`). This page lists what was changed/added on
+top of the March Hare CVSNT 2.5.05.3744 code base. Paths relative to
+`cvsnt/cvsnt-2.5.05.3744/`.
+
+## 1. Content-addressed blob storage for binary files (the big one)
+
+For files committed with `-kB` (binary, no keyword expansion, binary deltas)
+the RCS `,v` files no longer contain revision data. Instead every revision's
+"text" is a fixed-size reference:
+
+```
+blake3:<64 hex characters of the BLAKE3-256 hash of the content>
+```
+
+(`src/sha_blob_reference.h`; deltas between revisions degenerate to
+`d1 1\na1 1\nblake3:<hash>` — replace the single "line", see
+`src/rcs_checkin.cpp`). The actual content lives in a content-addressed store
+(`ca_blobs_fs/`), where each blob is stored (zlib- or zstd-compressed, with a
+small header) under `blobs/<xx>/<yy>/<64-hex-hash>` — `xx`/`yy` being the
+first two bytes of the hash. Consequences:
+
+* `,v` files of huge binary assets are a few hundred bytes; server-side
+  operations that parse or rewrite `,v` (tag, branch, status) no longer read
+  gigabytes.
+* Identical content is stored once, repository-wide (dedup), and can be
+  garbage-collected / repacked offline (`tools/gc-blobs.cpp`,
+  `tools/repack-blobs.cpp`).
+* Content transfer is offloaded from the CVS protocol connection to the blob
+  server (parallel, resumable-by-retry, cacheable by proxies).
+* `blobs de-facto immutable` — overwriting an existing blob is not allowed.
+
+Components:
+
+* `ca_blobs_fs/` — the store library (push/pull streaming, mmap pulls,
+  streaming zlib/zstd compressors, BLAKE3 hashing via `blake3/`)
+* `keyValueServer/` — a small TCP key-value protocol (default port **2403**)
+  with `serverLib` (thread per connection), `clientLib` (used by cvs),
+  `blob_sockets`, a **caching proxy** (`proxy/cafs_proxy.vcxproj`,
+  write-through cache) and sample server implementations
+* `src/blob_operations.cpp`, `src/download_blob_to.cpp` — cvs-side plumbing:
+  a background pool of up to 8 threads pushes/pulls blobs while the main
+  protocol loop keeps running; URLs are tried round-robin (public proxies →
+  private proxies → master)
+* `src/blob_kv_processor.cpp` (native kv protocol) and
+  `src/blob_http_processor.cpp` (HTTP pull via `src/httplib.h`) — two
+  transports behind one `BlobNetworkProcessor` interface
+* `src/rcs_cvt_kB.cpp`, `tools/convert_to_blob.cpp` (`cvtblob`) — migration
+  of existing `,v` files to blob references
+
+### Protocol extensions (all negotiated, old clients keep working)
+
+* Server→client responses: `Blob-ref` (send a reference instead of file
+  content; client queues a background download), `Blob-ref-created`,
+  `Blob-url` (tell the client where the blob servers/proxies are, from the
+  server's `PServer/BlobURL`, `BlobURL0..31` settings), `Blob-OTP`
+  (time-based one-time secret for blob-server authentication/encryption,
+  `BlobEncryptedURL0..31`) — see `src/server.cpp`
+  (`send_blob_url_to_client`, `send_blob_otp_to_client`) and the response
+  table in `src/client.cpp`.
+* Client→server: `Blob-ref-transfer` / `Blob-transfer` valid-requests; on
+  commit the client uploads the blob to the blob server and sends only the
+  reference to the CVS server (`src/client.cpp: send_modified`).
+* Client options: `--blob_url url[|url2|...]` override, `-j N` download
+  concurrency (`blob_concurrency_download_level`).
+
+## 2. `-kB` / `-kBz` commit and update flow
+
+The `ver` banner's "`-kB/-kBz patch`" refers to this flow (flags parsed in
+`src/rcs.cpp: RCS_get_kflags` — `B` = binary with binary deltas, `z` =
+compress):
+
+* **commit** (`src/client.cpp: send_modified/send_blob_files`): when the
+  server advertises `Blob-ref-transfer`/`Blob-transfer`, the client does NOT
+  send the binary content over the CVS connection. It hashes the file,
+  uploads the blob to the blob server through the background pool
+  (compressed when the file has the `z` modifier, see `client.cpp:5889`),
+  and sends only the session blob reference to the CVS server.
+* **update/checkout**: the server answers with `Blob-ref` instead of file
+  data; the client registers the new revision in `CVS/Entries` and queues a
+  background download of the blob (`src/client.cpp:
+  update_blob_ref_entries`, `src/download_blob_to.cpp`).
+* Modified-file detection for binary files stays timestamp-based via
+  `CVS/Entries` (plus CVSNT's `Entries.Extra` per-file metadata inherited
+  from upstream: edit baseline MD5, RCS timestamp, merge tags).
+
+## 3. Modern compression and hashing everywhere
+
+* **zstd** (vendored `zstd/`, used for wire compression as an alternative to
+  zlib — `src/zstd_buffer.cpp` — and for blob packing in `ca_blobs_fs`)
+* **BLAKE3** (vendored `blake3/` with SSE2/SSE4.1/AVX2/AVX-512 asm) — content
+  hashing; `src/sha256/` retained for the older sha256-based blob format
+  (`sha256:` prefix still parses, see `keyValueServer/readme.md`)
+
+## 4. Miscellaneous fork changes
+
+* `src/RecurseRepository.cpp` — server-side repository recursion helper
+  (faster directory walking for module expansion)
+* `src/concurrent_queue.h` — the work queue used by the blob thread pool
+* `-F file` global option — read command arguments from a file (long file
+  lists exceed OS command-line limits in gamedev-sized checkouts)
+* Windows x64 build modernized (VS2019/v142 solution, `build-windows.py`
+  added by this repo), macOS packaging in `osx/` (`build-macosx`,
+  x86_64+arm64), Linux server build script (`build-linux-server`)
+* `mkmodules`/trigger execution order fix: premodule triggers run before the
+  update operation (see git history: `c82d510`)
+* Various hardening/large-file fixes throughout `src/` (the fork exists to
+  survive checkouts with 10^5–10^6 files and multi-GB binaries)
+
+## 5. Repository administration additions
+
+Server-side settings live in the `PServer` configuration section (registry
+`HKLM\SOFTWARE\CVS\PServer` on Windows, `/etc/cvsnt/PServer` on Unix):
+
+| Setting | Meaning |
+|---------|---------|
+| `BlobURL`, `BlobURL0`..`BlobURL31` | blob server / proxy URLs handed to clients (`Blob-url` response) |
+| `BlobEncryptedURL0`..`31` | URLs that demand OTP-encrypted blob traffic |
+| `BlobOTP` | secret used to derive time-based OTP pages for blob auth |
+
+Offline maintenance tools (`tools/`, built by `tools/build_tools`):
+`cvtblob` (convert an RCS repo to blob references), `gc-blobs` (find/remove
+unreferenced blobs), `repack-blobs` (recompress), `blake3-calc`/`sha256_calc`,
+`simplelock`/`unlock` (lock DB maintenance).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,85 @@
+# Performance: why update / tag / branch scale with file count
+
+This is a developer-facing summary. The full analysis, with per-operation
+cost tables and `file:line` evidence for every claim, is in
+[`_reports/perf-analysis.md`](../_reports/perf-analysis.md).
+
+## The short version
+
+On huge trees the wall-clock of `cvs update` and `cvs tag`/branch is dominated
+by **fixed per-file overhead on the server**, not by data transfer. The blob
+system already removed the data-transfer cost for binaries (references instead
+of content, parallel out-of-band pulls). What remains is per-`,v`-file work
+that runs once per file, sequentially, no matter how little changed.
+
+The client↔server protocol itself is **not** the bottleneck: requests and
+responses are fully streamed/buffered, with no per-file network round-trip.
+The per-file round-trips that hurt are **server↔lockserver**.
+
+## Where the time goes
+
+1. **Lockserver round-trips — ~2 per file on update, ~6 per file on tag.**
+   Every `RCS_parse` takes a lock from the lock daemon over a socket and
+   releases it when the node is freed (`src/rcs.cpp:905`, `:766`; lockserver
+   on by default). Nothing is batched. 300k files ⇒ 600k+ synchronous
+   round-trips on a single update; tag does it twice (two recursion passes)
+   plus a write-lock pair inside the rewrite.
+2. **Full `,v` header parse per file, every time, no cache.**
+   `RCS_parsercsfile_i` unconditionally calls `RCS_reparsercsfile`, parsing
+   *every delta header* — even when the answer is "up to date". The comment at
+   `src/rcs.cpp:336-340` still advertises lazy parsing, but the code
+   (`src/rcs.cpp:349`) is no longer lazy. There is no RCS cache anywhere.
+3. **Tag rewrites the whole `,v`, then re-parses it and throws the result
+   away.** `RCS_rewrite` writes full admin + raw-copies the entire body +
+   renames, then does a complete re-parse of the file it just wrote
+   (`src/rcs.cpp:7199-7200`) which the tag file-proc immediately discards. Tag
+   also runs two full recursion passes (`src/tag.cpp:409` check pass, `:431`
+   tag pass), each re-parsing every file.
+4. **Windows `stat()` opens every file.** Default `use_ntea=1`
+   (`windows-NT/win32.cpp:363`) makes every stat of an existing file do
+   `CreateFile(FILE_READ_EA)` + `NtQueryEaFile` + `CloseHandle` on top of
+   `GetFileAttributesEx` — a real file open per file, which AV filters
+   intercept. Client stats every working file once per update.
+5. **Server "fake sandbox" churn** — per `Directory` request the server
+   materializes a temp working area (`dirswitch`+`create_adm_p`+`mkdir_p`,
+   O(depth) syscalls + ~6 file ops), and the final `rm -rf` of that temp tree
+   happens *before* the compressed-stream shutdown trailer, i.e. partly on the
+   client-visible critical path.
+6. **No parallelism on the server path** — recursion is strictly sequential.
+   The only existing parallelism is the client blob-transfer pool.
+
+## What's already fast (Gaijin work)
+
+Blob references keep the server data-free on update; client blob pulls/pushes
+run on a ≤8-thread pool with persistent per-server connections that overlap the
+protocol phase; the MD5 in `Entries.Extra` avoids re-sending touched-but-
+identical files; modified `-kB` files send only a BLAKE3 hash.
+
+## Improvement proposals
+
+Ordered roughly by impact-to-risk. Server-only changes don't affect protocol
+compatibility; protocol changes must be negotiated via `Valid-requests` so old
+clients are unaffected. Full sketches (with the exact functions/statics to
+touch and the compatibility notes) are in the
+[report](../_reports/perf-analysis.md).
+
+| # | Change | Speeds up | Risk |
+|---|--------|-----------|------|
+| P1/P2 | **Lockserver leasing** — one directory-granular Read (update) / Write (tag) lease instead of per-file lock/unlock | update, tag, branch | med (matches classic per-directory CVS lock semantics; server-only) |
+| P3 | **Restore lazy delta parsing** — stop at the first revision key, parse deltas on demand | update, tag | med (touches the RCS parser core; needs care) |
+| P4 | **Per-directory `(size,mtime)`-validated head/symbols cache** — skip `RCS_parse` entirely for unchanged files | update, tag | med |
+| P5 | **Drop the discarded re-parse** after `RCS_rewrite` in tag paths | tag, branch | low (removes 1 of 3 parses) |
+| P6 | **Single-pass tag** when no pretag trigger is configured | tag, branch | low–med |
+| P7 | **Parallelize the tag file loop** (files are independent) | tag, branch | med (audit statics like `rcs_lockfile`) |
+| P8 | **Default Windows `ntea` off** (users can already set `CVSNT=nontea` today as a zero-code mitigation) | update (Windows) | low |
+| P9 | **Keep `Entries.Log` handles open per directory** instead of open/close per file | update | low |
+| P10 | **Delete the server temp sandbox after the stream shutdown trailer** | update tail latency | low |
+| P11 | **Memoize `open_directory`** (3× per directory today, with an in-code FIXME) | update | low |
+| P12 | **Opt-in per-directory manifest-hash protocol** — negotiate a directory digest so a no-change update is O(dirs), not O(files) | update | high (protocol; negotiated, old clients unaffected) |
+| P13 | **Blob pool cap tuning** (currently `min(8, cores-1)`) | update/commit of many `-kB` files | low |
+
+**Quick wins with no protocol impact:** P5, P8, P9, P10, P11 — all local
+server/client changes, each removing a constant per-file cost.
+**Biggest structural wins:** P1/P2 (lock batching) and P3/P4 (parse
+elimination) attack the two dominant per-file costs; P12 changes the scaling
+class of the common "nothing changed" update.

--- a/docs/source-layout.md
+++ b/docs/source-layout.md
@@ -1,0 +1,82 @@
+# Source tree layout
+
+```
+D:\G-CVSNT
+├── README.md, HOWTOBUILD.md, docs/          this documentation
+├── _reports/                                code-audit findings (generated)
+└── cvsnt/
+    ├── build-windows.py                     Windows build driver (no VS needed)
+    ├── build-linux-server, build-macosx,    platform build scripts
+    │   build-rhel6, build-altlinux
+    ├── make_msi.bat, make_msix64.bat        WiX MSI packaging (msi_tools/, *.wxs)
+    ├── cvslockd, cvsnt.xinetd, cvsnt.pam    Unix service integration files
+    ├── *.patch                              historical distro patches
+    ├── tortoiseCVS/                         TortoiseCVS fork (Windows shell ext)
+    └── cvsnt-2.5.05.3744/                   ← the actual source tree (CVSNT 3.5.x)
+        ├── cvsnt.sln, *.vcxproj             VS2019 (v142) solution
+        ├── configure.in, Makefile.am        autotools build (Unix)
+        ├── version_no.h                     product version / build number
+        │
+        │  ── the cvs program ──
+        ├── src/                             all cvs commands, client & server
+        │   ├── <command>.cpp                add, admin, annotate, checkout, commit,
+        │   │                                diff, edit, import, log, ls, remove,
+        │   │                                status, tag, update, watch, ...
+        │   ├── client.cpp / server.cpp      wire protocol, two halves
+        │   ├── rcs.cpp, rcs_checkin.cpp     RCS ,v read/write
+        │   ├── recurse.cpp, RecurseRepository.cpp   tree walking
+        │   ├── entries.cpp, vers_ts.cpp, classify.cpp  working-copy state
+        │   ├── lock.cpp                     repo locks (files or cvslock daemon)
+        │   ├── blob_*.cpp, download_blob_to.cpp, sha_blob_reference.h,
+        │   │   zstd_buffer.cpp, sha256/     Gaijin blob machinery
+        │   └── httplib.h                    bundled cpp-httplib (HTTP blob pull)
+        │
+        │  ── Gaijin blob infrastructure ──
+        ├── ca_blobs_fs/                     content-addressed store library
+        ├── keyValueServer/                  blob TCP server/client/proxy
+        │   ├── blob_sockets/, clientLib/, serverLib/
+        │   ├── proxy/                       cafs_proxy (write-through cache)
+        │   └── sample*/                     reference implementations
+        ├── blake3/                          vendored BLAKE3 (C + asm)
+        ├── zstd/                            vendored zstd
+        │
+        │  ── support libraries ──
+        ├── cvsapi/                          platform/network/db/unicode API (DLL)
+        │   └── db/sqlite, db/odbc, mdns/    plugins
+        ├── cvstools/                        settings + trigger glue (DLL)
+        ├── protocols/                       pserver, sserver, sspi, ssh, ext,
+        │                                    gserver, fork, enum plugins
+        ├── triggers/                        info (CVSROOT scripts), audit, email,
+        │                                    script, checkout plugins
+        ├── lib/ (gnulib), diff/ (libdiff), xdiff/, cvsdelta/, cvsgui/,
+        │   pcre/, zlib/, libxml/, ufc-crypt/, mdnsclient/   misc libs
+        ├── external_libs/                   prebuilt OpenSSL/iconv (Win32/x64),
+        │                                    sqlite3 amalgamation, dns_sd.h
+        │
+        │  ── services & tools ──
+        ├── cvsservice/                      Windows NT service (port 2401/2402)
+        ├── lockservice/                     cvslock lock daemon
+        ├── windows-NT/                      Win32 compat layer, cvsdiag, setuid,
+        │                                    installer helper
+        ├── tools/                           blob repo maintenance: cvtblob,
+        │                                    gc-blobs, repack-blobs, blake3-calc,
+        │                                    simplelock/unlock (build_tools script)
+        ├── rcs/ (co, rcsdiff, rlog), su/, extnt/, genkey/, genbuild/,
+        │   postinst/, uninsthlp/, control-panel/, cvsntcpl/   utilities
+        ├── contrib/, contrib_nt/            scripts, examples
+        ├── doc/, man/                       original texinfo/man documentation
+        ├── osx/, redhat/, debian/           platform packaging
+        └── testcvs/, simcvs/                test harnesses
+```
+
+Conventions worth knowing:
+
+* `windows-NT/config.h` vs generated `config.h` — the Windows build uses the
+  checked-in config; Unix generates one via `configure`.
+* Generated sources not in git: `cvsapi/win32/ServiceMsg.{h,rc}` (from
+  `ServiceMsg.mc`), `cvstools/trigger_h.h|trigger_i.c|win32/trigger.tlb`
+  (from `win32/trigger.idl`), `triggers/Server_h.h|Server_i.c|
+  script_trigger.tlb` (from `server.idl`). `build-windows.py` creates them
+  on demand.
+* Build outputs land in `Releasex64/` (or `Debug<platform>/`), intermediates
+  in `tmp/`.


### PR DESCRIPTION
Adds developer documentation, a Windows build path that does not need a Visual Studio installation, and the results of a static audit of the tree.

## Build tooling
`cvsnt/build-windows.py` parses the `.vcxproj` files of `cvsnt.sln` and drives `cl`/`ml64`/`rc`/`lib`/`link` directly, including the message-compiler and MIDL code generation that Visual Studio normally runs as custom build steps. That makes the client/server buildable from a bare MSVC toolchain plus a Windows SDK. It also works from a normal developer prompt.

Verified by building all 40 projects; the resulting `cvs.exe` reports CVSNT 3.5.24.

`HOWTOBUILD.md` documents this together with the existing Linux and macOS build scripts, and the generated-source and packaging steps.

## Documentation
`docs/` covers the architecture and component layout, the content-addressed blob storage this fork is built around (reference format, store layout, blob server and proxies, how clients learn the URLs), a map of the source tree, and an analysis of why `update`, `tag` and branch time scales with the number of files rather than their size.

## Audit reports
`_reports/` contains 62 static-analysis findings, one file per finding with location, code, failure scenario and a suggested fix, indexed by severity in `_reports/README.md`. The performance analysis behind `docs/performance.md` is there too, with `file:line` evidence for each claim.

Documentation and reports only - no source behaviour changes. The fixes for a first batch of these findings, and the optimizations from the performance analysis, are proposed in separate pull requests.
