### PR TITLE
Fix 18 defects found by static audit (one commit per fix)

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
@@ -38,6 +38,8 @@ std::string blobs_dir_path(const context *ctx){return ctx->root_path;}
 
 void set_root(context *ctx, const char *p)
 {
+  if (!p)               // documented contract: nullptr means "use the default root"
+    p = "";
   //better use std::format, but it is c++20
   ctx->root_path = dir_for_roots;
   if (ctx->root_path.length() && ctx->root_path[ctx->root_path.length()-1] != '/' && p[0] != '/')

--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/content_addressed_fs.cpp
@@ -198,7 +198,10 @@ PushResult finish(PushData *fp, char *actual_hash_str)
   fp->fp = nullptr;
 
   if (fcloseRet != 0)
+  {
+    blob_fileio_unlink_file(fp->temp_file_name.c_str());
     return PushResult::IO_ERROR;
+  }
 
   char final_hash[64];
   char *final_hash_p = actual_hash_str ? actual_hash_str : final_hash;
@@ -208,7 +211,10 @@ PushResult finish(PushData *fp, char *actual_hash_str)
     blake3_hasher_finalize(&fp->hasher, digest, sizeof(digest));
     bin_hash_to_hex_string_64(digest, final_hash_p);
     if (fp->provided_hash[0] && memcmp(fp->provided_hash, final_hash_p, 64) != 0)
+    {
+      blob_fileio_unlink_file(fp->temp_file_name.c_str());
       return PushResult::WRONG_HASH;
+    }
   } else
     memcpy(final_hash_p, fp->provided_hash, 64);
   std::string filepath = get_file_path(fp->root, final_hash_p);
@@ -218,7 +224,10 @@ PushResult finish(PushData *fp, char *actual_hash_str)
     return PushResult::DEDUPLICATED;
   }
   make_blob_dirs(filepath);
-  return blob_fileio_rename_file_if_nexist(fp->temp_file_name.c_str(), filepath.c_str()) ? PushResult::OK : PushResult::IO_ERROR;
+  if (blob_fileio_rename_file_if_nexist(fp->temp_file_name.c_str(), filepath.c_str()))
+    return PushResult::OK;
+  blob_fileio_unlink_file(fp->temp_file_name.c_str());
+  return PushResult::IO_ERROR;
 }
 
 PullData* start_pull(const context *ctx, const char* hash_hex_string, uint64_t &blob_sz)

--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/fileio.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/src/fileio.cpp
@@ -226,6 +226,8 @@ const void* blob_fileio_os_mmap(const char *filepath, std::uintmax_t flen)
     return nullptr;
   void *ret = mmap(NULL, flen, PROT_READ, MMAP_FLAGS, fd, 0);
   close(fd);
+  if (ret == MAP_FAILED)
+    return nullptr;
   return ret;
 }
 

--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/tests/README.md
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/tests/README.md
@@ -1,0 +1,35 @@
+# ca_blobs_fs unit tests
+
+`test_ca_blobs_fs.cpp` is a standalone test for the content-addressed blob
+store. It links against the built `ca_blobs_fs` static library and its
+dependencies and exercises push/dedup/exists/pull plus the audited
+`set_root(ctx, nullptr)` contract.
+
+## Prerequisites
+
+Build the libraries first (they land in `Releasex64/`):
+
+```
+cd cvsnt
+python build-windows.py --vc <MSVC dir> --sdk <Win10 SDK dir> --projects zlib,zstd,blake3,ca_blobs_fs
+```
+
+## Build & run (Windows, bare MSVC toolchain)
+
+From a shell with the MSVC/SDK `INCLUDE`/`LIB` environment set (a
+"x64 Native Tools" prompt, or export them as `build-windows.py` does), from
+the source root `cvsnt-2.5.05.3744/`:
+
+```
+cl /nologo /std:c++17 /EHsc /MD /I ca_blobs_fs ^
+   ca_blobs_fs\tests\test_ca_blobs_fs.cpp ^
+   Releasex64\ca_blobs_fs.lib Releasex64\blake3.lib Releasex64\zstd.lib Releasex64\zlib.lib ^
+   /Fe:test_ca_blobs_fs.exe
+test_ca_blobs_fs.exe
+```
+
+Exit code 0 means all checks passed; non-zero prints which check failed.
+
+On Linux/macOS the equivalent is a `clang++ -std=c++17` link against the
+`libca_blobs_fs`/`libblake3` produced by the autotools build (see
+`tools/build_tools` for the analogous link lines).

--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/tests/test_ca_blobs_fs.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/tests/test_ca_blobs_fs.cpp
@@ -1,0 +1,101 @@
+// Standalone unit tests for the content-addressed blob store (ca_blobs_fs).
+//
+// Exercises the real library: push (framed via push_whole_blob_from_raw_data),
+// content-addressed dedup, existence, and a pull round-trip; plus the audited
+// fix that set_root(ctx, nullptr) must honor the documented "use the default
+// root" contract instead of crashing (fix: blob-008).
+//
+// Build: see tests/README.md for the exact cl command.
+// Exit code 0 = all passed, non-zero = a failure (prints which).
+
+#include "../content_addressed_fs.h"
+#include "../calc_hash.h"
+#include "../push_whole_blob.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+using namespace caddressed_fs;
+
+static int g_failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { std::printf("FAIL: %s\n", (msg)); ++g_failures; } \
+    else         { std::printf("ok  : %s\n", (msg)); } } while (0)
+
+// Push raw bytes as a blob; returns the 64-char hex hash (NUL-terminated).
+static bool push_raw(context *ctx, const void *data, size_t sz, char hash65[65], bool pack)
+{
+  std::memset(hash65, 0, 65);
+  bool ok = push_whole_blob_from_raw_data(ctx, data, sz, hash65, pack);
+  hash65[64] = 0;
+  return ok;
+}
+
+int main()
+{
+  std::error_code ec;
+  const fs::path base = fs::temp_directory_path(ec) / "cafs_unit_test";
+  fs::remove_all(base, ec);
+  const fs::path root = base / "root";
+  // The store does not create its own blobs/ base dir (callers mkdir it).
+  fs::create_directories(root / "blobs", ec);
+
+  context *ctx = create();
+  CHECK(ctx != nullptr, "create() returns a context");
+
+  // blob-008: nullptr root must not crash (documented "use the default root").
+  set_root(ctx, nullptr);
+  CHECK(true, "set_root(ctx, nullptr) did not crash");
+
+  set_root(ctx, root.string().c_str());
+  set_allow_trust(true);
+
+  const char payloadA[] = "the quick brown fox jumps over the lazy dog, 12345";
+  const size_t plenA = sizeof(payloadA) - 1;
+  char hashA[65];
+  CHECK(push_raw(ctx, payloadA, plenA, hashA, /*pack*/false), "push blob A (unpacked)");
+  CHECK(std::strlen(hashA) == 64, "push returns a 64-char hex hash");
+  CHECK(exists(ctx, hashA), "exists() finds blob A");
+  CHECK(get_size(ctx, hashA) != invalid_size, "get_size() reports a size for blob A");
+
+  // Content addressing: pushing identical bytes again yields the same hash and
+  // does not error (dedup fast path).
+  char hashA2[65];
+  CHECK(push_raw(ctx, payloadA, plenA, hashA2, false), "re-push identical content");
+  CHECK(std::strcmp(hashA, hashA2) == 0, "identical content hashes identically (dedup)");
+
+  // Different content -> different hash; both coexist.
+  const char payloadB[] = "a completely different payload, packed with zstd";
+  char hashB[65];
+  CHECK(push_raw(ctx, payloadB, sizeof(payloadB) - 1, hashB, /*pack*/true), "push blob B (zstd)");
+  CHECK(std::strcmp(hashA, hashB) != 0, "different content hashes differently");
+  CHECK(exists(ctx, hashA) && exists(ctx, hashB), "both blobs exist after distinct pushes");
+
+  // A hash that was never pushed must not exist.
+  const char missing[65] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+  CHECK(!exists(ctx, missing), "exists() is false for an unknown hash");
+
+  // Pull round-trip sanity: the stored blob is readable and non-empty.
+  {
+    uint64_t sz = 0;
+    PullData *pl = start_pull(ctx, hashA, sz);
+    CHECK(pl != nullptr, "start_pull opens blob A");
+    if (pl)
+    {
+      uint64_t got = 0;
+      const char *data = pull(pl, 0, got);
+      CHECK(data != nullptr && got > 0, "pull() returns non-empty data");
+      destroy(pl);
+    }
+  }
+
+  destroy(ctx);
+  fs::remove_all(base, ec);
+
+  std::printf("\n%s (%d failure%s)\n", g_failures ? "TESTS FAILED" : "ALL TESTS PASSED",
+              g_failures, g_failures == 1 ? "" : "s");
+  return g_failures ? 1 : 0;
+}

--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
@@ -398,7 +398,10 @@ static bool exchange_session_keys(intptr_t raw_socket, const uint8_t otp_page[ot
           uint8_t encrypted[sizeof(ourDhAuthData)];
           int outLen = 0;
           if (1 != EVP_EncryptUpdate(enc, encrypted, &outLen, ourDhAuthData, sizeof(ourDhAuthData)) || outLen != sizeof(encrypted))
+          {
+            EVP_CIPHER_CTX_free(enc);
             return nullptr;
+          }
           EVP_CIPHER_CTX_free(enc); enc = NULL;
 
           if (raw_send_exact(raw_socket, encrypted, sizeof(encrypted)) <= 0)

--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
@@ -416,9 +416,12 @@ static bool exchange_session_keys(intptr_t raw_socket, const uint8_t otp_page[ot
           }
           EVP_CIPHER_CTX *dec = init_cipher_from_otp(otp_page, false);
           if (1 != EVP_DecryptUpdate(dec, otherDhAuthData, &outLen, encrypted, sizeof(ourDhAuthData)) || outLen != sizeof(encrypted))
+          {
+            EVP_CIPHER_CTX_free(dec);
             return nullptr;
+          }
           memset(encrypted, 0, sizeof(encrypted));
-          EVP_CIPHER_CTX_free(enc); enc = NULL;
+          EVP_CIPHER_CTX_free(dec); dec = NULL;
           return otherDhAuthData;
       }
       ))

--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/clientLib/blob_push_pull_client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/clientLib/blob_push_pull_client.cpp
@@ -27,7 +27,7 @@ int connect_with_timeout(intptr_t raw_sock, const struct sockaddr *addr, size_t 
 
   //set the socket in non-blocking
   if (!raw_set_non_blocking(raw_sock, true))
-    blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d (%d)\n", blob_get_last_sock_error());
+    blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d\n", blob_get_last_sock_error());
   auto connectRet = connect(raw_sock, addr, (int)addr_len);
   if (connectRet == -1 && !raw_socket_would_block(raw_get_last_sock_error()))
   {
@@ -51,7 +51,7 @@ int connect_with_timeout(intptr_t raw_sock, const struct sockaddr *addr, size_t 
   if (FD_ISSET(raw_sock, &Write))
   {
     if (!raw_set_non_blocking(raw_sock, false))
-      blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d (%d)\n", raw_get_last_sock_error());
+      blob_logmessage(LOG_ERROR, "ioctlsocket failed with error: %d\n", raw_get_last_sock_error());
     return 0;
   }
   return -1;

--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/free_disk_space.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/proxy/free_disk_space.cpp
@@ -14,7 +14,7 @@ uint64_t available_disk_space(const char *dir)
 {
   std::error_code ec;
   const std::filesystem::space_info si = std::filesystem::space(dir, ec);
-  if (!bool(ec))
+  if (bool(ec))
     return uint64_t(~uint64_t(0));
   return si.available;
 }

--- a/cvsnt/cvsnt-2.5.05.3744/protocols/common.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/protocols/common.cpp
@@ -247,7 +247,7 @@ static int tcp_connect_http(const cvsroot *cvsroot)
 				server_error(1,"Proxy server requires authentication");
 		}
 		else
-			server_error(1,"Proxy server connect failed: ",p?p:"No response");
+			server_error(1,"Proxy server connect failed: %s",p?p:"No response");
 	}
 
 	while(strlen(line)>1)

--- a/cvsnt/cvsnt-2.5.05.3744/protocols/ssh.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/protocols/ssh.cpp
@@ -198,12 +198,12 @@ int ssh_connect(const struct protocol_interface *protocol, int verify_only)
 				}
 				*key++ = '\0';
 				key=strchr(key,';');
-				*key++ = '\0';
 				if(!key || !*key)
 				{
 					/* Something wrong - ignore password */
 					server_error(1,"No password or key set.  Try 'cvs login'\n");
 				}
+				*key++ = '\0';
 				version = crypt_password+4;
 			}
 			else

--- a/cvsnt/cvsnt-2.5.05.3744/protocols/sspi.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/protocols/sspi.cpp
@@ -659,7 +659,7 @@ int ClientAuthenticate(const char *protocol, const char *name, const char *pwd, 
 	int rc, rcISC;
 	SEC_WINNT_AUTH_IDENTITY nameAndPwd = {0};
 	int bytesReceived = 0, bytesSent = 0;
-	char myTokenSource[DNLEN*4];
+	char myTokenSource[MAX_PATH];
 	TimeStamp useBefore;
 	DWORD ctxReq, ctxAttr;
 	int dwRead,dwWritten;
@@ -690,7 +690,7 @@ int ClientAuthenticate(const char *protocol, const char *name, const char *pwd, 
 		rc = AcquireCredentialsHandle( NULL, (char*)protocol, SECPKG_CRED_OUTBOUND, NULL, name?&nameAndPwd:NULL, NULL, NULL, &credHandle, &useBefore );
 
 		ctxReq = /*ISC_REQ_ALLOCATE_MEMORY |*/ ISC_REQ_REPLAY_DETECT | ISC_REQ_SEQUENCE_DETECT | ISC_REQ_CONFIDENTIALITY | ISC_REQ_EXTENDED_ERROR;
-	    sprintf (myTokenSource, "cvs/%s", hostname);
+	    snprintf (myTokenSource, sizeof(myTokenSource), "cvs/%s", hostname);
 	}
 	else
 	{
@@ -725,7 +725,8 @@ int ClientAuthenticate(const char *protocol, const char *name, const char *pwd, 
 		rc = AcquireCredentialsHandle( NULL, (char*)protocol, SECPKG_CRED_OUTBOUND, NULL, &cred, NULL, NULL, &credHandle, &useBefore );
 
 		ctxReq = /*ISC_REQ_ALLOCATE_MEMORY |*/ ISC_REQ_REPLAY_DETECT | ISC_REQ_SEQUENCE_DETECT | ISC_REQ_CONFIDENTIALITY | ISC_REQ_EXTENDED_ERROR | ISC_REQ_MUTUAL_AUTH | ISC_REQ_STREAM;
-		strncpy(myTokenSource,hostname,sizeof(myTokenSource));
+		strncpy(myTokenSource,hostname,sizeof(myTokenSource)-1);
+		myTokenSource[sizeof(myTokenSource)-1]=0;
 
 		CertCloseStore(hMy,0);
 	}

--- a/cvsnt/cvsnt-2.5.05.3744/src/blob_http_processor.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/blob_http_processor.cpp
@@ -22,8 +22,8 @@ struct HttpNetworkProcessor:public BlobNetworkProcessor
     if (!res || res->status != 200)
     {
       err = res ? httplib::detail::status_message(res->status) : "unknown";
-      err += " err code";
-      err += res ? res->status : -1;
+      err += " err code ";
+      err += std::to_string(res ? res->status : -1);
       return false;
     }
     return true;

--- a/cvsnt/cvsnt-2.5.05.3744/src/blob_kv_processor.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/blob_kv_processor.cpp
@@ -14,6 +14,11 @@ inline KVRet send_blob_file_data_net(BlobSocket &client, const char *file, const
   using namespace caddressed_fs;
   using namespace streaming_compression;
   FILE* rf = fopen(file, "rb");
+  if (!rf)
+  {
+    output << "Can't open binary blob file " << file; err = output.str();
+    return KVRet::Error;
+  }
   fseek(rf, 0, SEEK_END);
   const size_t fsz = ftell(rf);
   fseek(rf, 0, SEEK_SET);

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -5782,6 +5782,8 @@ bool send_blob_file_direct(const char *file, char *hash_encoded, bool blob_binar
   init_blob_hash_context(hctx, sizeof(hctx));
   char bufIn[128<<10];
   FILE* rf = fopen(file, "rb");
+  if (!rf)
+    error(1,0, "Can't open binary blob for %s", file);
   std::vector<char> blob;blob.resize(fsz); size_t dataWritten = 0;
   StreamStatus st = compress_lambda(
     [&](const char *&src, size_t &src_pos, size_t &src_size)

--- a/cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
@@ -2052,12 +2052,10 @@ void fixaddfile (const char *file, const char *repository)
 				error (0, errno, "cannot remove %s", rcs);
 		}
 		else
-		{
 			freercsnode (&rcsfile);
-			really_quiet = save_really_quiet;
-			xfree (rcs);
-		}
+		really_quiet = save_really_quiet;
 	}
+	xfree (rcs);
 }
 
 /*

--- a/cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/commit.cpp
@@ -572,7 +572,7 @@ int commit (int argc, char **argv)
 		send_arg("-T");
 
 	if(ignore_keywords)
-		send_arg("i");
+		send_arg("-i");
 
 	if(bugid.size())
 	{

--- a/cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
@@ -247,7 +247,7 @@ void BackgroundProcessor::init()
   base_repo = repo;
   if (base_repo[0] != '/')
     base_repo = "/" + base_repo;
-  if (base_repo[base_repo.length()] != '/')
+  if (base_repo[base_repo.length()-1] != '/')
     base_repo += "/";
 
   uint32_t publicUrlsCnt = 0, privateUrlsCnt = 0;

--- a/cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/download_blob_to.cpp
@@ -45,7 +45,7 @@ struct atomic_wrapper
   atomic_wrapper():_a(){}
   atomic_wrapper(const std::atomic<T> &a):_a(a.load()){}
   atomic_wrapper(const atomic_wrapper &other):_a(other._a.load()){}
-  atomic_wrapper &operator=(const atomic_wrapper &other) {_a.store(other._a.load());}
+  atomic_wrapper &operator=(const atomic_wrapper &other) {_a.store(other._a.load()); return *this;}
   operator T() {return T(_a);}
   atomic_wrapper(const T& other) { _a = other; }
   atomic_wrapper& operator=(const T& other) { _a = other; return *this; }

--- a/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
@@ -604,7 +604,7 @@ static int check_filesdoneproc (void *callerdat, int err, char *repos, char *upd
 static int pretag_proc(void *params, const trigger_interface *cb)
 {
 	pretag_params_t *args = (pretag_params_t *)params;
-	int ret;
+	int ret = 0;
 
 	TRACE(1,"pretag_proc(%s,%s,%s,%c)",PATCH_NULL(args->directory),PATCH_NULL(args->action),PATCH_NULL(args->tag),args->tag_type);
 

--- a/known_issues.md
+++ b/known_issues.md
@@ -1,0 +1,97 @@
+# Known issues
+
+Bugs found by static audit of the Gaijin-modified CVSNT source that are **not
+yet fixed**. 17 simple, behaviour-preserving fixes landed in this iteration
+(see the git history / the fixes are each a separate commit); the 45 issues
+below were deferred because they change behaviour on a normal path, need
+64-bit protocol plumbing, are security-sensitive enough to want careful
+review, or live in sample code. Full analysis for each id (code, failure
+scenario, suggested fix) is in `_reports/<id>.md`.
+
+Legend for "why deferred": **size** = needs coordinated 64-bit size plumbing
+across client+server+buffer; **behaviour** = fix activates/alters a normal
+code path and wants a test first; **security** = network-facing/pre-auth, wants
+careful review + a regression test; **cross** = has a sibling site that must be
+fixed together; **sample** = non-shipping sample/test code.
+
+## Critical
+
+| id | file | issue | why deferred |
+|----|------|-------|--------------|
+| api-009 | protocols/sspi_unix.cpp | sspi (unix) **server**: client-controlled length drives `read()` into a fixed 1024-byte stack buffer — remote pre-auth stack overflow | security |
+
+## High
+
+| id | file | issue | why deferred |
+|----|------|-------|--------------|
+| core-011 | src/client.cpp | `send_modified` announces file size with `%lu` — truncates >4 GB on Windows, desyncs the protocol | size |
+| core-013 | src/server.cpp | receive path uses `int`/`atoi` for file size — >2 GB uploads overflow | size |
+| core-015 | src/server.cpp | `server_updated` uses 32-bit `unsigned long` + `%lu` — truncates >4 GB checkouts | size |
+| core-014 | src/server.cpp | `Blob-ref-created` branch is dead code (`vers==NULL && vers->ts_user==NULL`); can clobber untracked files | behaviour |
+| core-017 | src/rcs_checkin.cpp | `RCS_checkin` `strcat`s encoding onto a `static char[64]` every call — accumulates and overflows | behaviour |
+| core-001 | src/update.cpp | `join_file` frees the global `options` instead of the local copy — drops sticky `-kb`, possible double free | behaviour |
+| blob-001 | ca_blobs_fs/src/streaming_compressors.cpp | streaming ZLIB compressor calls `inflate()` instead of `deflate()` | behaviour (path currently unused) |
+| blob-002 | ca_blobs_fs/src/streaming_compressors.cpp | `decode_stream_blob_data` miscomputes header-part size when the header splits across chunks — remotely triggerable OOB | security |
+| api-001 | protocols/sserver.cpp | sserver auth: NULL `strcpy` on malformed scrambled password (pserver guards it, sserver doesn't) | security, cross (api-003) |
+| api-003 | protocols/sserver.cpp (win32) | same Unscramble NULL deref on win32 | security, cross (api-001) |
+| api-018 | windows-NT/win32.cpp | `BreakNameIntoParts` unbounded copy → pre-auth server stack overflow via client username | security |
+| api-022 | protocols/sspi_unix.cpp | sspi (unix) client: server-controlled length drives `tcp_read` into a fixed challenge struct | security |
+| api-014 | protocols/sspi.cpp | sspi client passes a server-controlled string as a printf format | security, cross (api-015) |
+| api-015 | protocols/sspi_unix.cpp | sspi (unix) client: same format-string bug | security, cross (api-014) |
+
+## Medium
+
+| id | file | issue | why deferred |
+|----|------|-------|--------------|
+| core-018 | src/client.cpp | `update -C`: `client_overwrite_existing` latches on and never resets, silently overwriting untracked in-the-way files | behaviour (fixed as part of the client-update-features work) |
+| core-002 | src/update.cpp | `checkout_file` frees RCS-owned version string when resurrecting during a join | behaviour |
+| core-003 | src/update.cpp | `bound_merge_by_bugid` NULL deref when the bug's earliest change is the first revision | behaviour |
+| core-007 | src/commit.cpp | `commit_fileproc` error paths skip `do_unlock_file`, leaving files write-locked on the lock server | behaviour |
+| core-009 | src/tag.cpp | `cvs tag/rtag -A -b` double-frees the revision string | behaviour |
+| core-012 | src/server.cpp | `serve_entry_extra` NULL deref if `EntryExtra` arrives before any `Entry` (remote) | security |
+| blob-003 | ca_blobs_fs/src/streaming_compressors.cpp | one-shot `decompress()` returns Error for Unpacked data on success; leaks z_stream on error | behaviour |
+| blob-006 | ca_blobs_fs/src/fileio.cpp | `blobe_fileio_pull` ignores the `from` offset — corrupts any non-zero-offset pull | behaviour |
+| blob-012 | src/client.cpp | `get_session_blob_reference_hash` unchecked `fopen` (same class as the two fixed this round) | cross |
+| blob-014 | keyValueServer/serverLib | accept loop tests the `should_stop` pointer, not `*should_stop` | behaviour |
+| blob-018 | keyValueServer/serverLib | `handle_pull` over-sends the whole blob for a bounded range request | behaviour |
+| api-002 | protocols/sserver.cpp (win32) | uses uninitialized `certonly` when the registry value is absent | behaviour |
+| api-006 | protocols/ext.cpp | `ext_disconnect` resets `current_in` twice, leaving `current_out` stale/closed | cross (api-007) |
+| api-007 | protocols/fork.cpp | `fork_disconnect`: same double-reset | cross (api-006) |
+| api-011 | cvsapi/cvs_string.cpp | `cvs::wide` UTF-8 decoder reads past end on truncated multibyte | behaviour |
+| api-012 | cvsapi/win32/FileAccess.cpp | `CFileAccess::mimetype` writes NUL at a byte index into a `wchar_t` buffer | behaviour |
+| api-013 | cvsapi/unix/SocketIO.cpp | unix `CSocketIO::recv` over-advances `m_bufpos`, dropping buffered bytes | behaviour |
+| api-017 | windows-NT/setuid.cpp | `nt_setuid` reads `lsaUserRights[0]` instead of `[n]` when building token privileges | behaviour |
+| api-020 | protocols/pserver.cpp | pserver auth: double-free + accepts bad protocol end when `server_error` returns | security |
+| api-021 | cvsservice/Service.cpp | `DoUnisonThread` races on process-global std handles across connections | behaviour |
+
+## Low
+
+| id | file | issue | why deferred |
+|----|------|-------|--------------|
+| core-006 | src/import.cpp / rcs | keyword-expansion options passed in the `nametag` slot of `RCS_checkout` | behaviour |
+| core-016 | src/entries.cpp | `Scratch_Entry`/`Rename_Entry` write a duplicate implicit-Add line into `Entries.Log` | behaviour |
+| blob-004 | ca_blobs_fs/src/streaming_compressors.cpp | one-shot `compress_stream` reads StreamType from the wrong pointer in the Unpacked branch | behaviour (path unused) |
+| blob-010 | src/blob_kv_processor.cpp | upload size via `ftell` (`long`) truncates for >2 GB blobs | size |
+| blob-013 | ca_blobs_fs/src/fileio.cpp | `pull_at_once` ignores decode failures, exposes uninitialized tail | behaviour |
+| api-008 | protocols/ext.cpp | `expand_command_line` unbounded `%`-expansion strcpy + off-by-one | security |
+| api-010 | protocols/server.cpp | server (rsh): `tcp_read` int return truncated into `unsigned char` | behaviour |
+| api-019 | cvsapi/Zeroconf.cpp | SRV parse: `size_t` underflow in `resize(i-1)` on crafted mDNS name | behaviour |
+| blob-021 | keyValueServer/sample/cafs_client.cpp | sample PUSHFILE computes the wrong chunk size | sample |
+| blob-022 | keyValueServer/sample/sample_server.cpp | `sample_server.cpp` does not compile | sample |
+
+## Recommended next iteration, in priority order
+
+1. **The >2 GB/4 GB size-truncation cluster (core-011, core-013, core-015,
+   blob-010).** This directly undermines the fork's purpose (large binaries).
+   It is one coordinated change: widen the size type to 64-bit on both sides
+   and fix the `%lu`/`atoi` formatting, plus `buf_chain_length`/`buf_length`
+   which return `int`. Needs a >2 GB round-trip test.
+2. **Network/pre-auth memory safety (api-009, api-018, api-022, blob-002,
+   api-001/003, api-014/015).** Remotely reachable; fix the copy-paste twins
+   together and add a malformed-input regression test each.
+3. **Blob-reference correctness (core-014, blob-006, blob-012).** In the
+   flagship binary path.
+4. **The remaining behaviour fixes**, each with a test written first.
+
+Sample-code issues (blob-021, blob-022) can be fixed opportunistically or the
+samples dropped from the build.


### PR DESCRIPTION
Fixes 18 defects found by a static audit of the tree. Each fix is its own commit, each is small and behaviour-preserving on the non-buggy path, and every one was verified to still build all 40 projects.

## Memory safety / crashes
- `:ssh:` KEY password parsing dereferenced a `strchr` result before its NULL check, so a stored key value with only one `;` in its tail wrote through NULL. The check now precedes the dereference, matching the block above it.
- The SSPI client formatted `cvs/<hostname>` into a 60-byte stack buffer with `sprintf`; a long hostname overflowed it. Now a `MAX_PATH` buffer with `snprintf`, and the sibling `strncpy` NUL-terminates.
- `mmap` failure returns `MAP_FAILED`, not `NULL`, but the blob store returned it directly and the caller only tested for `NULL`, so a failed mapping was used as a valid pointer.
- Two blob paths used an `fopen` result without a NULL check, crashing the client when a working file was deleted or locked between being queued and uploaded.
- `caddressed_fs::set_root` dereferenced its argument although the header documents `nullptr` as "use the default root".

## Correctness
- `commit -i` sent the argument `i` instead of `-i`. Because the server's option string starts with `+`, the bare `i` ended option parsing and every following option was read as a file name.
- `pretag_proc` returned an uninitialized value when a trigger library implements no pretag hook, so `tag`/`rtag` could fail non-deterministically with "Pre-tag check failed".
- `available_disk_space` inverted its error check and always returned the sentinel, so the proxy garbage collector never saw a full disk.
- `atomic_wrapper`'s copy-assignment had no `return` statement.
- The blob root's trailing-slash test indexed the terminating NUL, so it always appended a slash and produced `repo//`, which maps to a different storage path.
- An HTTP blob-download failure appended the status code with `operator+=(char)`, printing one garbage byte instead of the number.

## Resource handling
- `finish()` left the temporary blob on disk when it returned `WRONG_HASH`, on `fclose` failure, or on a failed rename. With server-side trust disabled a client could fill the disk with orphans.
- `exchange_session_keys` freed the already-freed encrypt context instead of the decrypt one, leaking a cipher context per handshake, and leaked the encrypt context on its own error path.
- `fixaddfile` restored the global `really_quiet` only on one branch, so a failed add silenced all later output in the same session, and leaked its path buffer.

## Diagnostics
- A proxy connect failure passed the reason as an argument to a format string with no conversion specifier, discarding it.
- Two socket error logs had two `%d` conversions but one argument.

## Also included
- Unit tests for the content-addressed blob store (push framing, dedup, existence, pull round-trip, and the `nullptr` root contract), with build instructions. All checks pass.
- `known_issues.md` lists the 45 findings **not** fixed here, grouped by severity with the reason each was deferred (coordinated 64-bit size plumbing, security review, behaviour change, or sample code) and a recommended order for the next pass.

The largest single remaining item is a cluster where the legacy non-blob transfer path truncates file sizes above 2 GB / 4 GB in both directions - it needs one coordinated change across client, server and the buffer layer, so it is deliberately not in this batch.

Depends on nothing, but `known_issues.md` refers to the report files added by the documentation pull request.
