### PR TITLE
perf: reduce per-file overhead in update and tag

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -479,6 +479,7 @@ FILE *open_file(const char *, const char *);
 List *Find_Directories(char *repository, int which, List *entries, const char *virtual_repository);
 void Entries_Close(List *entries);
 void Entries_Close_Dir(List *entries, const char *dir);
+void Entries_Log_Close_Cached();
 List *Entries_Open(int aflag, const char *update_dir);
 List *Entries_Open_Dir(int aflag, const char *dir, const char *update_dir);
 void Subdirs_Known(List *entries);

--- a/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
@@ -26,6 +26,27 @@ static Entnode *subdir_record (int, const char *, const char *);
 static FILE *entfile, *entexfile;
 static char *entfilename, *entexfilename;		/* for error messages */
 
+/* Register is called once per updated/checked-out file; opening and closing
+   both log files for every call costs 6 filesystem operations per file.
+   Instead, keep the two append handles open across consecutive Register
+   calls for the same working directory (keyed by the directory itself,
+   since the log paths are relative), flushing after every append so the
+   on-disk state after each call is exactly what the open/close-per-call
+   code produced.  The handles are closed whenever the current directory
+   changes, and before write_entries rewrites and unlinks the logs.  */
+static FILE *entlog_cache_fp, *entexlog_cache_fp;
+static char *entlog_cache_wd;		/* working directory the handles belong to */
+
+void Entries_Log_Close_Cached ()
+{
+    if (entlog_cache_fp && fclose (entlog_cache_fp) == EOF)
+		error (0, errno, "error closing %s", CVSADM_ENTLOG);
+    if (entexlog_cache_fp && fclose (entexlog_cache_fp) == EOF)
+		error (0, errno, "error closing %s", CVSADM_ENTEXTLOG);
+    entlog_cache_fp = entexlog_cache_fp = NULL;
+    xfree (entlog_cache_wd);
+}
+
 /*
  * Construct an Entnode
  */
@@ -141,6 +162,10 @@ static int write_ent_ex_proc (Node *node, void *closure)
 static void write_entries (List *list)
 {
     int sawdir;
+
+    /* The log files are unlinked below; any cached append handles must be
+       closed first (everything they wrote is already flushed).  */
+    Entries_Log_Close_Cached ();
 
     sawdir = 0;
 
@@ -396,23 +421,43 @@ void Register (List *list, const char *fname, const char *vn, const char *ts, co
 		TRACE(3,"Register(): !noexec");
 		entfilename = CVSADM_ENTLOG;
 		entexfilename = CVSADM_ENTEXTLOG;
-		entfile = CVS_FOPEN (entfilename, "a");
-		entexfile = CVS_FOPEN (entexfilename, "a");
 
-		if (entfile == NULL)
+		/* Reuse the append handles left open by the previous Register call
+		   if we are still in the same working directory (the log paths are
+		   relative); otherwise close them and open this directory's logs.  */
+		const char *wd = xgetwd ();
+		if (wd == NULL)
+			error (1, errno, "cannot get working directory");
+		if (entlog_cache_fp != NULL && fncmp (entlog_cache_wd, wd))
+			Entries_Log_Close_Cached ();
+		if (entlog_cache_fp == NULL)
 		{
-			/* Warning, not error, as in write_entries.  */
-			/* FIXME-update-dir: should be including update_dir in message.  */
-			error (0, errno, "cannot open %s", entfilename);
-			return;
+			entlog_cache_fp = CVS_FOPEN (entfilename, "a");
+			if (entlog_cache_fp == NULL)
+			{
+				/* Warning, not error, as in write_entries.  */
+				/* FIXME-update-dir: should be including update_dir in message.  */
+				error (0, errno, "cannot open %s", entfilename);
+				xfree (wd);
+				return;
+			}
+			entexlog_cache_fp = CVS_FOPEN (entexfilename, "a");
+			if (entexlog_cache_fp == NULL)
+			{
+				/* Warning, not error, as in write_entries.  */
+				/* FIXME-update-dir: should be including update_dir in message.  */
+				error (0, errno, "cannot open %s", entexfilename);
+				Entries_Log_Close_Cached ();
+				xfree (wd);
+				return;
+			}
+			entlog_cache_wd = (char *) wd;	/* takes ownership */
 		}
-		if (entexfile == NULL)
-		{
-			/* Warning, not error, as in write_entries.  */
-			/* FIXME-update-dir: should be including update_dir in message.  */
-			error (0, errno, "cannot open %s", entexfilename);
-			return;
-		}
+		else
+			xfree (wd);
+
+		entfile = entlog_cache_fp;
+		entexfile = entexlog_cache_fp;
 
 		if (fprintf (entfile, "A ") < 0)
 			error (1, errno, "cannot write %s", entfilename);
@@ -422,10 +467,15 @@ void Register (List *list, const char *fname, const char *vn, const char *ts, co
 		write_ent_proc (node, NULL);
 		write_ent_ex_proc (node, NULL);
 
-		if (fclose (entfile) == EOF)
-			error (1, errno, "error closing %s", entfilename);
-		if (fclose (entexfile) == EOF)
-			error (1, errno, "error closing %s", entexfilename);
+		/* Flush instead of closing: the on-disk log after every Register
+		   is identical to what the close-per-call code produced, while the
+		   open handles are reused by the next call.  */
+		if (fflush (entfile) == EOF)
+			error (1, errno, "cannot write %s", entfilename);
+		if (fflush (entexfile) == EOF)
+			error (1, errno, "cannot write %s", entexfilename);
+		entfile = NULL;
+		entexfile = NULL;
     }
 	TRACE(3,"Register(): finished");
 }
@@ -964,6 +1014,10 @@ void Entries_Close_Dir (List *list, const char *dir)
 
 void Entries_Close(List *list)
 {
+    /* Release any cached Entries.Log append handles; the isfile probe and
+       write_entries below expect no open handle on the log files.  */
+    Entries_Log_Close_Cached ();
+
     if (list)
     {
 		if (!noexec) 

--- a/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
@@ -269,6 +269,9 @@ void Scratch_Entry (List *list, const char *fname)
     {
 		if (!noexec)
 		{
+			/* Never hold two concurrent handles on Entries.Log: drop
+			   Register's cached append handle before opening our own.  */
+			Entries_Log_Close_Cached ();
 			entfilename = CVSADM_ENTLOG;
 			entexfilename = CVSADM_ENTEXTLOG;
 			entfile = CVS_FOPEN (entfilename, "a");
@@ -309,6 +312,9 @@ void Rename_Entry (List *list, const char *from, const char *to)
     {
 		if (!noexec)
 		{
+			/* Never hold two concurrent handles on Entries.Log: drop
+			   Register's cached append handle before opening our own.  */
+			Entries_Log_Close_Cached ();
 			entfilename = CVSADM_ENTLOG;
 			entexfilename = CVSADM_ENTEXTLOG;
 			entfile = CVS_FOPEN (entfilename, "a");
@@ -1379,6 +1385,9 @@ static Entnode *subdir_record (int cmd, const char *parent, const char *dir)
 
     if (!noexec)
     {
+	/* Never hold two concurrent handles on Entries.Log: drop Register's
+	   cached append handle before opening our own.  */
+	Entries_Log_Close_Cached ();
 	if (parent == NULL)
 	    entfilename = CVSADM_ENTLOG;
 	else

--- a/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/entries.cpp
@@ -433,7 +433,12 @@ void Register (List *list, const char *fname, const char *vn, const char *ts, co
 		   relative); otherwise close them and open this directory's logs.  */
 		const char *wd = xgetwd ();
 		if (wd == NULL)
-			error (1, errno, "cannot get working directory");
+		{
+			/* Warning, not error: a Register that cannot journal used to
+			   degrade rather than abort the whole command.  */
+			error (0, errno, "cannot get working directory");
+			return;
+		}
 		if (entlog_cache_fp != NULL && fncmp (entlog_cache_wd, wd))
 			Entries_Log_Close_Cached ();
 		if (entlog_cache_fp == NULL)

--- a/cvsnt/cvsnt-2.5.05.3744/src/rcs.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/rcs.cpp
@@ -7151,7 +7151,7 @@ static char *rcs_lockfilename (const char *rcsfile)
    first call RCS_reparsercsfile, then munge the data structures as
    desired (via RCS_delete_revs, RCS_settag, &c), then call RCS_rewrite.  */
 
-void RCS_rewrite (RCSNode *rcs, Deltatext *newdtext, char *insertpt, int compress_new_delta)
+void RCS_rewrite (RCSNode *rcs, Deltatext *newdtext, char *insertpt, int compress_new_delta, int reparse)
 {
     FILE *fout;
 	size_t lockId_temp;
@@ -7196,8 +7196,16 @@ void RCS_rewrite (RCSNode *rcs, Deltatext *newdtext, char *insertpt, int compres
     rcsbuf_close (&rcs->rcsbuf);
     rcs_internal_unlockfile (fout, rcs->path, lockId_temp);
 
+	/* The in-memory contents point into the buffer freed by rcsbuf_close,
+	   so they are always cleared here.  Re-reading and re-parsing the file
+	   we just wrote is only useful to callers that keep using the node
+	   (checkin/commit paths); callers that free the node right after the
+	   rewrite pass reparse=0 and skip that cost.  Clearing is idempotent,
+	   so the eventual freercsnode remains safe, and any unexpected later
+	   access hits NULL fields instead of stale data.  */
 	free_rcsnode_contents(rcs);
-	RCS_reparsercsfile(rcs);
+	if (reparse)
+		RCS_reparsercsfile(rcs);
 }
 
 /*

--- a/cvsnt/cvsnt-2.5.05.3744/src/rcs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/rcs.h
@@ -370,7 +370,9 @@ void RCS_addaccess (RCSNode *, char *);
 void RCS_delaccess (RCSNode *, char *);
 char *RCS_getaccess (RCSNode *);
 RETSIGTYPE rcs_cleanup (int sig);
-void RCS_rewrite (RCSNode *rcs, Deltatext *newdtext, char *insertpt, int compress_new_delta);
+/* reparse=0 skips the re-read/re-parse of the file just written; only pass 0
+   when the node is discarded without further use after the rewrite.  */
+void RCS_rewrite (RCSNode *rcs, Deltatext *newdtext, char *insertpt, int compress_new_delta, int reparse = 1);
 int rcs_change_text (const char *, char *, size_t, const char *,
 			    size_t, char **, size_t *);
 void RCS_deltas (RCSNode *, FILE *, struct rcsbuffer *, const char *,

--- a/cvsnt/cvsnt-2.5.05.3744/src/recurse.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/recurse.cpp
@@ -837,6 +837,11 @@ static int do_recursion (struct recursion_frame *frame, int top_level)
     /* call-back files done proc (if any) */
     if (process_this_directory && dodoneproc && frame->filesdoneproc != NULL)
 	{
+		/* Release Register's cached CVS/Entries.Log append handles first.
+		   A filesdoneproc may remove the whole admin directory (export
+		   does), and on Windows an open file cannot be deleted.  The
+		   handles are per-directory anyway and are reopened on demand.  */
+		Entries_Log_Close_Cached ();
 		err = frame->filesdoneproc (frame->callerdat, err, (char*)mapped_repository,
 				    (char*)(update_dir[0] ? update_dir : "."),
 				    entries);

--- a/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
@@ -5097,6 +5097,13 @@ void server_cleanup (int sig)
 	return;
     }
 
+    /* A fatal error can get us here with Register's cached Entries.Log
+       append handles still open inside the temp tree; close them so the
+       deletion below cannot be blocked by an open file.  Do this before the
+       network buffer is torn down so that a rare close error can still be
+       reported through a live connection.  */
+    Entries_Log_Close_Cached ();
+
     /* Shut down the network buffer before deleting the temp directory:
        with stream compression the shutdown emits the trailer the client
        is waiting for, while removing a large temp tree can take a long
@@ -5108,11 +5115,6 @@ void server_cleanup (int sig)
 		buf_shutdown (buf_to_net);
 		buf_to_net = NULL;
 	}
-
-    /* A fatal error can get us here with Register's cached Entries.Log
-       append handles still open inside the temp tree; close them so the
-       deletion below cannot be blocked by an open file.  */
-    Entries_Log_Close_Cached ();
 
     CVS_CHDIR (Tmpdir);
     /* Temporarily clear noexec, so that we clean up our temp directory

--- a/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
@@ -5097,6 +5097,18 @@ void server_cleanup (int sig)
 	return;
     }
 
+    /* Shut down the network buffer before deleting the temp directory:
+       with stream compression the shutdown emits the trailer the client
+       is waiting for, while removing a large temp tree can take a long
+       time.  Nothing in the deletion path below writes to the protocol
+       buffers (its errors are deliberately ignored and tracing is
+       disabled), so it does not need the connection.  */
+    if (buf_to_net != NULL)
+	{
+		buf_shutdown (buf_to_net);
+		buf_to_net = NULL;
+	}
+
     CVS_CHDIR (Tmpdir);
     /* Temporarily clear noexec, so that we clean up our temp directory
        regardless of it (this could more cleanly be handled by moving
@@ -5105,20 +5117,13 @@ void server_cleanup (int sig)
     save_noexec = noexec;
     noexec = 0;
     /* FIXME?  Would be nice to not ignore errors.  But what should we do?
-       We could try to do this before we shut down the network connection,
-       and try to notify the client (but the client might not be waiting
-       for responses).  We could try something like syslog() or our own
+       The network connection is already shut down, so we cannot notify
+       the client.  We could try something like syslog() or our own
        log file.  */
 	trace = 0;
 	if(orig_server_temp_dir)
 		unlink_file_dir (orig_server_temp_dir);
     noexec = save_noexec;
-
-    if (buf_to_net != NULL)
-	{
-		buf_shutdown (buf_to_net);
-		buf_to_net = NULL;
-	}
 
 	CProtocolLibrary lib;
 	lib.UnloadProtocol(server_protocol);

--- a/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
@@ -5109,6 +5109,11 @@ void server_cleanup (int sig)
 		buf_to_net = NULL;
 	}
 
+    /* A fatal error can get us here with Register's cached Entries.Log
+       append handles still open inside the temp tree; close them so the
+       deletion below cannot be blocked by an open file.  */
+    Entries_Log_Close_Cached ();
+
     CVS_CHDIR (Tmpdir);
     /* Temporarily clear noexec, so that we clean up our temp directory
        regardless of it (this could more cleanly be handled by moving

--- a/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/tag.cpp
@@ -31,7 +31,7 @@ static Dtype tag_dirproc(void *callerdat, char *dir,
 				 char *repos, char *update_dir,
 				 List *entries, const char *virtual_repository, Dtype hint);
 static int rtag_fileproc(void *callerdat, struct file_info *finfo);
-static int rtag_delete(RCSNode *rcsfile);
+static int rtag_delete(RCSNode *rcsfile, int reparse);
 static int tag_fileproc(void *callerdat, struct file_info *finfo);
 static int add_to_valtags(char *name);
 
@@ -675,6 +675,13 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
     if ((rcsfile = finfo->rcs) == NULL)
 		return 1;
 
+    /* After a rewrite, a regular file's node is freed as soon as this proc
+       returns, so re-parsing the file just written is wasted work.  The
+       .directory_history pseudo-file (tagged via tag_dirproc) is the
+       exception: its node belongs to the directory-mapping stack and
+       outlives us, so it must stay fully parsed.  */
+    int reparse = !strcmp (finfo->file, RCSREPOVERSION);
+
     /*
      * For tagging an RCS file which is a symbolic link, you'd best be
      * running with RCS 5.6, since it knows how to handle symbolic links
@@ -682,7 +689,7 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
      */
 
     if (delete_flag)
-		return rtag_delete (rcsfile);
+		return rtag_delete (rcsfile, reparse);
 
 	if(numtag && !date && alias_branch)
 	{
@@ -714,7 +721,7 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
 	if (version == NULL)
 	{
 		/* Clean up any old tags */
-		rtag_delete (rcsfile);
+		rtag_delete (rcsfile, reparse);
 
 		if (!quiet && !force_tag_match)
 		{
@@ -745,7 +752,7 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
 					PATCH_NULL(symtag),
 					PATCH_NULL(numtag),
 					PATCH_NULL(current_date) );
-			RCS_rewrite (rcsfile, NULL, NULL, 0);
+			RCS_rewrite (rcsfile, NULL, NULL, 0, reparse);
 			tag_set_ok = 1;
 		}
     }
@@ -808,7 +815,7 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
 					PATCH_NULL(symtag),
 					PATCH_NULL(rev),
 					PATCH_NULL(current_date) );
-	    RCS_rewrite (rcsfile, NULL, NULL, 0);
+	    RCS_rewrite (rcsfile, NULL, NULL, 0, reparse);
 		tag_set_ok = 1;
 	}
     }
@@ -843,7 +850,7 @@ static int rtag_fileproc (void *callerdat, struct file_info *finfo)
  * This is done here because it's MUCH faster than just blindly calling
  * "rcs" to remove the tag... trust me.
  */
-static int rtag_delete (RCSNode *rcsfile)
+static int rtag_delete (RCSNode *rcsfile, int reparse)
 {
     char *version;
     int retcode;
@@ -890,7 +897,7 @@ static int rtag_delete (RCSNode *rcsfile)
 	return (1);
     }
 	TRACE(3,"rtag_delete(2) rewrite rcsfile");
-    RCS_rewrite (rcsfile, NULL, NULL, 0);
+    RCS_rewrite (rcsfile, NULL, NULL, 0, reparse);
     return (0);
 }
 
@@ -910,6 +917,11 @@ static int tag_fileproc (void *callerdat, struct file_info *finfo)
 
     TRACE(3,"tag_fileproc");
     vers = Version_TS (finfo, NULL, NULL, NULL, 0, 0, 0);
+
+    /* See rtag_fileproc: skip the post-rewrite re-parse for nodes that are
+       discarded right after this proc; the .directory_history pseudo-file
+       node outlives us and keeps it.  */
+    int reparse = !strcmp (finfo->file, RCSREPOVERSION);
 
     TRACE(3,"tag_fileproc - Version_TS complete");
     if ((numtag != NULL) || (date != NULL))
@@ -1045,7 +1057,7 @@ static int tag_fileproc (void *callerdat, struct file_info *finfo)
 	TRACE(3,"tag_fileproc(1) rewrite rcsfile=\"%s\" symtag=\"%s\"",
 					PATCH_NULL(vers->srcfile->path),
 					PATCH_NULL(symtag) );
-	RCS_rewrite (vers->srcfile, NULL, NULL, 0);
+	RCS_rewrite (vers->srcfile, NULL, NULL, 0, reparse);
 
 	/* warm fuzzies */
 	if (!really_quiet)
@@ -1201,7 +1213,7 @@ static int tag_fileproc (void *callerdat, struct file_info *finfo)
 					PATCH_NULL(symtag),
 					PATCH_NULL(rev),
 					PATCH_NULL(current_date) );
-    RCS_rewrite (vers->srcfile, NULL, NULL, 0);
+    RCS_rewrite (vers->srcfile, NULL, NULL, 0, reparse);
 
     /* more warm fuzzies */
     if (!really_quiet)

--- a/suggested_optimizations.md
+++ b/suggested_optimizations.md
@@ -71,7 +71,8 @@ Each item lists what/where, expected impact, risk, and a status.
 - **Risk**: low-medium. The log write path is crash-recovery data for the
   Entries rewrite; per-append flushing keeps durability identical, and the
   close hooks preserve the open/unlink discipline on Windows.
-- **Status**: proposed
+- **Status**: implemented (commit "entries: keep the Entries.Log append
+  handles open across Register calls")
 
 ## 4. Batch or lease lockserver locks instead of two round-trips per file
 

--- a/suggested_optimizations.md
+++ b/suggested_optimizations.md
@@ -1,0 +1,214 @@
+# Suggested performance optimizations
+
+Scope: server and client hot paths of `update`, `tag`/branch and checkout on
+very large trees (hundreds of thousands of files). The dominant costs are
+fixed per-file overheads: lockserver round-trips, full `,v` header parses,
+redundant re-parses, and per-file open/close of administrative files. All
+paths below are relative to `cvsnt/cvsnt-2.5.05.3744/`.
+
+Each item lists what/where, expected impact, risk, and a status.
+
+---
+
+## 1. Skip the discarded re-parse after rewriting a `,v` in tag paths
+
+- **What/where**: `RCS_rewrite` (`src/rcs.cpp`) ends with
+  `free_rcsnode_contents()` + `RCS_reparsercsfile()` — a complete re-read and
+  re-parse (admin header plus every delta header) of the file it has just
+  written. The tag/rtag file procs (`src/tag.cpp`: `tag_fileproc`,
+  `rtag_fileproc`, `rtag_delete`) call `RCS_rewrite` as their last use of the
+  node; the node is freed immediately afterwards (`do_file_proc`,
+  `src/recurse.cpp`), so the re-parsed data is thrown away unread.
+- **Change**: add an opt-out parameter (default keeps today's behaviour) and
+  pass it from the tag-path call sites that discard the node. The
+  `.directory_history` pseudo-file is excluded: its node is owned by the
+  directory-mapping stack and outlives the file proc, so it keeps the re-parse.
+- **Expected impact**: removes 1 of the 3 full parses per tagged file (plus one
+  file open). Tagging cost per file is parse-bound, so this is a measurable
+  cut in `tag`/`rtag`/branch wall time on big modules.
+- **Risk**: low. The node's contents are cleared (idempotently, the eventual
+  `freercsnode` clears them again) instead of being rebuilt; any accidental
+  later use would hit NULL fields rather than stale data. Commit paths keep
+  the re-parse.
+- **Status**: proposed
+
+## 2. Send the network shutdown trailer before deleting the server temp sandbox
+
+- **What/where**: `server_cleanup` (`src/server.cpp`) deletes the whole
+  per-connection temporary working area (`unlink_file_dir(orig_server_temp_dir)`,
+  one filesystem entry per directory the command touched) *before* calling
+  `buf_shutdown(buf_to_net)`, which emits the compression trailer the client
+  waits for. The delete of a huge sandbox therefore sits on the client-visible
+  critical path.
+- **Change**: reorder — shut down `buf_to_net` first, then delete the temp
+  tree. The deletion path is silent (it never writes to the protocol buffers;
+  errors are deliberately ignored and tracing is disabled there), so nothing
+  it does needs the connection.
+- **Expected impact**: removes O(directories) file deletions from the tail
+  latency of every remote command; most visible on updates of wide trees.
+- **Risk**: low. Pure reorder of two independent blocks in the same function;
+  behaviour on the `dont_delete_temp` path is unchanged.
+- **Status**: proposed
+
+## 3. Keep the per-directory Entries.Log append handles open across files
+
+- **What/where**: `Register` (`src/entries.cpp`) is called once per
+  updated/checked-out file and each call does `fopen`+`fprintf`+`fclose` on
+  *both* `CVS/Entries.Log` and `CVS/Entries.Extra.Log` — 2 opens, 2 writes and
+  2 closes per file, repeated for every file in a directory.
+- **Change**: cache the two append handles between consecutive `Register`
+  calls, keyed by the current working directory; `fflush` after every append
+  (so on-disk state after each call is identical to today's), and close the
+  cached handles before `write_entries` rewrites/unlinks the logs and on
+  `Entries_Close`. Other writers (`Scratch_Entry`, `subdir_record`, …) keep
+  their own short-lived append handles; append-mode writes keep ordering
+  correct.
+- **Expected impact**: 6 filesystem calls per registered file drop to
+  amortized 1 write; biggest on checkouts/updates that touch many files per
+  directory (Windows clients benefit most, where opens are the expensive op).
+- **Risk**: low-medium. The log write path is crash-recovery data for the
+  Entries rewrite; per-append flushing keeps durability identical, and the
+  close hooks preserve the open/unlink discipline on Windows.
+- **Status**: proposed
+
+## 4. Batch or lease lockserver locks instead of two round-trips per file
+
+- **What/where**: every `RCS_parse` of every `,v` takes a lock from the lock
+  daemon over a socket and releases it when the node is freed
+  (`rcsbuf_open`/`freercsnode`, `src/rcs.cpp`; `do_lock_file`/`do_unlock_file`,
+  `src/lock.cpp`). Each is a synchronous send+receive. An update of N files
+  costs 2·N round-trips; tag costs ~6·N (two recursion passes plus the
+  write-lock pair inside the rewrite).
+- **Change**: take one directory-granular lease per repository directory
+  (read for update, write for tag) and have per-file lock/unlock reuse it;
+  or, less invasively, pipeline the unlock so it does not wait for a reply.
+- **Expected impact**: very high — removes the dominant per-file latency on
+  both update and tag for large trees.
+- **Risk**: medium. Touches locking semantics; per-file write locks inside
+  `RCS_rewrite` and the version-tracking hooks must keep working. Needs
+  careful staging and testing against a live lock daemon.
+- **Status**: proposed (deferred: changes lock-acquisition granularity; needs
+  dedicated concurrency testing)
+
+## 5. Restore lazy delta parsing in the RCS parser
+
+- **What/where**: `RCS_parsercsfile_i` (`src/rcs.cpp`) unconditionally calls
+  `RCS_reparsercsfile`, whose `getdelta` loop reads and allocates the header
+  of *every revision* in the file — even when the caller only needs
+  head/branch/symbols to decide "up to date". The comment above it still
+  describes the original lazy design.
+- **Change**: stop the initial parse at the first revision key; parse delta
+  headers on first access behind a "partial" flag checked at the version-list
+  access points.
+- **Expected impact**: high — server CPU and read volume per file drop from
+  O(revisions) to O(1) for the common unchanged-file path.
+- **Risk**: medium. Every direct user of `rcs->versions` must honour the
+  partial flag; Attic and magic-branch edge cases need auditing.
+- **Status**: proposed (deferred: broad blast radius in the parser core)
+
+## 6. Per-directory cache of parsed `,v` head state
+
+- **What/where**: there is no cache of parse results anywhere; unchanged files
+  are re-opened and re-parsed on every command. A per-repository-directory
+  cache file holding `(name, size, mtime, head, kopt, dead, symbols)` would
+  let the server answer HEAD/tag classification for unchanged files with one
+  `stat` per `,v` and no open/parse/lock at all.
+- **Expected impact**: very high for "nothing changed" updates (order of
+  magnitude on the per-file server cost), also accelerates branch updates.
+- **Risk**: medium — correctness hinges on strict invalidation
+  (size+mtime validation, rewrite-via-rename keeps them fresh) and on cache
+  updates being advisory only.
+- **Status**: proposed (deferred: needs its own design/testing round)
+
+## 7. Single-pass tag when no pre-tag trigger is configured
+
+- **What/where**: `rtag_proc` (`src/tag.cpp`) always runs two full recursions:
+  a check pass (`check_fileproc`) that parses every file to build the trigger
+  list, then the tag pass that parses every file again. When no pretag trigger
+  is installed and up-to-date checking is off, the first pass's results are
+  used for nothing except permission checks.
+- **Change**: when no trigger is configured, fold the checks into the tag pass
+  and skip the first recursion.
+- **Expected impact**: medium-high — halves the remaining parse+lock cost of
+  tag/branch.
+- **Risk**: medium. The two-pass structure is load-bearing when triggers
+  exist; the fold must replicate the permission/up-to-date checks exactly.
+- **Status**: proposed (deferred: behavioural surface around triggers)
+
+## 8. Parallelize the server-side per-file tag loop
+
+- **What/where**: `do_recursion` (`src/recurse.cpp`) processes files strictly
+  sequentially. Tagging touches independent files; only output, history
+  append and the lockserver socket are shared.
+- **Expected impact**: high on multi-core servers (near-linear for the
+  rewrite-bound part of tag).
+- **Risk**: high. Statics in the RCS lock path (`rcs_lockfile`, `rcs_lockfd`),
+  the shared lockserver socket and error handling are all thread-unsafe today.
+- **Status**: proposed (deferred: requires a thread-safety audit first)
+
+## 9. Cheaper Windows stat for working files
+
+- **What/where**: on Windows the default stat path
+  (`wnt_stat`/`wnt_lstat`, `windows-NT/win32.cpp`) opens every existing file
+  (`CreateFile` + `NtQueryEaFile` + `CloseHandle`) just to fetch a fake Unix
+  mode from extended attributes; the client stats every working file at least
+  once per update. Setting the environment variable `CVSNT=nontea` already
+  disables this today and is a good mitigation on client machines.
+- **Change**: skip the extended-attribute read where the caller only needs
+  timestamps/size, or change the client-side default; keep `CVSNT=ntea` as
+  opt-in.
+- **Expected impact**: high on Windows clients (removes a real file open per
+  file per update — the syscall AV filters make most expensive).
+- **Risk**: low for a fast-path variant; a default flip changes
+  executable-bit fidelity for interop setups, so it needs a deliberate
+  decision.
+- **Status**: proposed (default behaviour intentionally left unchanged; use
+  `CVSNT=nontea` as an immediate mitigation)
+
+## 10. Avoid opening the directory-version state three times per directory
+
+- **What/where**: for each directory, update runs `open_directory` twice in
+  `update_predirent_proc` (`src/update.cpp`) and a third time in
+  `do_dir_proc` (`src/recurse.cpp`); each call probes for
+  `.directory_history,v` (and on repositories that have it, re-parses and
+  re-checks-out the mapping). The code carries a FIXME about it.
+- **Analysis result**: the two calls in `update_predirent_proc` are *not*
+  redundant — they intentionally open an old-version/new-version pair that
+  `upgrade_entries` consumes from the directory stack. Only the third call
+  repeats work, and reusing it means carrying pushed stack state (parsed
+  mapping node, rename scripts) across the recursion boundary.
+- **Expected impact**: medium on repositories using directory versioning;
+  small elsewhere (a few failed probes per directory).
+- **Risk**: medium — the directory stack has push/pop side effects that
+  `upgrade_entries` depends on positionally.
+- **Status**: proposed (deferred: safe memoization needs a larger refactor of
+  the directory-stack lifecycle)
+
+## 11. Directory-level manifest short-circuit in the protocol
+
+- **What/where**: the client sends one `Entry`+`Unchanged` pair per file and
+  the server classifies each file separately, even when an entire directory
+  is unchanged. A negotiated per-directory digest (client sends a hash of its
+  entries state; server compares against a cached repository-side digest)
+  would let both sides skip unchanged directories wholesale.
+- **Expected impact**: very high — turns the "nothing changed" update from
+  O(files) into O(directories).
+- **Risk**: high. New protocol request (must be negotiated so old
+  clients/servers are unaffected) and it depends on a reliable server-side
+  state cache (item 6).
+- **Status**: proposed (deferred: protocol change)
+
+## 12. Blob download pool tuning
+
+- **What/where**: the client's parallel blob downloader
+  (`src/download_blob_to.cpp`) caps its thread pool at
+  `min(8, hardware_concurrency-1)`; each queued blob costs one request on a
+  persistent connection.
+- **Change**: make the cap a first-class configurable (it is env-only today)
+  and/or pipeline small-blob requests per connection.
+- **Expected impact**: medium for updates fetching many small binary files on
+  low-latency links.
+- **Risk**: low, but it is client throughput tuning rather than a structural
+  fix, and needs network benchmarks to pick defaults.
+- **Status**: proposed (deferred: needs measurement infrastructure to justify
+  new defaults)

--- a/suggested_optimizations.md
+++ b/suggested_optimizations.md
@@ -30,7 +30,8 @@ Each item lists what/where, expected impact, risk, and a status.
   `freercsnode` clears them again) instead of being rebuilt; any accidental
   later use would hit NULL fields rather than stale data. Commit paths keep
   the re-parse.
-- **Status**: proposed
+- **Status**: implemented (commit "tag: skip the discarded re-parse after
+  RCS_rewrite")
 
 ## 2. Send the network shutdown trailer before deleting the server temp sandbox
 

--- a/suggested_optimizations.md
+++ b/suggested_optimizations.md
@@ -48,7 +48,8 @@ Each item lists what/where, expected impact, risk, and a status.
   latency of every remote command; most visible on updates of wide trees.
 - **Risk**: low. Pure reorder of two independent blocks in the same function;
   behaviour on the `dont_delete_temp` path is unchanged.
-- **Status**: proposed
+- **Status**: implemented (commit "server: send the shutdown trailer before
+  deleting the temp sandbox")
 
 ## 3. Keep the per-directory Entries.Log append handles open across files
 


### PR DESCRIPTION
`update`, `tag` and branch time on large trees is dominated by fixed per-file overhead on the server rather than by the amount of data. `suggested_optimizations.md` records the full set of candidates with their expected effect and risk; this pull request implements the three that are local, safe and need no protocol or locking change, and leaves the rest marked as proposed with the reason each was deferred.

## Implemented

**Skip the discarded re-parse after `RCS_rewrite` in the tag paths.** After rewriting a `,v`, `RCS_rewrite` re-parsed the file it had just written, and the tag file procedures immediately discarded the result - one of the three full parses per tagged file. `RCS_rewrite` gained a defaulted parameter so only the tag paths opt out; every other caller is unchanged. The `.directory_history` pseudo-file is explicitly excluded because its node is owned by the directory stack and outlives the file procedure.

**Keep the `CVS/Entries.Log` append handles open across `Register` calls.** Registering a file opened and closed both journals every time. They are now cached per working directory and flushed after every append, so the on-disk state after each call is exactly what the previous code produced, and closed whenever the directory changes, before the journals are rewritten, and at the end of a directory.

**Send the stream-shutdown trailer before deleting the server's temporary tree.** With stream compression the shutdown emits the trailer the client waits for, while removing a large temporary tree can take a long time; the delete no longer sits on the client-visible critical path.

## Deferred (recorded, not implemented)
Lock-server leasing, lazy delta parsing, a validated head/symbols cache, single-pass tag, parallelizing the tag loop, and a negotiated per-directory manifest digest - each changes locking semantics, the parser core, or the protocol, and wants its own design and testing round. The Windows extended-attribute `stat` default is deliberately left alone; the document records the existing environment setting as a zero-code mitigation.

## Verification
Every change was built and then exercised against a scratch repository: import, checkout, commit, update, `tag`, `rtag`, branch, tag deletion, `log` of a rewritten `,v` with its symbols intact, and a fresh checkout of a new branch.

Two rounds of review were run over these commits and their findings are addressed in the branch. The last one caught a real regression worth calling out: because a files-done callback may remove the whole `CVS` directory - `export` does exactly that - and it runs before the end-of-directory close, the cached journal handles were still open, and Windows cannot delete an open file. Every exported directory reported "cannot remove CVS directory", and the failed recursive delete left the process in the wrong working directory so subdirectories were exported into `mod/CVS/` instead of `mod/`. The handles are now released before the callback; this was reproduced with the fix reverted and confirmed clean with it applied.
