### PR TITLE
update: rename-aside under -C, --no-sharp-files, and -exc path exclusion

### DIFF
--- a/cvsnt/cvsnt-2.5.05.3744/src/classify.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/classify.cpp
@@ -106,11 +106,30 @@ Ctype Classify_File (struct file_info *finfo, const char *tag, const char *date,
 	}
 	else if (!pipeout && vers->ts_user && No_Difference(finfo, vers, (kf.flags&KFLAG_STATIC || kf_ent.flags&KFLAG_STATIC), ignore_keywords))
 	{
-	    /* the files were different so it is a conflict */
-	    if (!really_quiet)
-		error (0, 0, "move away %s; it is in the way",
-		       fn_root(finfo->fullname));
-	    ret = T_CONFLICT;
+	    /* The files were different, so the untracked user file is in
+	       the way.  Under "update -C" move it aside (recoverably) and
+	       check the repository copy out in its place; otherwise this
+	       is the historical conflict.  */
+	    char *aside_name = NULL;
+
+	    if (update_inway_rename_aside && !noexec)
+		aside_name = rename_file_aside (finfo->file);
+
+	    if (aside_name != NULL)
+	    {
+		if (!really_quiet)
+		    error (0, 0, "in-the-way file %s moved to %s",
+			   fn_root(finfo->fullname), aside_name);
+		xfree (aside_name);
+		ret = T_CHECKOUT;
+	    }
+	    else
+	    {
+		if (!really_quiet)
+		    error (0, 0, "move away %s; it is in the way",
+			   fn_root(finfo->fullname));
+		ret = T_CONFLICT;
+	    }
 	}
 	else
 	{

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -1432,6 +1432,88 @@ time_t get_file_mtime(const char *filename)
 }
 static char *time_stamp (time_t mtime, int local);
 
+/* The files (full pathnames, as in finfo->fullname) whose local
+   modifications "update -C" tossed during the send phase.  Because -C
+   sends no contents, the server answers with "Created" for them, and the
+   receive phase must let exactly these files be replaced instead of
+   treating them as untracked in-the-way files.  This is the per-file
+   replacement for the old process-wide client_overwrite_existing latch,
+   which used to disable the in-the-way protection for every file in the
+   rest of the run once a single modified file had been backed up.  */
+static List *client_reverted_files;
+
+/* Record that the send phase reverted FULLNAME under "update -C".  */
+static void remember_reverted_file (const char *fullname)
+{
+    Node *p;
+
+    if (client_reverted_files == NULL)
+	client_reverted_files = getlist ();
+    p = getnode ();
+    p->type = FILES;
+    p->key = xstrdup (fullname);
+    if (addnode (client_reverted_files, p) != 0)
+	freenode (p);
+}
+
+/* Strip any leading "./" components so that receive-phase pathnames
+   ("./a.txt") compare equal to send-phase fullnames ("a.txt").  */
+static const char *strip_dotslash (const char *path)
+{
+    while (path[0] == '.' && ISDIRSEP (path[1]))
+	path += 2;
+    return path;
+}
+
+/* Under "update -C", try to move an untracked in-the-way file aside (to
+   ".#_notversioned.<file>.<timestamp>") so that the incoming repository
+   copy can be checked out in its place in the same pass.
+
+   The decision is made here, for this one file, at the moment its own
+   response is processed -- deliberately not via a flag latched while some
+   other file was being sent, which used to silently overwrite in-the-way
+   files once any modified file had been backed up.
+
+   Returns 1 if the path is now clear and the checkout can proceed, 0 to
+   keep the historical "move away <file>; it is in the way" failure.  The
+   case-insensitive clash handling is left to the caller.  */
+static int inway_rename_aside (const char *filename, const char *short_pathname)
+{
+    char *realfilename = NULL;
+    char *aside_name;
+
+    /* A file whose local modifications were tossed by this run's own
+       "update -C" send phase is not in the way: replace it (the backup,
+       if wanted, was already made when it was sent).  */
+    if (client_reverted_files != NULL
+	&& findnode_fn (client_reverted_files,
+			strip_dotslash (short_pathname)) != NULL)
+	return 1;
+
+    if (!update_inway_rename_aside)
+	return 0;
+
+    /* A name that differs only in case is handled by the existing
+       case-ambiguity path in our caller, not here.  */
+    if (filenames_case_insensitive && !case_isfile (filename, &realfilename))
+    {
+	xfree (realfilename);
+	return 0;
+    }
+
+    aside_name = rename_file_aside (filename);
+    if (aside_name == NULL)
+    {
+	error (0, 0, "cannot move %s aside; it is in the way", short_pathname);
+	return 0;
+    }
+
+    if (!really_quiet)
+	error (0, 0, "in-the-way file %s moved to %s", short_pathname, aside_name);
+    xfree (aside_name);
+    return 1;
+}
+
 /* Update the Entries line for this file.  */
 static void update_entries (char *data_arg, List *ent_list, char *short_pathname, char *filename)
 {
@@ -1541,7 +1623,8 @@ static void update_entries (char *data_arg, List *ent_list, char *short_pathname
 		xfree(realfilename);
 	}
 	else
-	if (data->existp == UPDATE_ENTRIES_NEW && !client_overwrite_existing && isfile (filename))
+	if (data->existp == UPDATE_ENTRIES_NEW && !client_overwrite_existing && isfile (filename)
+	    && !inway_rename_aside (filename, short_pathname))
 	{
 	    /* Emit a warning and refuse to update the file; we don't want
 	       to clobber a user's file.  */
@@ -2403,7 +2486,8 @@ static void update_blob_ref_entries (char *data_arg, List *ent_list, char *short
     {
     	xfree(realfilename);
     }
-    else if (data->existp == UPDATE_ENTRIES_NEW && !client_overwrite_existing && isfile (filename))
+    else if (data->existp == UPDATE_ENTRIES_NEW && !client_overwrite_existing && isfile (filename)
+             && !inway_rename_aside (filename, short_pathname))
     {
       if (filenames_case_insensitive && !case_isfile(filename,&realfilename))
       {
@@ -5444,7 +5528,13 @@ static int send_fileproc (void *callerdat, struct file_info *finfo)
     							filename, bakname);
     				xfree (bakname);
                 }
-				client_overwrite_existing = 1;
+				/* This used to latch the process-wide
+				   client_overwrite_existing flag on, which from that
+				   point on silently overwrote every untracked
+				   in-the-way file in the rest of the run.  Instead,
+				   remember this one file so that only its own
+				   "Created" response may replace it.  */
+				remember_reverted_file (finfo->fullname);
 			}
 		}
 		else
@@ -5958,6 +6048,9 @@ void send_files (int argc, char **argv, int local, int aflag, unsigned int flags
     args.no_contents = flags & SEND_NO_CONTENTS;
     args.blob_contents = !(flags & SEND_NO_BLOBS_CONTENT);
     args.backup_modified = flags & BACKUP_MODIFIED_FILES;
+    /* Start each send phase with a clean per-file revert list.  */
+    if (client_reverted_files != NULL)
+	dellist (&client_reverted_files);
     err = start_recursion
 	(send_fileproc, send_filesdoneproc, (PREDIRENTPROC) NULL,
 	 send_dirent_proc, send_dirleave_proc, (void *) &args,

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -1267,15 +1267,13 @@ static void copy_a_file (char *data, List *ent_list, char *short_pathname, char 
     if (last_component (newname) != newname)
 	error (1, 0, "protocol error: Copy-file tried to specify directory");
 
-    /* Under --no-sharp-files the server's instruction to make a ".#"
-       backup copy is consumed but not acted upon.  */
-    if (update_no_sharp_files
-	&& strncmp (newname, BAKPREFIX, sizeof (BAKPREFIX) - 1) == 0)
-    {
-	xfree (newname);
-	return;
-    }
-
+    /* The server's Copy-file instruction is always honoured, even under
+       --no-sharp-files.  It arrives *before* the content that replaces the
+       working file, so the client cannot tell whether the imminent overwrite
+       preserves the user's work (a text merge, whose result carries conflict
+       markers) or destroys it (a nonmergeable/binary conflict, where this
+       copy becomes the only remaining copy of the user's version).  Skipping
+       it would silently discard uncommitted changes in the latter case.  */
     copy_file (filename, newname, 1, 1);
     xfree (newname);
 }
@@ -1567,7 +1565,9 @@ static int inway_rename_aside (const char *filename, const char *short_pathname)
 			strip_dotslash (short_pathname)) != NULL)
 	return 1;
 
-    if (!update_inway_rename_aside)
+    /* "cvs -n update" must not touch the working directory.  (The server
+       sends no content under -n, so this is belt-and-braces.)  */
+    if (!update_inway_rename_aside || noexec)
 	return 0;
 
     /* A name that differs only in case is handled by the existing

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -809,6 +809,12 @@ static List *last_entries;
 
 static char *last_dir_name;
 
+/* Nonzero while a response for a path excluded with "update -exc" is
+   being processed: the response handler must consume the response's
+   payload from the wire and do nothing else (no directory creation, no
+   file writes, no Entries changes).  */
+static int client_excluded_response;
+
 static void call_in_directory (char *pathname, void (*func)(char *data, List *ent_list, char *short_pathname, char *filename), char *data)
 {
     char *dir_name;
@@ -893,8 +899,6 @@ static void call_in_directory (char *pathname, void (*func)(char *data, List *en
     }
     else
 	*p = '\0';
-    if (client_prune_dirs)
-		add_prune_candidate (dir_name);
 
     filename = strrchr (short_repos, '/');
     if (filename == NULL)
@@ -905,6 +909,26 @@ static void call_in_directory (char *pathname, void (*func)(char *data, List *en
     short_pathname = (char*)xmalloc (strlen (pathname) + strlen (filename) + 5);
     strcpy (short_pathname, pathname);
     strcat (short_pathname, filename);
+
+    /* "update -exc": a response for an excluded path is consumed (its
+       payload is read off the wire by the handler) but acted upon in no
+       way, so excluded files and directories are neither created nor
+       updated.  Note that no directories are created and no prune
+       candidate is recorded for it.  */
+    if (path_excluded (dir_name) || path_excluded (short_pathname))
+    {
+	client_excluded_response = 1;
+	(*func) (data, (List *) NULL, short_pathname, filename);
+	client_excluded_response = 0;
+	xfree (dir_name);
+	xfree (reposdirname);
+	xfree (short_pathname);
+	xfree (reposname);
+	return;
+    }
+
+    if (client_prune_dirs)
+		add_prune_candidate (dir_name);
 
     if (last_dir_name == NULL
 	|| strcmp (last_dir_name, dir_name) != 0)
@@ -1187,11 +1211,55 @@ warning: server is not creating directories one at a time");
     xfree (reposname);
 }
 
+/* Read SIZE bytes of response payload from the server and discard them.
+   Used when a response for a path excluded with "update -exc" must be
+   consumed without being acted upon.  */
+static void discard_from_server (int size)
+{
+    char buf[8192];
+    size_t usize;
+    size_t nread;
+    size_t toread;
+
+    if (size <= 0)
+	return;
+    usize = (size_t) size;
+    nread = 0;
+    while (nread < usize)
+    {
+	toread = usize - nread;
+	if (toread > sizeof buf)
+	    toread = sizeof buf;
+	nread += try_read_from_server (buf, toread);
+    }
+}
+
+/* Read a counted file (as in read_counted_file) and discard it.  */
+static void discard_counted_file (void)
+{
+    char *size_string;
+    int size;
+
+    read_line (&size_string);
+    if (size_string[0] == 'z')
+	error (1, 0,
+	       "protocol error: compressed files not supported for that operation");
+    size = atoi (size_string);
+    xfree (size_string);
+    discard_from_server (size);
+}
+
 static void copy_a_file (char *data, List *ent_list, char *short_pathname, char *filename)
 {
     char *newname;
 
     read_line (&newname);
+
+    if (client_excluded_response)
+    {
+	xfree (newname);
+	return;
+    }
 
     /* cvsclient.texi has said for a long time that newname must be in the
        same directory.  Wouldn't want a malicious or buggy server overwriting
@@ -1555,6 +1623,38 @@ static void update_entries (char *data_arg, List *ent_list, char *short_pathname
 #endif
     time_t file_mtime = 0;
     read_line (&entries_line);
+
+    if (client_excluded_response)
+    {
+	/* "update -exc": consume the payload, act on nothing.  */
+	if (data->contents == UPDATE_ENTRIES_UPDATE
+	    || data->contents == UPDATE_ENTRIES_PATCH
+	    || data->contents == UPDATE_ENTRIES_RCS_DIFF)
+	{
+	    char *mode_string;
+	    char *size_string;
+
+	    read_line (&mode_string);
+	    xfree (mode_string);
+	    read_line (&size_string);
+	    discard_from_server (atoi (size_string));
+	    xfree (size_string);
+	}
+	xfree (entries_line);
+	if (stored_mode != NULL)
+	{
+	    xfree (stored_mode);
+	    stored_mode = NULL;
+	}
+	stored_modtime_valid = 0;
+	stored_checksum_valid = 0;
+	if (updated_fname != NULL)
+	{
+	    xfree (updated_fname);
+	    updated_fname = NULL;
+	}
+	return;
+    }
 
     /*
      * Parse the entries line.
@@ -2419,6 +2519,33 @@ static void update_blob_ref_entries (char *data_arg, List *ent_list, char *short
 
   read_line (&entries_line);
 
+  if (client_excluded_response)
+  {
+      /* "update -exc": consume the payload, act on nothing.  */
+      char *mode_string;
+      char *size_string;
+
+      read_line (&mode_string);
+      xfree (mode_string);
+      read_line (&size_string);
+      discard_from_server (atoi (size_string));
+      xfree (size_string);
+      xfree (entries_line);
+      if (stored_mode != NULL)
+      {
+	  xfree (stored_mode);
+	  stored_mode = NULL;
+      }
+      stored_modtime_valid = 0;
+      stored_checksum_valid = 0;
+      if (updated_fname != NULL)
+      {
+	  xfree (updated_fname);
+	  updated_fname = NULL;
+      }
+      return;
+  }
+
   /*
    * Parse the entries line.
    */
@@ -2434,7 +2561,7 @@ static void update_blob_ref_entries (char *data_arg, List *ent_list, char *short
   if ((cp = strchr (vn, '/')) == NULL)
       error (1, 0, "bad entries line `%s' from server", entries_line);
   *cp++ = '\0';
-  
+
   ts = cp;
   if ((cp = strchr (ts, '/')) == NULL)
       error (1, 0, "bad entries line `%s' from server", entries_line);
@@ -2446,7 +2573,7 @@ static void update_blob_ref_entries (char *data_arg, List *ent_list, char *short
       error (1, 0, "bad entries line `%s' from server", entries_line);
   *cp++ = '\0';
   tag_or_date = cp;
-  
+
   /* If a slash ends the tag_or_date, ignore everything after it.  */
   cp = strchr (tag_or_date, '/');
   if (cp != NULL)
@@ -2726,6 +2853,28 @@ static void update_meta_entries (char *data_arg, List *ent_list, char *short_pat
 #endif
 
   read_line (&entries_line);
+
+  if (client_excluded_response)
+  {
+      /* "update -exc": consume the payload, act on nothing.  */
+      char *mode_string;
+
+      read_line (&mode_string);
+      xfree (mode_string);
+      xfree (entries_line);
+      if (stored_mode != NULL)
+      {
+	  xfree (stored_mode);
+	  stored_mode = NULL;
+      }
+      stored_modtime_valid = 0;
+      if (updated_fname != NULL)
+      {
+	  xfree (updated_fname);
+	  updated_fname = NULL;
+      }
+      return;
+  }
 
   /*
    * Parse the entries line.
@@ -3048,6 +3197,17 @@ static void update_baserev(char *data, List *ent_list, char *short_pathname, cha
 
 	read_line(&type);
 
+	if (client_excluded_response)
+	{
+		/* "update -exc": consume the payload, act on nothing.  */
+		if (type[0] == 'U')
+			discard_counted_file ();
+		xfree (type);
+		xfree (basepathgz);
+		xfree (basepath);
+		return;
+	}
+
 	TRACE(3,"Updating base revision %s [%c]",basepath,type[0]);
 	switch(type[0])
 	{
@@ -3085,6 +3245,9 @@ static void handle_update_baserev(char *args, int len)
 
 static void remove_entry (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+    if (client_excluded_response)
+	return;
+
     Scratch_Entry (ent_list, filename);
 }
 
@@ -3095,6 +3258,9 @@ static void handle_remove_entry (char *args, int len)
 
 static void remove_entry_and_file (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+    if (client_excluded_response)
+	return;
+
     Scratch_Entry (ent_list, filename);
     /* Note that we don't ignore existence_error's here.  The server
        should be sending Remove-entry rather than Removed in cases
@@ -3110,6 +3276,12 @@ static void rename_entry_and_file (char *data, List *ent_list, char *short_pathn
 	char *renamed_to;
 
     read_line (&renamed_to);
+
+    if (client_excluded_response)
+    {
+	xfree (renamed_to);
+	return;
+    }
 
     Rename_Entry (ent_list, filename, renamed_to);
 
@@ -3153,6 +3325,10 @@ static void handle_module_expansion(char *args, int len)
 static void set_static (char *data, List *ent_list, char *short_pathname, char *filename)
 {
     FILE *fp;
+
+    if (client_excluded_response)
+	return;
+
     fp = open_file (CVSADM_ENTSTAT, "w+");
     if (fclose (fp) == EOF)
         error (1, errno, "cannot close %s", CVSADM_ENTSTAT);
@@ -3171,12 +3347,18 @@ static void handle_set_static_directory (char *args, int len)
 
 static void clear_static (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+    if (client_excluded_response)
+	return;
+
     if (unlink_file (CVSADM_ENTSTAT) < 0 && ! existence_error (errno))
         error (1, errno, "cannot remove file %s", CVSADM_ENTSTAT);
 }
 
 static void clear_rename (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+	if (client_excluded_response)
+		return;
+
 	if (unlink_file (CVSADM_RENAME) < 0 && ! existence_error(errno))
         error (1, errno, "cannot remove file %s", CVSADM_RENAME);
 }
@@ -3228,6 +3410,12 @@ static void set_sticky (char *data, List *ent_list, char *short_pathname, char *
 
     read_line (&tagspec);
 
+    if (client_excluded_response)
+    {
+	xfree (tagspec);
+	return;
+    }
+
     /* FIXME-update-dir: error messages should include the directory.  */
     f = CVS_FOPEN (CVSADM_TAG, "w+");
     if (f == NULL)
@@ -3277,6 +3465,9 @@ static void handle_set_sticky (char *pathname, int len)
 
 static void clear_sticky (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+    if (client_excluded_response)
+	return;
+
     if (unlink_file (CVSADM_TAG) < 0 && ! existence_error (errno))
 		error (1, errno, "cannot remove %s", CVSADM_TAG);
 }
@@ -3305,6 +3496,12 @@ static void handle_clear_sticky (char *pathname, int len)
 
 static void templat (char *data, List *ent_list, char *short_pathname, char *filename)
 {
+    if (client_excluded_response)
+    {
+	discard_counted_file ();
+	return;
+    }
+
     /* FIXME: should be computing second argument from CVSADM_TEMPLATE
        and short_pathname.  */
     read_counted_file (CVSADM_TEMPLATE, "<CVS/Template file>");
@@ -5397,6 +5594,25 @@ static int send_fileproc (void *callerdat, struct file_info *finfo)
     const char *filename;
 
     TRACE(3,"send_fileproc (1)");
+
+    /* "update -exc": excluded files are not mentioned to the server at
+       all; any response the server sends for them regardless is dropped
+       by the receive phase.  Still record the file in this directory's
+       ignore list so that it is not reported as unknown ("? file").  */
+    if (path_excluded (finfo->fullname))
+    {
+	if (ignlist)
+	{
+	    Node *p;
+
+	    p = getnode ();
+	    p->type = FILES;
+	    p->key = xstrdup (finfo->file);
+	    (void) addnode (ignlist, p);
+	}
+	return 0;
+    }
+
     send_a_repository ("", finfo->repository, finfo->update_dir);
 
     xfinfo = *finfo;
@@ -5626,6 +5842,12 @@ static Dtype send_dirent_proc (void *callerdat, char *dir, char *repository, cha
 	    error (0, 0, "Ignoring %s", update_dir);
         return (R_SKIP_ALL);
     }
+
+    /* "update -exc": do not send excluded directories at all, so the
+       server neither updates nor recreates them.  Whatever it streams
+       for them anyway (e.g. under -d) is dropped by the receive phase.  */
+    if (path_excluded (update_dir))
+        return (R_SKIP_ALL);
 
     /*
      * If the directory does not exist yet (e.g. "cvs update -d foo"),
@@ -6184,12 +6406,16 @@ static void notified_a_file (char *data, List *ent_list, char *short_pathname, c
     FILE *fp;
     FILE *newf;
     size_t line_len = 8192;
-    char *line = (char*)xmalloc (line_len);
+    char *line;
     char *cp;
     int nread;
     int nwritten;
     char *p;
 
+    if (client_excluded_response)
+	return;
+
+    line = (char*)xmalloc (line_len);
     fp = open_file (CVSADM_NOTIFY, "r");
 	if(!fp)
 	{

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -1199,6 +1199,15 @@ static void copy_a_file (char *data, List *ent_list, char *short_pathname, char 
     if (last_component (newname) != newname)
 	error (1, 0, "protocol error: Copy-file tried to specify directory");
 
+    /* Under --no-sharp-files the server's instruction to make a ".#"
+       backup copy is consumed but not acted upon.  */
+    if (update_no_sharp_files
+	&& strncmp (newname, BAKPREFIX, sizeof (BAKPREFIX) - 1) == 0)
+    {
+	xfree (newname);
+	return;
+    }
+
     copy_file (filename, newname, 1, 1);
     xfree (newname);
 }
@@ -5517,7 +5526,7 @@ static int send_fileproc (void *callerdat, struct file_info *finfo)
 
 			if (args->backup_modified)
 			{
-                if (backup_local_files)
+                if (backup_local_files && !update_no_sharp_files)
                 {
     				char *bakname;
     				bakname = backup_file (filename, vers->vn_user);

--- a/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/client.cpp
@@ -1517,6 +1517,15 @@ static char *time_stamp (time_t mtime, int local);
    rest of the run once a single modified file had been backed up.  */
 static List *client_reverted_files;
 
+/* Strip any leading "./" components so that receive-phase pathnames
+   ("./a.txt") compare equal to send-phase fullnames ("a.txt").  */
+static const char *strip_dotslash (const char *path)
+{
+    while (path[0] == '.' && ISDIRSEP (path[1]))
+	path += 2;
+    return path;
+}
+
 /* Record that the send phase reverted FULLNAME under "update -C".  */
 static void remember_reverted_file (const char *fullname)
 {
@@ -1526,18 +1535,11 @@ static void remember_reverted_file (const char *fullname)
 	client_reverted_files = getlist ();
     p = getnode ();
     p->type = FILES;
-    p->key = xstrdup (fullname);
+    /* Normalize exactly as the lookup does, so a leading "./" on either side
+       cannot make a reverted file miss the list.  */
+    p->key = xstrdup (strip_dotslash (fullname));
     if (addnode (client_reverted_files, p) != 0)
 	freenode (p);
-}
-
-/* Strip any leading "./" components so that receive-phase pathnames
-   ("./a.txt") compare equal to send-phase fullnames ("a.txt").  */
-static const char *strip_dotslash (const char *path)
-{
-    while (path[0] == '.' && ISDIRSEP (path[1]))
-	path += 2;
-    return path;
 }
 
 /* Under "update -C", try to move an untracked in-the-way file aside (to
@@ -1653,6 +1655,11 @@ static void update_entries (char *data_arg, List *ent_list, char *short_pathname
 	    xfree (updated_fname);
 	    updated_fname = NULL;
 	}
+	/* The pending EntriesExtra belongs to this excluded file and is
+	   matched by bare filename, so it must not be left for a later
+	   same-named file in another directory.  */
+	xfree (extra_entry);
+	extra_entry = NULL;
 	return;
     }
 
@@ -2543,6 +2550,10 @@ static void update_blob_ref_entries (char *data_arg, List *ent_list, char *short
 	  xfree (updated_fname);
 	  updated_fname = NULL;
       }
+      /* See update_entries: the pending EntriesExtra is matched by bare
+	 filename, so drop this excluded file's copy.  */
+      xfree (extra_entry);
+      extra_entry = NULL;
       return;
   }
 
@@ -2873,6 +2884,10 @@ static void update_meta_entries (char *data_arg, List *ent_list, char *short_pat
 	  xfree (updated_fname);
 	  updated_fname = NULL;
       }
+      /* See update_entries: the pending EntriesExtra is matched by bare
+	 filename, so drop this excluded file's copy.  */
+      xfree (extra_entry);
+      extra_entry = NULL;
       return;
   }
 
@@ -6412,8 +6427,10 @@ static void notified_a_file (char *data, List *ent_list, char *short_pathname, c
     int nwritten;
     char *p;
 
-    if (client_excluded_response)
-	return;
+    /* No exclusion check here on purpose: this only removes the acknowledged
+       entry from CVS/Notify and never touches a working file.  Skipping it
+       would leave the entry behind for ever and re-send the notification on
+       every later command.  */
 
     line = (char*)xmalloc (line_len);
     fp = open_file (CVSADM_NOTIFY, "r");

--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -752,6 +752,11 @@ char *rename_file_aside (const char *filename);
    "move away <file>; it is in the way".  Set once from the parsed options;
    the actual decision and rename happen per file.  */
 extern int update_inway_rename_aside;
+/* Nonzero when "update --no-sharp-files" is in effect: no ".#<file>.<rev>"
+   backup copies of the user's own modified files are created (and the
+   server's Copy-file backup instruction is ignored).  The in-the-way
+   rename-aside of -C is NOT suppressed by this -- safety wins.  */
+extern int update_no_sharp_files;
 void resolve_symlink (char **filename);
 void sleep_past (time_t desttime);
 

--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -631,6 +631,7 @@ int ign_close();
 void ign_dir_add (const char *name);
 int ignore_directory (const char *name);
 void exclude_path_add (const char *name);
+void exclude_clear (void);
 const char *exclude_path_get (int i);
 int path_excluded (const char *name);
 void ign_send ();
@@ -756,9 +757,11 @@ char *rename_file_aside (const char *filename);
    the actual decision and rename happen per file.  */
 extern int update_inway_rename_aside;
 /* Nonzero when "update --no-sharp-files" is in effect: no ".#<file>.<rev>"
-   backup copies of the user's own modified files are created (and the
-   server's Copy-file backup instruction is ignored).  The in-the-way
-   rename-aside of -C is NOT suppressed by this -- safety wins.  */
+   backup copies of the user's own modified files are created.  Two things
+   are NOT suppressed by this, because they hold the only remaining copy of
+   the user's work -- safety wins: the in-the-way rename-aside of -C, and a
+   backup the server asks for via Copy-file (a nonmergeable/binary conflict
+   is indistinguishable from a text merge at the time that arrives).  */
 extern int update_no_sharp_files;
 void resolve_symlink (char **filename);
 void sleep_past (time_t desttime);

--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -630,6 +630,8 @@ void ign_setup();
 int ign_close();
 void ign_dir_add (const char *name);
 int ignore_directory (const char *name);
+void exclude_path_add (const char *name);
+int path_excluded (const char *name);
 void ign_send ();
 void ign_display();
 

--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -631,6 +631,7 @@ int ign_close();
 void ign_dir_add (const char *name);
 int ignore_directory (const char *name);
 void exclude_path_add (const char *name);
+const char *exclude_path_get (int i);
 int path_excluded (const char *name);
 void ign_send ();
 void ign_display();

--- a/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/src/cvs.h
@@ -746,6 +746,12 @@ extern void get_file (const char *, const char *, const char *,
 char *shell_escape(char **buf, const char *str);
 char *shell_escape_backslash(char **buf, const char *str);
 char *backup_file (const char *filename, const char *suffix);
+char *rename_file_aside (const char *filename);
+/* Nonzero when "update -C" should move an untracked in-the-way file aside
+   (to ".#_notversioned.<file>.<timestamp>") instead of failing with
+   "move away <file>; it is in the way".  Set once from the parsed options;
+   the actual decision and rename happen per file.  */
+extern int update_inway_rename_aside;
 void resolve_symlink (char **filename);
 void sleep_past (time_t desttime);
 

--- a/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
@@ -404,12 +404,24 @@ void exclude_path_add (const char *path)
     if (isabsolute (copy))
 	error (1, 0, "-exc path `%s' must be relative to the update root", copy);
 
-    if (exc_current <= exc_max)
+    if (exc_current >= exc_max)
     {
 	exc_max += IGN_GROW;
 	exc_list = (char **) xrealloc (exc_list, (exc_max + 1) * sizeof (char *));
     }
     exc_list[exc_current++] = copy;
+}
+
+/* Drop every exclusion entry.  The list is per-command state: a server
+   process that serves more than one command in its lifetime must not let
+   one command's -exc paths silently skip files in the next one.  */
+void exclude_clear (void)
+{
+    int i;
+
+    for (i = 0; i < exc_current; ++i)
+	xfree (exc_list[i]);
+    exc_current = 0;
 }
 
 /* Return the I'th exclusion entry (normalized), or NULL when I is past

--- a/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
@@ -412,6 +412,16 @@ void exclude_path_add (const char *path)
     exc_list[exc_current++] = copy;
 }
 
+/* Return the I'th exclusion entry (normalized), or NULL when I is past
+   the end of the list.  Lets the client relay the exclusion set to a
+   server that advertises the "Exclude" request.  */
+const char *exclude_path_get (int i)
+{
+    if (i < 0 || i >= exc_current)
+	return NULL;
+    return exc_list[i];
+}
+
 /* Return nonzero if PATH (relative to the directory the command was
    started in; either a file or a directory) is excluded: equal to an
    exclusion entry, or lying below one.  */

--- a/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/ignore.cpp
@@ -365,6 +365,77 @@ int ignore_directory (const char *name)
 
     return 0;
 }
+
+/* "update -exc" support: a one-shot list of paths (files or directories,
+   relative to the directory the update was started in) to exclude from
+   the update.  Matching is path-prefix based on whole components: an
+   entry "sub/dir" excludes "sub/dir" and everything below it, but not
+   "sub/dir2".  Unlike dir_ign_list this list is never persisted and is
+   only ever populated from the update command line.  */
+
+static char **exc_list = NULL;
+static int exc_max = 0;
+static int exc_current = 0;
+
+/* Add one path to the exclusion list.  Directory separators are
+   normalized to "/", leading "./" and trailing "/" are stripped.  */
+void exclude_path_add (const char *path)
+{
+    char *copy, *p;
+    size_t len;
+
+    copy = xstrdup (path);
+    for (p = copy; *p; ++p)
+	if (*p == '\\')
+	    *p = '/';
+    p = copy;
+    while (p[0] == '.' && p[1] == '/')
+	p += 2;
+    memmove (copy, p, strlen (p) + 1);
+    len = strlen (copy);
+    while (len > 0 && copy[len - 1] == '/')
+	copy[--len] = '\0';
+
+    if (len == 0)
+    {
+	xfree (copy);
+	return;
+    }
+    if (isabsolute (copy))
+	error (1, 0, "-exc path `%s' must be relative to the update root", copy);
+
+    if (exc_current <= exc_max)
+    {
+	exc_max += IGN_GROW;
+	exc_list = (char **) xrealloc (exc_list, (exc_max + 1) * sizeof (char *));
+    }
+    exc_list[exc_current++] = copy;
+}
+
+/* Return nonzero if PATH (relative to the directory the command was
+   started in; either a file or a directory) is excluded: equal to an
+   exclusion entry, or lying below one.  */
+int path_excluded (const char *path)
+{
+    int i;
+    size_t len;
+
+    if (!exc_list)
+	return 0;
+
+    while (path[0] == '.' && (path[1] == '/' || path[1] == '\\'))
+	path += 2;
+
+    for (i = 0; i < exc_current; ++i)
+    {
+	len = strlen (exc_list[i]);
+	if (fnncmp (path, exc_list[i], len) == 0
+	    && (path[len] == '\0' || path[len] == '/' || path[len] == '\\'))
+	    return 1;
+    }
+
+    return 0;
+}
 
 /*
  * Process the current directory, looking for files not in ILIST and

--- a/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
@@ -2935,6 +2935,21 @@ static void serve_set (char *arg)
     variable_set (arg);
 }
 
+/* "Exclude <path>" -- negotiated support for "update -exc": feed the
+   update exclusion filter, so the same path_excluded() hooks that filter
+   a local update also prune this server's recursion (the excluded
+   subtrees are then neither walked nor streamed).  Advertised in
+   Valid-requests; a client must only send this when it saw the
+   advertisement, and falls back to its own client-side filtering
+   against servers that lack it.  Invalid paths are ignored -- the
+   client-side filtering still applies.  */
+static void serve_exclude (char *arg)
+{
+    if (arg == NULL || *arg == '\0' || isabsolute (arg))
+	return;
+    exclude_path_add (arg);
+}
+
 static void serve_questionable (char *arg)
 {
     if (dir_name == NULL)
@@ -4936,6 +4951,7 @@ struct request requests[] =
   REQ_LINE("Notify", serve_notify, 0),
   REQ_LINE("NotifyUser", serve_notify_user, 0),
   REQ_LINE("Questionable", serve_questionable, 0),
+  REQ_LINE("Exclude", serve_exclude, 0),
   REQ_LINE("Utf8", serve_utf8, RQ_ROOTLESS), /* Depreciated, but checked for option support by server */
   REQ_LINE("Case", NULL, 0), /* Deprecated but we send it for older clients */
   REQ_LINE("Argument", serve_argument, RQ_ESSENTIAL),

--- a/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/server.cpp
@@ -3314,6 +3314,11 @@ free_args_and_return:
 	argument_count = 1;
     }
 
+    /* The Exclude requests that preceded this command applied only to it;
+       drop them so a later command on the same connection does not silently
+       skip files.  */
+    exclude_clear ();
+
     /* Flush out any data not yet sent.  */
     set_block (buf_to_net);
     buf_flush (buf_to_net, 1);

--- a/cvsnt/cvsnt-2.5.05.3744/src/subr.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/subr.cpp
@@ -937,7 +937,44 @@ char *backup_file (const char *filename, const char *suffix)
 }
 
 /*
- * Copy a string into a buffer escaping any shell metacharacters. 
+ * Move an in-the-way (not version controlled) file aside so that a fresh
+ * repository copy can be checked out in its place.  The file is renamed
+ * (not copied) to ".#_notversioned.<file>.<unix-timestamp>", which keeps
+ * it recoverable and covered by the default ".#*" ignore pattern.
+ *
+ * Returns the new name (caller may xfree() it), or NULL if the rename
+ * failed (a non-fatal error is printed in that case).
+ */
+char *rename_file_aside (const char *filename)
+{
+    char *aside_name;
+    unsigned long stamp = (unsigned long) time (NULL);
+    int attempt;
+
+    aside_name = (char*)xmalloc (sizeof (BAKPREFIX) + sizeof ("_notversioned.")
+                                 + strlen (filename) + 32);
+    /* Avoid silently replacing an aside file from a previous run made
+       within the same second.  */
+    for (attempt = 0; attempt < 100; ++attempt)
+    {
+        sprintf (aside_name, "%s_notversioned.%s.%lu", BAKPREFIX, filename,
+                 stamp + attempt);
+        if (!isfile (aside_name))
+            break;
+    }
+
+    if (CVS_RENAME (filename, aside_name) < 0)
+    {
+        error (0, errno, "cannot rename %s to %s", filename, aside_name);
+        xfree (aside_name);
+        return NULL;
+    }
+
+    return aside_name;
+}
+
+/*
+ * Copy a string into a buffer escaping any shell metacharacters.
  *
  * Returns a pointer to the allocated buffer
  */

--- a/cvsnt/cvsnt-2.5.05.3744/src/subr.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/subr.cpp
@@ -962,6 +962,14 @@ char *rename_file_aside (const char *filename)
         if (!isfile (aside_name))
             break;
     }
+    if (attempt == 100)
+    {
+        /* Every candidate name is taken: give up rather than rename over an
+           aside file that may itself be the only copy of something.  */
+        error (0, 0, "cannot find a free name to move %s aside", filename);
+        xfree (aside_name);
+        return NULL;
+    }
 
     if (CVS_RENAME (filename, aside_name) < 0)
     {

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -165,7 +165,8 @@ static const char *const update_usage[] =
     "\t-W spec\tWrappers specification line (! to reset).\n",
     "\t--blob_zero\tDownloaded blobs would be written as zero length file. That is for 'hot-proxy' scenario (to save space and optimize performance of update).\n",
     "\t--no-sharp-files\tDo not create .#<file>.<rev> backup copies of modified\n",
-    "\t\tfiles (in-the-way files are still moved aside under -C).\n",
+    "\t\tfiles (in-the-way files are still moved aside under -C, and a\n",
+    "\t\tconflict backup that holds your only copy is still kept).\n",
     "\t-exc paths\tExclude comma-separated paths (files or directories, relative\n",
     "\t\tto the update root) from the update, including -d directory creation.\n",
     "\t\tOne-shot and client-side; nothing is recorded in the working copy.\n",
@@ -184,6 +185,13 @@ int update (int argc, char **argv)
 
     if (argc == -1)
 		usage (update_usage);
+
+    /* These are per-command state.  A server process that serves more than
+       one command in its lifetime must not carry one update's exclusions or
+       switches into the next one, where they would silently skip files.  */
+    exclude_clear ();
+    update_no_sharp_files = 0;
+    update_inway_rename_aside = 0;
 
     /* parse the args */
     static struct option long_update_options[] =

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -432,6 +432,26 @@ int update (int argc, char **argv)
 		if (merge_bugid)
 			option_with_arg("-B", merge_bugid);
 
+		/* Relay the -exc exclusion set to a server that advertises the
+		   "Exclude" request, so it prunes the excluded subtrees from
+		   its own recursion instead of walking and streaming them.
+		   Never sent otherwise (per Valid-requests negotiation); with
+		   an older server the client-side filtering alone provides
+		   the exclusion.  This is a request, not an update option:
+		   an unknown update option would abort the old server.  */
+		if (exclude_path_get (0) != NULL && supported_request ("Exclude"))
+		{
+			int exci;
+			const char *excpath;
+
+			for (exci = 0; (excpath = exclude_path_get (exci)) != NULL; ++exci)
+			{
+				send_to_server ("Exclude ", 0);
+				send_to_server (excpath, 0);
+				send_to_server ("\n", 1);
+			}
+		}
+
 		client_overwrite_existing = case_sensitive;
 
 	    if (failed_patches_count == 0)

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -108,6 +108,10 @@ int backup_local_files = 1;
    failing.  Option state only; the per-file decision is made at the point
    where each individual in-the-way file is discovered.  */
 int update_inway_rename_aside = 0;
+/* See cvs.h: "update --no-sharp-files" suppresses the ".#<file>.<rev>"
+   backup copies.  Client-consumed only: never forwarded to the server
+   (an unknown update option is fatal to an old server).  */
+int update_no_sharp_files = 0;
 static int toss_local_changes;
 static int force_tag_match = 1;
 static int update_build_dirs;
@@ -160,6 +164,8 @@ static const char *const update_usage[] =
     "\t-n\tDo not backup local files(silently remove). Irreversibly deletes locally modified files.\n",
     "\t-W spec\tWrappers specification line (! to reset).\n",
     "\t--blob_zero\tDownloaded blobs would be written as zero length file. That is for 'hot-proxy' scenario (to save space and optimize performance of update).\n",
+    "\t--no-sharp-files\tDo not create .#<file>.<rev> backup copies of modified\n",
+    "\t\tfiles (in-the-way files are still moved aside under -C).\n",
     "(Specify the --help global option for a list of other help options)\n",
     NULL
 };
@@ -180,6 +186,8 @@ int update (int argc, char **argv)
     static struct option long_update_options[] =
     {
     	{"blob_zero", 0, NULL, 1},
+    	/* Client-consumed only; never forwarded to the server.  */
+    	{"no-sharp-files", 0, NULL, 2},
     	{0, 0, NULL, 0},
     };
 
@@ -192,6 +200,10 @@ int update (int argc, char **argv)
         case 1:
         extern bool blob_downloaded_no_write;
         blob_downloaded_no_write = true;
+		break;
+        case 2:
+        /* --no-sharp-files */
+        update_no_sharp_files = 1;
 		break;
 	    case 'A':
 		aflag = 1;
@@ -808,7 +820,7 @@ static int update_fileproc (void *callerdat, struct file_info *finfo)
 			retval = 0;
             if (toss_local_changes)
             {
-                if (backup_local_files)
+                if (backup_local_files && !update_no_sharp_files)
                 {
                     char *bakname;
                     bakname = backup_file (finfo->file, vers->vn_user);
@@ -2311,6 +2323,20 @@ static void write_letter (struct file_info *finfo, int letter)
     return;
 }
 
+/* Under --no-sharp-files, remove the ".#" copy that the merge machinery
+   made for its own use (restore-on-failure, no-op detection) once it is
+   no longer needed.  The caller must NOT discard a backup that holds the
+   only remaining copy of the user's version (the nonmergeable-conflict
+   case) -- there, safety wins over the option.  */
+static void discard_sharp_backup (const char *backup)
+{
+    if (update_no_sharp_files && isfile (backup))
+    {
+	if (unlink_file (backup) < 0)
+	    error (0, errno, "cannot remove backup %s", backup);
+    }
+}
+
 /*
  * Do all the magic associated with a file which needs to be merged
  */
@@ -2320,6 +2346,7 @@ static int merge_file (struct file_info *finfo, Vers_TS *vers)
     int status;
     int retcode = 0;
     int retval;
+    int keep_backup = 0;
 	kflag kf;
 	kflag kftmp;
 	mode_t mode = 0644; /* stupid default! */
@@ -2368,6 +2395,10 @@ static int merge_file (struct file_info *finfo, Vers_TS *vers)
 #endif
 
 	status = checkout_file (finfo, vers, 0, 1, 1, 0, is_rcs, NULL, NULL);
+
+	/* The backup now holds the only copy of the user's version;
+	   keep it even under --no-sharp-files.  */
+	keep_backup = 1;
 
 	/* Is there a better term than "nonmergeable file"?  What we
 	   really mean is, not something that CVS cannot or does not
@@ -2506,6 +2537,8 @@ static int merge_file (struct file_info *finfo, Vers_TS *vers)
     }
     retval = 0;
  out:
+    if (!keep_backup)
+	discard_sharp_backup (backup);
     xfree (backup);
     return retval;
 }
@@ -2711,6 +2744,7 @@ static void join_file (struct file_info *finfo, Vers_TS *vers)
     char *t_options;
 	kflag kf;
     int status;
+    int keep_backup = 0;
 
     const char *rev1;
     const char *rev2;
@@ -3183,6 +3217,10 @@ static void join_file (struct file_info *finfo, Vers_TS *vers)
 	   be checked out (writable) after a merge.  */
 	xchmod (finfo->file, 1);
 
+	/* The backup now holds the only copy of the user's version;
+	   keep it even under --no-sharp-files.  */
+	keep_backup = 1;
+
 	/* Hmm.  We don't give them REV1 anywhere.  I guess most people
 	   probably don't have a 3-way merge tool for the file type in
 	   question, and might just get confused if we tried to either
@@ -3211,6 +3249,7 @@ static void join_file (struct file_info *finfo, Vers_TS *vers)
 		//cvs_output (finfo->file, 0);
 		//cvs_output ("\n", 1);
 
+		discard_sharp_backup (backup);
 		xfree(rev1);
 		xfree(rev2);
 		xfree(backup);
@@ -3287,6 +3326,8 @@ static void join_file (struct file_info *finfo, Vers_TS *vers)
 				(struct buffer *) NULL);
     }
 #endif
+    if (!keep_backup)
+	discard_sharp_backup (backup);
     xfree (backup);
 	xfree (t_options);
 	baserev_update(finfo, vers, T_NEEDS_MERGE);

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -166,6 +166,9 @@ static const char *const update_usage[] =
     "\t--blob_zero\tDownloaded blobs would be written as zero length file. That is for 'hot-proxy' scenario (to save space and optimize performance of update).\n",
     "\t--no-sharp-files\tDo not create .#<file>.<rev> backup copies of modified\n",
     "\t\tfiles (in-the-way files are still moved aside under -C).\n",
+    "\t-exc paths\tExclude comma-separated paths (files or directories, relative\n",
+    "\t\tto the update root) from the update, including -d directory creation.\n",
+    "\t\tOne-shot and client-side; nothing is recorded in the working copy.\n",
     "(Specify the --help global option for a list of other help options)\n",
     NULL
 };
@@ -190,6 +193,40 @@ int update (int argc, char **argv)
     	{"no-sharp-files", 0, NULL, 2},
     	{0, 0, NULL, 0},
     };
+
+    /* "-exc <path>[,<path>...]" is extracted before getopt runs: it is a
+       multi-character switch that getopt would misparse as "-e xc", and
+       it must never reach the server (an unknown update option makes an
+       old server print usage and abort the whole session), so it is
+       consumed here and acted upon client-side only.  May be repeated.  */
+    {
+	int i, j;
+
+	for (i = 1; i < argc; ++i)
+	{
+	    if (strcmp (argv[i], "--") == 0)
+		break;
+	    if (strcmp (argv[i], "-exc") == 0)
+	    {
+		char *p, *q;
+
+		if (i + 1 >= argc)
+		    error (1, 0, "-exc requires an argument");
+		for (p = argv[i + 1]; p != NULL; p = q)
+		{
+		    q = strchr (p, ',');
+		    if (q != NULL)
+			*q++ = '\0';
+		    if (*p != '\0')
+			exclude_path_add (p);
+		}
+		for (j = i + 2; j < argc; ++j)
+		    argv[j - 2] = argv[j];
+		argc -= 2;
+		--i;
+	    }
+	}
+    }
 
     optind = 0;
     int options_index = 0;//not used
@@ -738,6 +775,24 @@ static int update_fileproc (void *callerdat, struct file_info *finfo)
 
 	file_is_edited = 0;
 
+    /* "update -exc": excluded files are neither created nor updated.
+       Still record the file in this directory's ignore list so that it
+       is not reported as unknown ("? file").  */
+    if (path_excluded (finfo->fullname))
+    {
+	if (ignlist)
+	{
+	    Node *p;
+
+	    p = getnode ();
+	    p->type = FILES;
+	    p->key = xstrdup (finfo->file);
+	    if (addnode (ignlist, p) != 0)
+		freenode (p);
+	}
+	return 0;
+    }
+
     status = Classify_File (finfo, tag, date, options, force_tag_match,
 			    aflag, &vers, pipeout, 0, 0);
 
@@ -1100,6 +1155,10 @@ static int update_predirent_proc (void *callerdat, char *dir, char *repository, 
 
 	if(ignore_directory(update_dir))
 		return R_SKIP_ALL;
+	/* "update -exc": prune excluded directories from the recursion, so
+	   they are neither created (under -d) nor descended into.  */
+	if(path_excluded(update_dir))
+		return R_SKIP_ALL;
 	if(!isdir(dir))
 	{
 		if(!update_build_dirs || (!server_active && !isdir (repository)))
@@ -1215,6 +1274,10 @@ static Dtype update_dirent_proc (void *callerdat, char *dir, char *repository, c
 	  error (0, 0, "Ignoring %s", update_dir);
         return R_SKIP_ALL;
     }
+
+    /* "update -exc": skip excluded directories, quietly.  */
+    if (path_excluded (update_dir))
+        return R_SKIP_ALL;
 
 	if(join_rev1 || join_rev2)
 	{

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -186,12 +186,20 @@ int update (int argc, char **argv)
     if (argc == -1)
 		usage (update_usage);
 
-    /* These are per-command state.  A server process that serves more than
-       one command in its lifetime must not carry one update's exclusions or
-       switches into the next one, where they would silently skip files.  */
-    exclude_clear ();
+    /* These are per-command state: a process that runs more than one command
+       in its lifetime must not carry one update's switches into the next,
+       where they would silently skip files.  Both are set from the options
+       parsed below, so clearing them here is always right.  */
     update_no_sharp_files = 0;
     update_inway_rename_aside = 0;
+
+    /* The exclusion list is different: when we are the server it was filled
+       by the Exclude requests that arrive *before* this command, so clearing
+       it here would discard them and make the server-side pruning a no-op.
+       The client fills it from its own command line just below, so it clears
+       it here; the server clears it once the command completes.  */
+    if (!server_active)
+	exclude_clear ();
 
     /* parse the args */
     static struct option long_update_options[] =

--- a/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/update.cpp
@@ -104,6 +104,10 @@ static const char *join_rev1, *date_rev1;
 static const char *join_rev2, *date_rev2;
 static int aflag = 0;
 int backup_local_files = 1;
+/* See cvs.h: "update -C" moves untracked in-the-way files aside instead of
+   failing.  Option state only; the per-file decision is made at the point
+   where each individual in-the-way file is discovered.  */
+int update_inway_rename_aside = 0;
 static int toss_local_changes;
 static int force_tag_match = 1;
 static int update_build_dirs;
@@ -134,7 +138,8 @@ static const char *const update_usage[] =
     "\t-A\tReset any sticky tags/date/kopts.\n",
 	"\t-B bugid\tPerform -j Merge bounded by bug.\n",
 	"\t-b\tPerform -j merge from branch point.\n",
-    "\t-C\tOverwrite locally modified files with clean repository copies.\n",
+    "\t-C\tOverwrite locally modified files with clean repository copies\n",
+    "\t\t(in-the-way files not under CVS are moved aside to .#_notversioned.*).\n",
 	"\t-c\tUpdate base revision copies.\n",
     "\t-D date\tSet date to update from (is sticky).\n",
     "\t-d\tBuild directories, like checkout does.\n",
@@ -312,7 +317,12 @@ int update (int argc, char **argv)
 		tag = NULL;
 	}
 
-    if (current_parsed_root->isremote) 
+    /* With -C an untracked file sitting where a repository file must be
+       created is moved aside (per file, when it is encountered) rather
+       than failing the update.  */
+    update_inway_rename_aside = toss_local_changes;
+
+    if (current_parsed_root->isremote)
     {
 	int pass;
 

--- a/cvsnt/cvsnt-2.5.05.3744/windows-NT/filesubr.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/windows-NT/filesubr.cpp
@@ -665,6 +665,44 @@ int readlink (char *path, char *buf, int buf_size)
 // From win32.cpp
 bool validate_filename(const char *path, bool warn);
 
+/* Nonzero when the CVS_RENAME_LOCKED_ASIDE environment variable enables
+   the last-resort handling of rename targets that stay locked: instead
+   of fatally giving up after the 10 second retry, the locked target is
+   itself renamed to a recoverable ".#_notversioned.<name>.<timestamp>"
+   and the rename is retried once.  Default (unset/empty/"0"): off,
+   historical behavior.  */
+static int rename_locked_aside_enabled ()
+{
+	const char *env = getenv ("CVS_RENAME_LOCKED_ASIDE");
+	return env != NULL && *env != '\0' && strcmp (env, "0") != 0;
+}
+
+/* Build "<dir>/.#_notversioned.<name>.<timestamp>" next to TO, avoiding
+   names that already exist.  Caller xfree()s the result.  */
+static char *locked_aside_name (const char *to)
+{
+	const char *base = to;
+	const char *p;
+	char *aside;
+	unsigned long stamp = (unsigned long) time (NULL);
+	int attempt;
+
+	for (p = to; *p; ++p)
+		if (ISDIRSEP (*p))
+			base = p + 1;
+
+	aside = (char*) xmalloc (strlen (to) + sizeof (BAKPREFIX "_notversioned.") + 32);
+	for (attempt = 0; attempt < 100; ++attempt)
+	{
+		sprintf (aside, "%.*s" BAKPREFIX "_notversioned.%s.%lu",
+			 (int) (base - to), to, base, stamp + attempt);
+		uc_name fn_aside = aside;
+		if (GetFileAttributes (fn_aside) == 0xFFFFFFFF)
+			break;
+	}
+	return aside;
+}
+
 /* Rename for NT which works for read only files.  */
 int wnt_rename (const char *from, const char *to)
 {
@@ -719,7 +757,7 @@ int wnt_rename (const char *from, const char *to)
 		count++;
 		if(count==100)
 		{
-			printf("Unable to rename file %s to %s for 10 seconds, giving up...\n",fn_root(from),fn_root(to),count/10,count>10?"s":"");
+			printf("Unable to rename file %s to %s for 10 seconds, giving up...\n",fn_root(from),fn_root(to));
 			break;
 		}
 		if(!(count%10))
@@ -738,7 +776,32 @@ int wnt_rename (const char *from, const char *to)
 		count++;
 		if(count==100)
 		{
-			printf("Unable to rename file %s to %s for 10 seconds, giving up...\n",fn_root(from),fn_root(to),count/10,count>10?"s":"");
+			/* Last resort, opt-in: the target would not let itself be
+			   replaced for 10 seconds -- commonly a running executable,
+			   whose image is locked against delete/replace but not
+			   against a plain rename.  Move the locked target aside to
+			   a recoverable name and retry the rename once.  */
+			if (rename_locked_aside_enabled () && GetFileAttributes (fn_to) != 0xFFFFFFFF)
+			{
+				char *aside = locked_aside_name (to);
+				uc_name fn_aside = aside;
+
+				if (MoveFile (fn_to, fn_aside))
+				{
+					printf("Renamed locked file %s to %s\n", fn_root(to), fn_root(aside));
+					xfree (aside);
+					if ((result = MoveFileEx(fn_from,fn_to,MOVEFILE_COPY_ALLOWED|MOVEFILE_REPLACE_EXISTING)))
+						break;
+					save_errno = GetLastError();
+					TRACE(3,"MoveFile after rename-aside returned error %08x",save_errno);
+				}
+				else
+				{
+					TRACE(3,"Rename-aside of locked target failed, error %08x",GetLastError());
+					xfree (aside);
+				}
+			}
+			printf("Unable to rename file %s to %s for 10 seconds, giving up...\n",fn_root(from),fn_root(to));
 			break;
 		}
 		if(!(count%10))

--- a/cvsnt/cvsnt-2.5.05.3744/windows-NT/filesubr.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/windows-NT/filesubr.cpp
@@ -789,11 +789,20 @@ int wnt_rename (const char *from, const char *to)
 				if (MoveFile (fn_to, fn_aside))
 				{
 					printf("Renamed locked file %s to %s\n", fn_root(to), fn_root(aside));
-					xfree (aside);
 					if ((result = MoveFileEx(fn_from,fn_to,MOVEFILE_COPY_ALLOWED|MOVEFILE_REPLACE_EXISTING)))
+					{
+						xfree (aside);
 						break;
+					}
 					save_errno = GetLastError();
 					TRACE(3,"MoveFile after rename-aside returned error %08x",save_errno);
+					/* The retry failed too: put the target back rather than
+					   leaving its path empty.  */
+					if (MoveFile (fn_aside, fn_to))
+						printf("Restored %s from %s\n", fn_root(to), fn_root(aside));
+					else
+						printf("Left %s in %s\n", fn_root(to), fn_root(aside));
+					xfree (aside);
 				}
 				else
 				{


### PR DESCRIPTION
Three opt-in additions to `cvs update` for large working copies, plus a fix for a latent overwrite bug they exposed. Defaults are unchanged: without the new switches every command behaves exactly as before.

## `update -C` moves an in-the-way file aside instead of failing
When a checkout is blocked by an untracked local file, `update` reports `move away <file>; it is in the way` and fails, so the whole update has to be run again after the file is dealt with. Under `-C` - which already means "discard my local state and take the repository copy" - the blocking file is now renamed to `.#_notversioned.<file>.<timestamp>` and the checkout proceeds in the same pass. The file is preserved under a recoverable name, and `.#*` is already ignored, so it does not show up as unknown. Without `-C` the historical refusal is unchanged.

Implemented at all three sites that produce that message: the inline-content and blob-reference receive paths, and the local/server classification path.

**This also fixes a latent bug.** `client_overwrite_existing` was a process-global set to 1 as soon as any modified file was backed up during the send phase and never reset. Since the whole send phase precedes the receive phase, one modified tracked file disabled the in-the-way guard for the rest of the run, so a newly added repository file could silently overwrite an unrelated untracked local file. The decision is now per file, recorded for the files `-C` actually reverted.

## `--no-sharp-files`
Suppresses the `.#<file>.<rev>` backup copies of the user's own modified files. Client-consumed only.

Two backups are deliberately **not** suppressed, because each is the only remaining copy of the user's work: the in-the-way rename above, and a backup the server asks for through `Copy-file`. The latter matters - that instruction arrives before the content that replaces the working file, so the client cannot tell a text merge (whose result keeps the user's work inline as conflict markers) from a nonmergeable binary conflict (where the working file is simply overwritten). Honouring it unconditionally is what keeps `--no-sharp-files` from destroying uncommitted binary changes.

## `-exc <path>[,<path>...]`
Excludes files and directories from an otherwise complete update, including the directory creation done by `-d`. This is the inverse of naming what to update: an include list does not pick up newly added files and directories, whereas users often want everything *except* a few paths.

Matching is path-prefix on whole components, so `-exc sub/dir` excludes `sub/dir` and everything under it but not `sub/dir2`. It is one-shot - nothing is recorded in the working copy. Excluded paths are neither created nor updated: the send phase skips them, and the receive phase consumes each response's payload from the stream but acts on nothing, so the protocol stays in sync.

`-exc` is extracted before option parsing (the option string would otherwise read `-exc` as `-e xc`) and is never sent to the server as an option, because an unrecognized option makes an older server print usage and abort the session. Where the server advertises the new `Exclude` request it is relayed so the server can skip walking excluded subtrees; against an older server the client-side filter alone produces the same working copy.

## Also
An opt-in Windows behaviour (off by default) for the rename retry loop: when a target cannot be replaced for ten seconds - typically a running executable - the locked target is moved aside and the rename retried once, instead of giving up fatally. If the retry also fails the target is moved back.

## Verification
Built after every change. Exercised against scratch repositories, locally and over a client/server connection: `-C` backup behaviour, `--no-sharp-files` leaving no backups while the content is still reverted, refusal without `-C` versus rename-aside with `-C` (with the original content confirmed intact under the aside name), directory and file exclusion while `-d` still creates other new directories, and component-boundary matching.

Reviewed twice; findings are addressed in the branch, including the `Copy-file` behaviour described above and the ordering of the per-command exclusion reset on the server.

Known limitation: the cvsnt rename-tracking responses do not yet consult the exclusion list, so a repository using rename tracking can still rename inside an excluded path. Recorded for a follow-up.
