### PR TITLE
Docs: architecture, blob store and build guide; three early fixes

### DIFF
--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -63,17 +63,24 @@ sudo make install
 Note the ordering: **zstd is built and installed before the main `make`**. The main build links
 against the installed `libzstd`, not against the in-tree copy.
 
-### Build the maintenance tools
+### The maintenance tools
 
-`cvtblob`, `gc-blobs`, `repack-blobs` and `blake3-calc` are built separately, with clang and C++17:
+On Linux the main `make` **already** builds these four, as `convert_to_blob`, `gc_blobs`,
+`repack_blobs` and `blake3_calc`: `tools/` is in the top-level `SUBDIRS` whenever the target is not
+macOS (`Makefile.am:42`, gated by `WITH_SERVER_AND_TOOLS` from `configure.in:767`), and
+`tools/Makefile.am:12` builds them with the configured compiler at `-std=c++17 -mavx2`.
+
+`tools/build_tools` is an *alternative* clang path that produces the hyphenated names
+`cvtblob`, `gc-blobs`, `repack-blobs`, `blake3-calc`:
 
 ```bash
 cd cvsnt/cvsnt-2.5.05.3744/tools
 ./build_tools
 ```
 
-`build_tools` expects `libblake3` and `libca_blobs_fs` to be installed already (they come from the
-main `make install`), plus `-lz -lzstd -pthread`. It also passes `-msse4.1`.
+It expects `libblake3` and `libca_blobs_fs` to be installed already (both are `lib_LTLIBRARIES`
+installed by the main `make install`), compiles with `clang++ -O3 -msse4.1`, and adds
+`-std=c++17 -lz -lzstd -pthread` for the three blob tools. `blake3-calc` needs only `-lblake3`.
 
 ### Useful `configure` options
 
@@ -81,7 +88,8 @@ main `make install`), plus `-lz -lzstd -pthread`. It also passes `-msse4.1`.
 | --- | --- |
 | `--enable-server` / `--enable-pserver` | Build the server halves |
 | `--enable-pam` | PAM authentication |
-| `--enable-ssl` | TLS (`sserver`) |
+| `--enable-sserver` / `--disable-sserver` | The `:sserver:` TLS protocol (on by default when OpenSSL is found, `configure.in:919`) |
+| `--with-ssl=DIR` | Where to look for OpenSSL if it is not in the default paths (`configure.in:146`) |
 | `--enable-gserver` / `--enable-sspi` | GSSAPI / SSPI methods |
 | `--enable-64bit` | 64-bit build |
 | `--disable-avx512` | Build BLAKE3 **without** AVX-512 kernels. AVX-512 is **on by default** on non-macOS targets (`configure.in:735`). AMD CPUs older than Zen 4 do not have it and will die with an illegal instruction, so use this flag if any target machine might be one (commit `2cd984a`) |
@@ -89,7 +97,6 @@ main `make install`), plus `-lz -lzstd -pthread`. It also passes `-msse4.1`.
 | `--with-protocol_dir=DIR` | Where protocol plugins are searched for |
 | `--disable-mysql`, `--disable-postgres`, `--disable-sqlite`, `--disable-odbc` | Skip database back-ends you do not need — this removes most of the optional dependencies |
 | `--disable-hfs` | Skip HFS+ support (macOS only) |
-| `--with-internal-zlib` | Use the vendored zlib instead of the system one |
 
 Run `bash configure --help` for the complete list.
 
@@ -130,9 +137,13 @@ The target architecture and deployment target come from `BUILD_ARCH` at the top 
 | `-arch arm64 -mmacosx-version-min=11.0` | Apple Silicon, macOS 11+ |
 | `-arch arm64 -mmacosx-version-min=13.0` | Apple Silicon, macOS 13+ |
 
-The macOS build is a **client-only** build: `osx/build-mac` passes `--disable-server`, along with
+The macOS build is a **client-only** build: `osx/build-mac:44` passes `--disable-server`, along with
 `--disable-hfs --with-internal-zlib --disable-ltdl --disable-odbc --disable-postgres
 --disable-mysql --disable-sspi --disable-sqlite --enable-64bit`.
+
+Two flags in that list are historical no-ops: `configure` recognises neither `--with-internal-zlib`
+nor `--disable-ltdl`, and discards both with an "unrecognized options" warning. ltdl is actually
+switched off on macOS by target detection (`configure.in:764`), not by a flag.
 
 Install the resulting archive:
 
@@ -159,8 +170,9 @@ Prebuilt macOS packages for x64 and arm64 are published under
   The projects specify `PlatformToolset` `v142` (VS 2019) and
   `WindowsTargetPlatformVersion` `10.0`. Newer toolsets work if you retarget the solution.
 * No external dependency downloads are needed: prebuilt import libraries and headers for OpenSSL,
-  iconv and Bonjour ship in `cvsnt/cvsnt-2.5.05.3744/external_libs/`
-  (`x64/` and `Win32/`, with the matching DLLs under `dll/`).
+  iconv and Bonjour ship in `cvsnt/cvsnt-2.5.05.3744/external_libs/` (`x64/` and `Win32/`).
+  Only the OpenSSL redistributables are included, under `dll/`; `libiconv.lib` links statically and
+  `dnssd.lib` resolves against the Bonjour service installed on the machine.
 
 ### Build
 
@@ -168,8 +180,8 @@ Prebuilt macOS packages for x64 and arm64 are published under
 cvsnt\cvsnt-2.5.05.3744\cvsnt.sln
 ```
 
-Open it, pick `Release|x64` (or `Release|Win32`), and build the solution. Roughly 40 projects are
-built; `cvsnt` produces `cvs.exe`.
+Open it, pick `Release|x64` (or `Release|Win32`), and build the solution. All 58 projects in the
+solution are marked to build; `cvsnt` produces `cvs.exe`.
 
 The main client/server project (`cvsnt.vcxproj`) is configured with:
 
@@ -183,12 +195,14 @@ The main client/server project (`cvsnt.vcxproj`) is configured with:
 ### Installer
 
 ```
-cvsnt\make_msix64.bat        (64-bit)
-cvsnt\make_msi.bat           (32-bit)
+cd cvsnt
+make_msix64.bat        (64-bit)
+make_msi.bat           (32-bit)
 ```
 
-These drive WiX against `cvsnt-x64-3.5.05.7674.wxs` / `cvsnt-x86-3.5.05.7674.wxs`. The WiX toolset
-and the helpers in `cvsnt/msi_tools/` must be on `PATH`.
+Both must be run **from the `cvsnt/` directory** — they invoke `msi_toolsin\candle.exe` and
+`msi_toolsin\light.exe` by relative path and read the `.wxs` from the current directory. The WiX
+toolset ships in `cvsnt/msi_tools/bin/`; nothing needs to be on `PATH`.
 
 ### Building without Visual Studio
 
@@ -205,14 +219,16 @@ Windows SDK 10.0.22621.0. The resulting binary runs:
 Concurrent Versions System (CVSNT) 3.5.24 (Gan + [Gaijin -kB/-kBz patch]) Build 7699 (client/server)
 ```
 
-The dependency order that works is: `blake3`, `zlib`, `zstd`, `ufc-crypt`, `cvsgui`, `ca_blobs_fs`,
-`blob_sockets`, `clientLib`, `gnulib`, `libdiff`, `cvsdelta`, `libsuid` → `cvsapi.dll` →
-`cvstools.dll` → `cvs.exe`.
+The dependency order that works is: `blake3`, `zlib`, `zstd`, `pcre`, `libxml2`, `ufc-crypt`,
+`cvsgui`, `ca_blobs_fs`, `blob_sockets`, `clientLib`, `gnulib`, `libdiff`, `cvsdelta`, `libsuid` →
+`cvsapi.dll` → `cvstools.dll` → `cvs.exe`. (`cvsapi.dll` needs `libxml2`, `pcre` and `ufc-crypt`;
+`cvstools.dll` needs `cvsapi.dll` and `cvsgui`; the rest link into `cvs.exe`.)
 
 Two things to know:
 
-* The DLLs from `external_libs/x64/dll/` (`libcrypto-1_1-x64.dll`, `libssl-1_1-x64.dll`) must sit
-  next to `cvs.exe` for it to start.
+* `libcrypto-1_1-x64.dll` from `external_libs/x64/dll/` must sit next to `cvs.exe` for it to start —
+  it is the only one of the two the binary actually imports. Copy `libssl-1_1-x64.dll` as well; a
+  build that enables `:sserver:` will need it.
 * `cvs init` needs the trigger plugin (`triggers/info_triggers.vcxproj`); without it you get
   `Couldn't open default trigger library`. Client commands work without it.
 
@@ -272,7 +288,7 @@ For the blob path you need a running `cafs_server`; see
 | Symptom | Cause and fix |
 | --- | --- |
 | `configure: error: requires libxml 2.7 or greater` | Install `libxml2-dev`/`libxml2-devel`. The check is `xmlSchemaValidCtxtGetParserCtxt` (`configure.in:365`) |
-| `configure: error: requires zlib > 1.2.0` | Install a newer zlib, or configure with `--with-internal-zlib` |
+| `configure: error: requires zlib > 1.2.0` | Install a zlib whose headers provide `deflateBound()` (`zlib1g-dev` / `zlib-devel`). The check at `configure.in:512` link-tests that symbol |
 | `No package 'libpcre' found` | Install `libpcre3-dev`/`pcre-devel`; the check goes through `pkg-config` |
 | Link errors for `ZSTD_*` | zstd was not built and installed before the main `make`. Do `cd zstd && make && sudo make install` first |
 | Illegal instruction at startup on an AMD CPU | AVX-512 is enabled by default and AMD CPUs before Zen 4 lack it. Reconfigure with `--disable-avx512` (commit `2cd984a`) |

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -1,0 +1,281 @@
+# How to build G-CVSNT
+
+All source lives under `cvsnt/cvsnt-2.5.05.3744/`. Every path below is relative to the repository
+root unless stated otherwise.
+
+Two build systems coexist:
+
+* **Autotools** (`configure.in` + per-directory `Makefile.am`) — Linux and macOS.
+* **Visual Studio** (`cvsnt.sln` + `*.vcxproj`) — Windows.
+
+They are independent. Changing the file list of a component means editing *both*.
+
+---
+
+## Linux
+
+### Dependencies
+
+Debian/Ubuntu:
+
+```bash
+sudo apt-get install build-essential autoconf automake libtool pkg-config \
+                     libxml2-dev libpcre3-dev libzstd-dev zlib1g-dev \
+                     libssl-dev libpam0g-dev
+```
+
+RHEL/CentOS — the list the project itself ships (`cvsnt/install-yum-packages`):
+
+```bash
+yum install devtoolset-9-gcc devtoolset-9-gcc-c++
+scl enable devtoolset-9 -- bash
+yum install dh-autoreconf libxml2-devel pcre-devel libtool-ltdl-devel \
+            glibc-static libstdc++-static libzstd-devel zstd pam-devel
+```
+
+Hard requirements enforced by `configure.in`: **libxml2 ≥ 2.7** (`configure.in:369`),
+**zlib > 1.2.0** (`configure.in:521`), and **libpcre** via `pkg-config`
+(`configure.in:376`).
+
+### Build a server
+
+The project's own driver is `cvsnt/build-linux-server`:
+
+```bash
+cd cvsnt/cvsnt-2.5.05.3744
+autoreconf -i
+bash configure \
+    --enable-pam \
+    --enable-server \
+    --enable-pserver \
+    --enable-sspi \
+    --enable-ext \
+    --disable-mysql \
+    --disable-postgres \
+    --disable-sqlite \
+    --enable-64bit
+
+cd zstd && make && sudo make install && cd ..
+make
+sudo make install
+```
+
+Note the ordering: **zstd is built and installed before the main `make`**. The main build links
+against the installed `libzstd`, not against the in-tree copy.
+
+### Build the maintenance tools
+
+`cvtblob`, `gc-blobs`, `repack-blobs` and `blake3-calc` are built separately, with clang and C++17:
+
+```bash
+cd cvsnt/cvsnt-2.5.05.3744/tools
+./build_tools
+```
+
+`build_tools` expects `libblake3` and `libca_blobs_fs` to be installed already (they come from the
+main `make install`), plus `-lz -lzstd -pthread`. It also passes `-msse4.1`.
+
+### Useful `configure` options
+
+| Option | Effect |
+| --- | --- |
+| `--enable-server` / `--enable-pserver` | Build the server halves |
+| `--enable-pam` | PAM authentication |
+| `--enable-ssl` | TLS (`sserver`) |
+| `--enable-gserver` / `--enable-sspi` | GSSAPI / SSPI methods |
+| `--enable-64bit` | 64-bit build |
+| `--disable-avx512` | Build BLAKE3 **without** AVX-512 kernels. AVX-512 is **on by default** on non-macOS targets (`configure.in:735`). AMD CPUs older than Zen 4 do not have it and will die with an illegal instruction, so use this flag if any target machine might be one (commit `2cd984a`) |
+| `--with-config_dir=DIR` | Where global settings live; defaults to `${sysconfdir}/cvsnt` |
+| `--with-protocol_dir=DIR` | Where protocol plugins are searched for |
+| `--disable-mysql`, `--disable-postgres`, `--disable-sqlite`, `--disable-odbc` | Skip database back-ends you do not need — this removes most of the optional dependencies |
+| `--disable-hfs` | Skip HFS+ support (macOS only) |
+| `--with-internal-zlib` | Use the vendored zlib instead of the system one |
+
+Run `bash configure --help` for the complete list.
+
+### Packaging
+
+`debian/` and `redhat/` contain packaging metadata. `cvsnt/build-rhel6` is a minimal
+`configure && make && make install` driver, and `cvsnt/build-altlinux` adds the zstd and tools steps.
+
+---
+
+## macOS
+
+Homebrew is required. `cvsnt/build-macosx` does everything:
+
+```bash
+cd cvsnt
+./build-macosx
+```
+
+What it does:
+
+1. `brew install autoconf automake pkg-config libtool pcre openssl@3`.
+2. Symlinks the Homebrew OpenSSL 3 headers and libraries into `/usr/local/include` and
+   `/usr/local/lib`. It handles both the Intel (`/usr/local/opt`) and Apple Silicon
+   (`/opt/homebrew/opt`) prefixes.
+3. `autoreconf -i --force`.
+4. Builds and installs the in-tree `zstd`.
+5. Runs `osx/build-mac`, which configures with clang for the chosen architecture and produces
+   a `.tar.gz` package in the repository root.
+
+The target architecture and deployment target come from `BUILD_ARCH` at the top of
+`cvsnt/build-macosx`. Uncomment the block you want:
+
+| `BUILD_ARCH` | Produces |
+| --- | --- |
+| `-arch x86_64 -msse4.1 -mmacosx-version-min=10.11` | Intel, macOS 10.11+ (default) |
+| `-arch x86_64 -msse4.1 -mavx -mavx2 -mavx512f -mmacosx-version-min=10.15` | Intel with AVX-512, macOS 10.15+ |
+| `-arch arm64 -mmacosx-version-min=11.0` | Apple Silicon, macOS 11+ |
+| `-arch arm64 -mmacosx-version-min=13.0` | Apple Silicon, macOS 13+ |
+
+The macOS build is a **client-only** build: `osx/build-mac` passes `--disable-server`, along with
+`--disable-hfs --with-internal-zlib --disable-ltdl --disable-odbc --disable-postgres
+--disable-mysql --disable-sspi --disable-sqlite --enable-64bit`.
+
+Install the resulting archive:
+
+```bash
+tar xzf cvsnt-3.5.*.tar.gz
+./install_copy_cvsnt.sh
+```
+
+That copies binaries and libraries into `/usr/local/bin`, `/usr/local/lib`, etc.
+
+`build-macosx` modifies the working tree. When it is done, run `git checkout .` to discard the
+generated files, as the script itself reminds you.
+
+Prebuilt macOS packages for x64 and arm64 are published under
+[Releases](https://github.com/GaijinEntertainment/G-CVSNT/releases).
+
+---
+
+## Windows
+
+### Prerequisites
+
+* Visual Studio 2019 or later with the **Desktop development with C++** workload.
+  The projects specify `PlatformToolset` `v142` (VS 2019) and
+  `WindowsTargetPlatformVersion` `10.0`. Newer toolsets work if you retarget the solution.
+* No external dependency downloads are needed: prebuilt import libraries and headers for OpenSSL,
+  iconv and Bonjour ship in `cvsnt/cvsnt-2.5.05.3744/external_libs/`
+  (`x64/` and `Win32/`, with the matching DLLs under `dll/`).
+
+### Build
+
+```
+cvsnt\cvsnt-2.5.05.3744\cvsnt.sln
+```
+
+Open it, pick `Release|x64` (or `Release|Win32`), and build the solution. Roughly 40 projects are
+built; `cvsnt` produces `cvs.exe`.
+
+The main client/server project (`cvsnt.vcxproj`) is configured with:
+
+* Preprocessor: `ISOLATION_AWARE_ENABLED;NDEBUG;_CONSOLE;WIN32;HAVE_CONFIG_H;POSIX;CVSGUI_PIPE`
+* Character set: Unicode
+* Include directories: `zstd`, `external_libs`, `windows-NT`, `src`, `lib`, `diff`, `zlib`,
+  `cvsgui`, `expat\lib`, `xmlapi`, `cvsapi\lib`, `cvsapi`, `cvstools`, `libxml\include`
+* Libraries: `libssl.lib libcrypto.lib comctl32.lib wsock32.lib netapi32.lib mpr.lib ole32.lib
+  libiconv.lib wininet.lib dbghelp.lib`
+
+### Installer
+
+```
+cvsnt\make_msix64.bat        (64-bit)
+cvsnt\make_msi.bat           (32-bit)
+```
+
+These drive WiX against `cvsnt-x64-3.5.05.7674.wxs` / `cvsnt-x86-3.5.05.7674.wxs`. The WiX toolset
+and the helpers in `cvsnt/msi_tools/` must be on `PATH`.
+
+### Building without Visual Studio
+
+`.vcxproj` files require MSBuild's C++ targets, which only ship with Visual Studio or the Visual
+Studio Build Tools. With only a standalone MSVC toolchain — `cl.exe`, `link.exe`, `lib.exe`,
+`nmake.exe` and a Windows SDK, but no MSBuild integration — the solution cannot be opened, and you
+have to drive the compiler yourself.
+
+**This has been done and verified.** A hand-written `nmake` makefile plus an environment batch file
+(replacing the absent `vcvarsall.bat`) builds `cvs.exe` and its dependencies with MSVC 19.44 and
+Windows SDK 10.0.22621.0. The resulting binary runs:
+
+```
+Concurrent Versions System (CVSNT) 3.5.24 (Gan + [Gaijin -kB/-kBz patch]) Build 7699 (client/server)
+```
+
+The dependency order that works is: `blake3`, `zlib`, `zstd`, `ufc-crypt`, `cvsgui`, `ca_blobs_fs`,
+`blob_sockets`, `clientLib`, `gnulib`, `libdiff`, `cvsdelta`, `libsuid` → `cvsapi.dll` →
+`cvstools.dll` → `cvs.exe`.
+
+Two things to know:
+
+* The DLLs from `external_libs/x64/dll/` (`libcrypto-1_1-x64.dll`, `libssl-1_1-x64.dll`) must sit
+  next to `cvs.exe` for it to start.
+* `cvs init` needs the trigger plugin (`triggers/info_triggers.vcxproj`); without it you get
+  `Couldn't open default trigger library`. Client commands work without it.
+
+`_reports/BUILD-01-windows-toolchain.md` has the full environment setup, the makefile, the exact
+dependency graph and every problem encountered along the way.
+
+---
+
+## Versioning
+
+Three files decide what `cvs --version` prints:
+
+| File | Contents |
+| --- | --- |
+| `version_no.h` | `CVSNT_PRODUCT_MAJOR` / `MINOR` / `PATCHLEVEL`, and the product-name suffix |
+| `build.h` | `CVSNT_PRODUCT_BUILD` — a single integer, bumped per build |
+| `version_fu.h` | Assembles the strings |
+
+`genbuild/` contains a helper that regenerates `build.h`.
+
+Bump `CVSNT_PRODUCT_PATCHLEVEL` or `CVSNT_PRODUCT_BUILD` when you change anything that affects
+client/server capability negotiation — the server uses the client version to decide which requests
+and responses it may use.
+
+---
+
+## Verifying a build
+
+```bash
+cvs --version
+```
+
+should print something like:
+
+```
+Concurrent Versions System (CVSNT) 3.5.24 (Gan + [Gaijin -kB/-kBz patch]) Build 7699 (client/server)
+```
+
+`(client/server)` confirms that server support was compiled in; a client-only build (macOS, and any
+build configured with `--disable-server`) says `(client)`.
+
+A quick functional smoke test without any server:
+
+```bash
+export CVSROOT=/tmp/testcvs
+cvs init
+cvs -d /tmp/testcvs checkout CVSROOT
+```
+
+For the blob path you need a running `cafs_server`; see
+[docs/06-server-operations.md](docs/06-server-operations.md).
+
+---
+
+## Common problems
+
+| Symptom | Cause and fix |
+| --- | --- |
+| `configure: error: requires libxml 2.7 or greater` | Install `libxml2-dev`/`libxml2-devel`. The check is `xmlSchemaValidCtxtGetParserCtxt` (`configure.in:365`) |
+| `configure: error: requires zlib > 1.2.0` | Install a newer zlib, or configure with `--with-internal-zlib` |
+| `No package 'libpcre' found` | Install `libpcre3-dev`/`pcre-devel`; the check goes through `pkg-config` |
+| Link errors for `ZSTD_*` | zstd was not built and installed before the main `make`. Do `cd zstd && make && sudo make install` first |
+| Illegal instruction at startup on an AMD CPU | AVX-512 is enabled by default and AMD CPUs before Zen 4 lack it. Reconfigure with `--disable-avx512` (commit `2cd984a`) |
+| macOS: `could not detect openssl@3 location` | `brew install openssl@3`; `build-macosx` looks in `/usr/local/opt/openssl@3` and `/opt/homebrew/opt/openssl@3` only |
+| Windows: `Microsoft.Cpp.Default.props was not found` | Visual Studio (or the Build Tools) is not installed, or the toolset in the projects is not installed. See "Building without Visual Studio" above |
+| The build leaves modified files in the tree | `build-macosx` and `autoreconf` generate files in place. `git checkout .` after building |

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -1,7 +1,9 @@
 # How to build G-CVSNT
 
-All source lives under `cvsnt/cvsnt-2.5.05.3744/`. Every path below is relative to the repository
-root unless stated otherwise.
+All source lives under `cvsnt/cvsnt-2.5.05.3744/`. Repository files (`README.md`, `docs/`,
+`_reports/`, `cvsnt/build-*`) are cited relative to the repository root; bare source paths
+(`configure.in`, `Makefile.am`, `tools/...`, `osx/...`, `zstd/...`) are relative to
+`cvsnt/cvsnt-2.5.05.3744/`.
 
 Two build systems coexist:
 
@@ -93,8 +95,8 @@ installed by the main `make install`), compiles with `clang++ -O3 -msse4.1`, and
 | `--enable-gserver` / `--enable-sspi` | GSSAPI / SSPI methods |
 | `--enable-64bit` | 64-bit build |
 | `--disable-avx512` | Build BLAKE3 **without** AVX-512 kernels. AVX-512 is **on by default** on non-macOS targets (`configure.in:735`). AMD CPUs older than Zen 4 do not have it and will die with an illegal instruction, so use this flag if any target machine might be one (commit `2cd984a`) |
-| `--with-config_dir=DIR` | Where global settings live; defaults to `${sysconfdir}/cvsnt` |
-| `--with-protocol_dir=DIR` | Where protocol plugins are searched for |
+| `--with-config-dir=DIR` | Where global settings live; defaults to `${sysconfdir}/cvsnt` |
+| `--with-protocol-dir=DIR` | Where protocol plugins are searched for |
 | `--disable-mysql`, `--disable-postgres`, `--disable-sqlite`, `--disable-odbc` | Skip database back-ends you do not need — this removes most of the optional dependencies |
 | `--disable-hfs` | Skip HFS+ support (macOS only) |
 
@@ -119,9 +121,13 @@ cd cvsnt
 What it does:
 
 1. `brew install autoconf automake pkg-config libtool pcre openssl@3`.
-2. Symlinks the Homebrew OpenSSL 3 headers and libraries into `/usr/local/include` and
-   `/usr/local/lib`. It handles both the Intel (`/usr/local/opt`) and Apple Silicon
-   (`/opt/homebrew/opt`) prefixes.
+2. Force-symlinks the Homebrew OpenSSL 3 headers and libraries into `/usr/local/include` and
+   `/usr/local/lib`, replacing whatever was there — prior targets are not saved or restored, so
+   the machine-wide OpenSSL setup can change for other software. It handles both the Intel
+   (`/usr/local/opt`) and Apple Silicon (`/opt/homebrew/opt`) prefixes, but the library links use
+   a nonexistent `libopenssl.*` stem for everything except `libcrypto`
+   (`cvsnt/build-macosx:31-39`); `libssl` itself is never linked, so configure's `SSL_CTX_new`
+   probe can fail on a clean machine and silently disable `:sserver:`.
 3. `autoreconf -i --force`.
 4. Builds and installs the in-tree `zstd`.
 5. Runs `osx/build-mac`, which configures with clang for the chosen architecture and produces
@@ -155,7 +161,9 @@ tar xzf cvsnt-3.5.*.tar.gz
 That copies binaries and libraries into `/usr/local/bin`, `/usr/local/lib`, etc.
 
 `build-macosx` modifies the working tree. When it is done, run `git checkout .` to discard the
-generated files, as the script itself reminds you.
+generated files, as the script itself reminds you — but only if the tree was clean when you
+started: `git checkout .` throws away *every* tracked modification, not just what the build
+generated. Commit or stash your own edits before building.
 
 Prebuilt macOS packages for x64 and arm64 are published under
 [Releases](https://github.com/GaijinEntertainment/G-CVSNT/releases).
@@ -181,7 +189,10 @@ cvsnt\cvsnt-2.5.05.3744\cvsnt.sln
 ```
 
 Open it, pick `Release|x64` (or `Release|Win32`), and build the solution. All 58 projects in the
-solution are marked to build; `cvsnt` produces `cvs.exe`.
+solution are marked to build; `cvsnt` produces `cvs.exe`. The solution has no `cafs_server`
+project — build the Windows blob server separately with
+`keyValueServer/server/build_server_cafs.cmd`; the solution's `cafs_proxy` project produces
+`cafs_proxy.exe`.
 
 The main client/server project (`cvsnt.vcxproj`) is configured with:
 
@@ -200,8 +211,8 @@ make_msix64.bat        (64-bit)
 make_msi.bat           (32-bit)
 ```
 
-Both must be run **from the `cvsnt/` directory** — they invoke `msi_toolsin\candle.exe` and
-`msi_toolsin\light.exe` by relative path and read the `.wxs` from the current directory. The WiX
+Both must be run **from the `cvsnt/` directory** — they invoke `msi_tools\bin\candle.exe` and
+`msi_tools\bin\light.exe` by relative path and read the `.wxs` from the current directory. The WiX
 toolset ships in `cvsnt/msi_tools/bin/`; nothing needs to be on `PATH`.
 
 ### Building without Visual Studio
@@ -232,8 +243,9 @@ Two things to know:
 * `cvs init` needs the trigger plugin (`triggers/info_triggers.vcxproj`); without it you get
   `Couldn't open default trigger library`. Client commands work without it.
 
-`_reports/BUILD-01-windows-toolchain.md` has the full environment setup, the makefile, the exact
-dependency graph and every problem encountered along the way.
+`_reports/BUILD-01-windows-toolchain.md` (in the analysis-reports slice of this audit series) has
+the full environment setup, the makefile, the exact dependency graph and every problem encountered
+along the way.
 
 ---
 

--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -63,7 +63,9 @@ sudo make install
 ```
 
 Note the ordering: **zstd is built and installed before the main `make`**. The main build links
-against the installed `libzstd`, not against the in-tree copy.
+against the installed `libzstd`, not against the in-tree copy. The driver also runs
+`tools/build_tools` after the main build, so the hyphenated tool names described below are
+produced as well.
 
 ### The maintenance tools
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ Documentation
 * [docs/](docs/) — architecture, blob storage, protocols, repository layout, server operations,
   client usage and a source map
 * [HOWTOBUILD.md](HOWTOBUILD.md) — building on Windows, Linux and macOS
-* [_reports/](_reports/) — code-analysis findings and performance analyses
+* [_reports/](_reports/) — code-analysis findings and performance analyses (lands in the next
+  slice of the audit series; a forward reference on this branch)

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ OSX 10.9+ notes:
 
 * prebuilt package archives are available in Releases (for x64 and arm64 arch):
   https://github.com/GaijinEntertainment/G-CVSNT/releases
+
+Documentation
+-------------
+
+* [docs/](docs/) — architecture, blob storage, protocols, repository layout, server operations,
+  client usage and a source map
+* [HOWTOBUILD.md](HOWTOBUILD.md) — building on Windows, Linux and macOS
+* [_reports/](_reports/) — code-analysis findings and performance analyses

--- a/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/streaming_blobs.h
+++ b/cvsnt/cvsnt-2.5.05.3744/ca_blobs_fs/streaming_blobs.h
@@ -54,8 +54,8 @@ inline bool decode_stream_blob_data(DownloadBlobInfo &info, const char *data, si
   using namespace streaming_compression;
   if (info.dataRead < sizeof(BlobHeader))
   {
-    size_t hdrPart = (data_length - info.dataRead);
-    hdrPart = hdrPart < sizeof(BlobHeader) ? hdrPart : sizeof(BlobHeader);
+    size_t hdrPart = sizeof(BlobHeader) - info.dataRead;
+    hdrPart = hdrPart < data_length ? hdrPart : data_length;
     memcpy((char*)&info.hdr + info.dataRead, data, hdrPart);
     info.dataRead += hdrPart;
 

--- a/cvsnt/cvsnt-2.5.05.3744/cvsapi/unix/SocketIO.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/cvsapi/unix/SocketIO.cpp
@@ -308,7 +308,7 @@ int CSocketIO::recv(char *buf, int len)
 	if((len-oldlen)<=m_buflen)
 	{
 		memcpy(buf+oldlen,m_buffer,len-oldlen);
-		m_bufpos+=len;
+		m_bufpos+=(len-oldlen);
 		return len;
 	}
 	memcpy(buf+oldlen,m_buffer,m_buflen);

--- a/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/keyValueServer/blob_sockets/blob_sockets.cpp
@@ -21,7 +21,7 @@ IpType blob_classify_ip(uint32_t ip)
   if (ip == 0x100007f)//127.0.0.1
     return IpType::LOCAL;
   //https://en.wikipedia.org/wiki/Private_network
-  if ( (ip&0xF) == 10)//10.x.x.x
+  if ( (ip&0xFF) == 10)//10.x.x.x
     return IpType::PRIVATE;
   if ( (ip&0xFFFF) == 0xa8c0)//192.168.x.x
     return IpType::PRIVATE;

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,0 +1,73 @@
+# G-CVSNT — Overview
+
+G-CVSNT is Gaijin Entertainment's fork of [CVSNT](http://www.cvsnt.org/) 2.5.05, re-versioned as
+**CVSNT 3.5.x**. It keeps the CVS command set, the CVS client/server protocol and the RCS (`,v`)
+repository format, but replaces the way *large binary files* are stored and transferred.
+
+The fork exists because classic CVS/CVSNT is a poor fit for game development:
+
+| Classic CVS behaviour | Why it hurts a game repository |
+| --- | --- |
+| Every revision of a binary file is appended to the `,v` file as a full copy | A 200 MB texture committed 50 times produces a ~10 GB `,v` file |
+| The whole `,v` file must be rewritten to add a tag or a branch | Tagging becomes an O(total repository bytes) operation |
+| Identical files stored in different paths are stored twice | Art pipelines produce enormous amounts of duplicate data |
+| File content travels inline in the client/server protocol stream | One slow connection stalls the whole update; no CDN/proxy caching possible |
+
+## The core idea: `-kB` and content-addressed blobs
+
+G-CVSNT adds a keyword-expansion mode **`-kB`** ("binary delta"), and its compressed variant
+**`-kBz`**. For a file registered with `-kB`:
+
+* The file *content* is stored once, by hash, in a **content-addressed file store** (CAFS) that lives
+  beside the repository — not inside the `,v` file.
+* The `,v` file stores only a fixed-size **blob reference** (`blake3:<64 hex chars>`) per revision.
+* Because the store is keyed by content hash, identical content anywhere in the repository — across
+  paths, branches, and revisions — occupies exactly one blob.
+* Blobs are transferred over a **separate, dedicated TCP protocol** (`blob_push`), not inline in the
+  CVS stream. That connection can be pointed at a read-only caching **proxy** near the client.
+
+The result: `,v` files stay small and roughly constant in size, tag/branch operations touch only small
+headers, and binary payload moves over a channel that can be cached, parallelised and proxied.
+
+## What is *not* changed
+
+* The CVS command surface (`checkout`, `update`, `commit`, `tag`, `rtag`, `diff`, `log`, …).
+* The RCS `,v` on-disk format itself — a G-CVSNT repository is still a CVS repository. Text files
+  (`-kkv`, `-kb`, …) are stored exactly as before, as RCS deltas.
+* The CVS client/server wire protocol — G-CVSNT only *adds* requests and responses, so an old client
+  can still talk to a new server for text-only work.
+* ACLs, triggers, `CVSROOT/` administrative files, the lock server, and the Windows service /
+  control-panel integration inherited from CVSNT.
+
+## Components shipped by this fork
+
+| Binary | Role |
+| --- | --- |
+| `cvs` / `cvs.exe` | The client, and (with `SERVER_SUPPORT`) the server-side command processor |
+| `cvslockd` | Lock server (advisory locking across concurrent server processes) |
+| `cafs_server` | Content-addressed blob store server — the authoritative blob storage |
+| `cafs_proxy_server` | Read-through caching proxy for `cafs_server`, deployable near clients |
+| `cvtblob` | Converts existing `,v` files with inline binary revisions into blob references |
+| `gc-blobs` | Garbage-collects blobs no longer referenced by any `,v` file |
+| `repack-blobs` | Recompresses blobs with the best available compressor |
+| `blake3-calc` | Prints the BLAKE3 hash (the blob key) of a file |
+
+## Version and identity
+
+* Product version comes from `cvsnt/cvsnt-2.5.05.3744/version_no.h`
+  (`CVSNT_PRODUCT_MAJOR/MINOR/PATCHLEVEL`) plus `build.h` (`CVSNT_PRODUCT_BUILD`).
+* The product name string is `" (Gan + [Gaijin -kB/-kBz patch])"`, so `cvs --version` prints e.g.
+  `Concurrent Versions System (CVSNT) 3.5.24 (Gan + [Gaijin -kB/-kBz patch]) Build 7699`.
+* The source directory is still named `cvsnt-2.5.05.3744` for historical reasons; it does **not**
+  reflect the shipped version.
+
+## Where to go next
+
+* [02-architecture.md](02-architecture.md) — process and module layout
+* [03-content-addressed-storage.md](03-content-addressed-storage.md) — the blob store in detail
+* [04-protocols.md](04-protocols.md) — CVS protocol extensions and the blob protocol
+* [05-repository-layout.md](05-repository-layout.md) — what is on disk, server and client side
+* [06-server-operations.md](06-server-operations.md) — running master, proxy, lock server, GC
+* [07-client-usage.md](07-client-usage.md) — commands and options that matter in this fork
+* [08-source-map.md](08-source-map.md) — directory-by-directory guide to the source tree
+* [../HOWTOBUILD.md](../HOWTOBUILD.md) — building on Windows, Linux and macOS

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -23,8 +23,11 @@ G-CVSNT adds a keyword-expansion mode **`-kB`** ("binary delta"), and its compre
 * The `,v` file stores only a fixed-size **blob reference** (`blake3:<64 hex chars>`) per revision.
 * Because the store is keyed by content hash, identical content anywhere in the repository — across
   paths, branches, and revisions — occupies exactly one blob.
-* Blobs are transferred over a **separate, dedicated TCP protocol** (`blob_push`), not inline in the
-  CVS stream. That connection can be pointed at a read-only caching **proxy** near the client.
+* Blobs are transferred over a **separate, dedicated TCP protocol** (`blob_push`), not inline in
+  the CVS stream — with one exception: a commit whose background pre-upload has not finished falls
+  back to `Blob-transfer` with the payload on the CVS connection (`send_blob_file_direct`,
+  `src/client.cpp:5775`). The blob connection can be pointed at a caching **proxy** near the
+  client (write-through by default).
 
 The result: `,v` files stay small and roughly constant in size, tag/branch operations touch only small
 headers, and binary payload moves over a channel that can be cached, parallelised and proxied.
@@ -49,11 +52,15 @@ headers, and binary payload moves over a channel that can be cached, parallelise
 | `cvs` / `cvs.exe` | The client, and (with `SERVER_SUPPORT`) the server-side command processor |
 | `cvslockd` | Lock server (advisory locking across concurrent server processes) |
 | `cafs_server` | Content-addressed blob store server — the authoritative blob storage |
-| `cafs_proxy_server` | Read-through caching proxy for `cafs_server`, deployable near clients |
-| `cvtblob` | Converts existing `,v` files with inline binary revisions into blob references |
-| `gc-blobs` | Garbage-collects blobs no longer referenced by any `,v` file |
-| `repack-blobs` | Recompresses blobs with the best available compressor |
-| `blake3-calc` | Prints the BLAKE3 hash (the blob key) of a file |
+| `cafs_proxy_server` | Caching proxy for `cafs_server`, deployable near clients; write-through by default (`cafs_proxy.exe` on Windows) |
+| `cvtblob` / `convert_to_blob` | Converts existing `,v` files with inline binary revisions into blob references |
+| `gc-blobs` / `gc_blobs` | Garbage-collects blobs no longer referenced by any `,v` file |
+| `repack-blobs` / `repack_blobs` | Recompresses blobs with the best available compressor |
+| `blake3-calc` / `blake3_calc` | Prints the BLAKE3 hash (the blob key) of a file |
+
+The default Linux `make install` ships the underscore names (`tools/Makefile.am:11`); the
+hyphenated names come from the alternate `tools/build_tools` path — see
+[06-server-operations.md](06-server-operations.md).
 
 ## Version and identity
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -34,8 +34,11 @@ headers, and binary payload moves over a channel that can be cached, parallelise
 * The CVS command surface (`checkout`, `update`, `commit`, `tag`, `rtag`, `diff`, `log`, …).
 * The RCS `,v` on-disk format itself — a G-CVSNT repository is still a CVS repository. Text files
   (`-kkv`, `-kb`, …) are stored exactly as before, as RCS deltas.
-* The CVS client/server wire protocol — G-CVSNT only *adds* requests and responses, so an old client
-  can still talk to a new server for text-only work.
+* The CVS client/server wire protocol — G-CVSNT only *adds* requests and responses. As shipped,
+  however, the new `Blob-transfer` request and `Blob-ref` response are marked *essential*, so this
+  build does **not** interoperate with a pre-blob client or server; a peer that omits them is
+  rejected outright (`src/server.cpp:1010`, `src/client.cpp:789`). See
+  [04-protocols.md](04-protocols.md).
 * ACLs, triggers, `CVSROOT/` administrative files, the lock server, and the Windows service /
   control-panel integration inherited from CVSNT.
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -1,0 +1,136 @@
+# Architecture
+
+## Process view
+
+```
+                        ┌─────────────────────────────────────────┐
+   developer workstation│                                         │
+                        │   cvs.exe  (client mode)                │
+                        │     │                    │              │
+                        └─────┼────────────────────┼──────────────┘
+                              │ CVS protocol       │ blob_push protocol
+                              │ (metadata, text,   │ (binary payload,
+                              │  RCS deltas)       │  content-addressed)
+                              ▼                    ▼
+        ┌──────────────────────────────┐   ┌──────────────────────────┐
+        │ inetd/service → protocol lib │   │ cafs_proxy_server        │
+        │      ↓                       │   │  (read-through cache,    │
+        │ cvs  (server mode)           │   │   near the client)       │
+        │      │           │           │   └───────────┬──────────────┘
+        │      │           │           │               │ miss → master
+        │      ▼           ▼           │               ▼
+        │  RCS ,v files   blob refs    │   ┌──────────────────────────┐
+        │  (repository)        └───────┼──▶│ cafs_server (master)     │
+        │      │                       │   │   <root>/blobs/xx/yy/... │
+        │      ▼                       │   └──────────────────────────┘
+        │  cvslockd (port 2402)        │
+        └──────────────────────────────┘
+```
+
+Three independent network services:
+
+| Service | Default port | Purpose |
+| --- | --- | --- |
+| CVS server | 2401 (`pserver`), or via `ext`/`sserver`/`sspi`/`gserver` | Command processing, metadata, RCS storage |
+| `cvslockd` | 2402 | Advisory read/write locks shared between concurrent CVS server processes (`src/lock.cpp:190`) |
+| `cafs_server` / `cafs_proxy_server` | 2403 | Content-addressed blob storage (`keyValueServer/server/cafs_server.cpp`) |
+
+The blob channel is deliberately separate. It carries no repository semantics — only
+`hash → bytes` — which is what makes a dumb caching proxy possible.
+
+## The single binary
+
+`cvs`/`cvs.exe` is both client and server. `src/main.cpp` dispatches on `argv[1]` through the command
+table at `src/main.cpp:159`; the `server`, `authserver`/`pserver` entries put the same binary into
+server mode (`src/server.cpp`). Which half of a source file runs is guarded by `server_active` and by
+the `SERVER_SUPPORT` / `CLIENT_SUPPORT` compile-time macros — most command files (`update.cpp`,
+`commit.cpp`, `tag.cpp`) contain both the client-side argument parsing and the server-side execution.
+
+## Connection methods (protocol plugins)
+
+The transport is a **loadable shared library**, resolved from the `:method:` part of `CVSROOT` by
+`CLibraryAccess::LoadProtocol` (`src/root.cpp:388`). Each plugin lives in `protocols/` and exports a
+`protocol_interface`:
+
+| Method | Source | Notes |
+| --- | --- | --- |
+| `pserver` | `protocols/pserver.cpp` | Cleartext password auth over TCP |
+| `sserver` | `protocols/sserver.cpp` | `pserver` inside TLS |
+| `sspi` | `protocols/sspi.cpp` | Windows SSPI / NTLM / Kerberos |
+| `gserver` | `protocols/gserver.cpp` | GSSAPI |
+| `ssh` | `protocols/ssh.cpp` | Built-in SSH client (`plink/`) |
+| `ext` | `protocols/ext.cpp` | External `rsh`/`ssh` command |
+| `server` | `protocols/server.cpp` | `:server:` — spawn via rsh |
+| `fork` | `protocols/fork.cpp` | Local child process, used for testing |
+| `enum` | `protocols/enum.cpp` | mDNS/Bonjour server discovery |
+
+Protocol plugins are discovered in the protocol directory configured at build time
+(`--with-protocol_dir`) or overridden with the global `-C` option.
+
+## Layered libraries
+
+```
+        cvs / cafs_server / cvslockd / triggers
+                        │
+        ┌───────────────┼────────────────┬─────────────────┐
+        ▼               ▼                ▼                 ▼
+     cvsapi         cvstools        ca_blobs_fs      keyValueServer
+   (C++ support   (config, paths,   (blob store     (blob wire protocol,
+    library)       library load)     on disk)        client + server + proxy)
+        │                                 │                 │
+        └──────────────┬──────────────────┴─────────────────┘
+                       ▼
+          zlib · zstd · pcre · libxml2 · blake3 · OpenSSL
+```
+
+* **`cvsapi/`** — the C++ support layer: `CSocketIO`, `CHttpSocket`, `CSqlConnection` and the
+  database back-ends under `cvsapi/db/`, `CCrypt`, compression wrappers, mDNS
+  (`cvsapi/mdns/`), and the platform split under `cvsapi/unix/` and `cvsapi/win32/`.
+* **`cvstools/`** — `CGlobalSettings` (registry / config-file settings), `CLibraryAccess`
+  (dynamic loading of protocol and trigger plugins), path and codepage helpers.
+* **`lib/`** — the GNU portability layer inherited from CVS: `getline`, `fnmatch`, `getopt`,
+  `xmalloc`, `regex`, `md5`, `savecwd`.
+* **`diff/`, `xdiff/`** — GNU diff, plus the pluggable external/XML diff back-ends.
+* **`ca_blobs_fs/`** — the on-disk content-addressed store (see
+  [03-content-addressed-storage.md](03-content-addressed-storage.md)).
+* **`keyValueServer/`** — the `blob_push` wire protocol: `clientLib/`, `serverLib/`, the
+  standalone `server/`, the caching `proxy/`, and the socket layer `blob_sockets/`.
+
+## Request flow — `cvs update` in client/server mode
+
+1. **Client** (`src/update.cpp:164` → `src/client.cpp`) parses options, walks the working copy with
+   `start_recursion` (`src/recurse.cpp`), and for each directory sends `Directory`, `Entry`,
+   and `Modified`/`Unchanged`/`Is-modified` requests, then `update`.
+2. **Server** (`src/server.cpp`, request table at `src/server.cpp:4908`) reconstructs a temporary
+   working directory from those requests, then runs the same `update` code with `server_active`
+   set.
+3. For each file the server compares the client's revision against the repository
+   (`src/classify.cpp`, `src/vers_ts.cpp`) and emits a response
+   (`Updated`, `Merged`, `Patched`, `Rcs-diff`, `Removed`, …; table at `src/client.cpp:4022`).
+4. For a `-kB` file the server emits **`Blob-ref`** instead of file content — the 71-byte reference
+   only. The client then fetches the actual bytes over the blob channel
+   (`src/download_blob_to.cpp`), optionally with several worker threads (`cvs -j N`).
+5. **Client** writes the file, updates `CVS/Entries`, and moves on.
+
+Step 4 is the pivot of the whole design: the CVS connection never carries large payloads, so it stays
+responsive and its cost is proportional to the *number* of files, not their size.
+
+## Commit flow for a `-kB` file
+
+1. Client hashes the working file with BLAKE3, compresses it, and **pushes the blob first**
+   (`src/blob_kv_processor.cpp` / `src/blob_http_processor.cpp`). If the store already has that hash,
+   the push is deduplicated server-side and costs one round trip.
+2. Client sends `Blob-ref-transfer` with the reference in place of file content.
+3. Server checks in a new revision whose *text* is the 71-byte reference
+   (`src/rcs_checkin.cpp`, `src/rcs.cpp:4288` `get_binary_blob_ver_file_path`).
+
+Because the `,v` file grows by ~100 bytes per revision regardless of file size, tag, branch and
+`rlog` costs stop tracking payload size.
+
+## Triggers
+
+Server-side extension points are shared libraries implementing `trigger_interface`
+(`triggers/server.h`), loaded through `CLibraryAccess`. Shipped triggers: `info_trigger`
+(the classic `loginfo`/`commitinfo`/`taginfo`/`historyinfo` files), `script_trigger`,
+`audit_trigger` (SQL audit log), `email_trigger`, `checkout_trigger`. See
+[06-server-operations.md](06-server-operations.md).

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -49,8 +49,8 @@ the `SERVER_SUPPORT` / `CLIENT_SUPPORT` compile-time macros — most command fil
 ## Connection methods (protocol plugins)
 
 The transport is a **loadable shared library**, resolved from the `:method:` part of `CVSROOT` by
-`CLibraryAccess::LoadProtocol` (`src/root.cpp:388`). Each plugin lives in `protocols/` and exports a
-`protocol_interface`:
+`CProtocolLibrary::LoadProtocol` (`cvstools/ProtocolLibrary.cpp:168`), called from `parse_cvsroot`
+(`src/root.cpp:618`). Each plugin lives in `protocols/` and exports a `protocol_interface`:
 
 | Method | Source | Notes |
 | --- | --- | --- |
@@ -62,10 +62,12 @@ The transport is a **loadable shared library**, resolved from the `:method:` par
 | `ext` | `protocols/ext.cpp` | External `rsh`/`ssh` command |
 | `server` | `protocols/server.cpp` | `:server:` — spawn via rsh |
 | `fork` | `protocols/fork.cpp` | Local child process, used for testing |
-| `enum` | `protocols/enum.cpp` | mDNS/Bonjour server discovery |
+| `enum` | `protocols/enum.cpp` | Answers the `BEGIN ENUM` query with the server name, its supported protocols and its repository list (client side: `cvstools/ServerInfo.cpp:41`) |
 
-Protocol plugins are discovered in the protocol directory configured at build time
-(`--with-protocol_dir`) or overridden with the global `-C` option.
+Protocol plugins are discovered in the **library** directory, configured at build time with
+`--with-protocol-dir` (`configure.in:812`, which sets `cvs_library_dir`) and overridden at run time
+with the global `-L` option (`src/main.cpp:1022`). The global `-C` option overrides the *config*
+directory, which is a different thing.
 
 ## Layered libraries
 
@@ -84,12 +86,15 @@ Protocol plugins are discovered in the protocol directory configured at build ti
 ```
 
 * **`cvsapi/`** — the C++ support layer: `CSocketIO`, `CHttpSocket`, `CSqlConnection` and the
-  database back-ends under `cvsapi/db/`, `CCrypt`, compression wrappers, mDNS
-  (`cvsapi/mdns/`), and the platform split under `cvsapi/unix/` and `cvsapi/win32/`.
-* **`cvstools/`** — `CGlobalSettings` (registry / config-file settings), `CLibraryAccess`
-  (dynamic loading of protocol and trigger plugins), path and codepage helpers.
-* **`lib/`** — the GNU portability layer inherited from CVS: `getline`, `fnmatch`, `getopt`,
-  `xmalloc`, `regex`, `md5`, `savecwd`.
+  database back-ends under `cvsapi/db/`, `CCrypt`, `CLibraryAccess` (the `dlopen`/`LoadLibrary`
+  wrapper), XML (`XmlTree`/`XmlNode`), codepage conversion (`Codepage`), mDNS (`cvsapi/mdns/`), and
+  the platform split under `cvsapi/unix/` and `cvsapi/win32/`.
+* **`cvstools/`** — `CGlobalSettings` (registry / config-file settings), `CProtocolLibrary` and
+  `CTriggerLibrary` (plugin loading, built on `CLibraryAccess`), `EntriesParser`, `RootSplitter`,
+  `Scramble`, and the `protocol_interface` / `trigger_interface` headers.
+* **`lib/`** — the GNU portability layer inherited from CVS: `getline`, `getdelim`, `fnmatch`,
+  `getopt_long`, `regcomp`, `getaddrinfo`/`getnameinfo`, `timegm`, `waitpid`. Note that `xmalloc`
+  lives in `src/subr.cpp:67`, `savecwd` in `src/savecwd.cpp`, and MD5 in `cvsapi/lib/md5.c`.
 * **`diff/`, `xdiff/`** — GNU diff, plus the pluggable external/XML diff back-ends.
 * **`ca_blobs_fs/`** — the on-disk content-addressed store (see
   [03-content-addressed-storage.md](03-content-addressed-storage.md)).
@@ -98,7 +103,7 @@ Protocol plugins are discovered in the protocol directory configured at build ti
 
 ## Request flow — `cvs update` in client/server mode
 
-1. **Client** (`src/update.cpp:164` → `src/client.cpp`) parses options, walks the working copy with
+1. **Client** (`src/update.cpp:165` → `src/client.cpp`) parses options, walks the working copy with
    `start_recursion` (`src/recurse.cpp`), and for each directory sends `Directory`, `Entry`,
    and `Modified`/`Unchanged`/`Is-modified` requests, then `update`.
 2. **Server** (`src/server.cpp`, request table at `src/server.cpp:4908`) reconstructs a temporary
@@ -121,8 +126,9 @@ responsive and its cost is proportional to the *number* of files, not their size
    (`src/blob_kv_processor.cpp` / `src/blob_http_processor.cpp`). If the store already has that hash,
    the push is deduplicated server-side and costs one round trip.
 2. Client sends `Blob-ref-transfer` with the reference in place of file content.
-3. Server checks in a new revision whose *text* is the 71-byte reference
-   (`src/rcs_checkin.cpp`, `src/rcs.cpp:4288` `get_binary_blob_ver_file_path`).
+3. Server checks in a new revision whose *text* is the 71-byte reference. The shrink from the
+   79-byte server-side session marker down to the 71-byte reference happens in
+   `RCS_write_binary_rev_data` (`src/rcs_cvt_kB.cpp:91`).
 
 Because the `,v` file grows by ~100 bytes per revision regardless of file size, tag, branch and
 `rlog` costs stop tracking payload size.
@@ -130,7 +136,8 @@ Because the `,v` file grows by ~100 bytes per revision regardless of file size, 
 ## Triggers
 
 Server-side extension points are shared libraries implementing `trigger_interface`
-(`triggers/server.h`), loaded through `CLibraryAccess`. Shipped triggers: `info_trigger`
+(`cvstools/trigger_interface.h`), loaded through `CTriggerLibrary::LoadTrigger`
+(`cvstools/TriggerLibrary.cpp:419`). Shipped triggers: `info_trigger`
 (the classic `loginfo`/`commitinfo`/`taginfo`/`historyinfo` files), `script_trigger`,
 `audit_trigger` (SQL audit log), `email_trigger`, `checkout_trigger`. See
 [06-server-operations.md](06-server-operations.md).

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -14,7 +14,7 @@
                               ▼                    ▼
         ┌──────────────────────────────┐   ┌──────────────────────────┐
         │ inetd/service → protocol lib │   │ cafs_proxy_server        │
-        │      ↓                       │   │  (read-through cache,    │
+        │      ↓                       │   │  (write-through cache,   │
         │ cvs  (server mode)           │   │   near the client)       │
         │      │           │           │   └───────────┬──────────────┘
         │      │           │           │               │ miss → master
@@ -35,8 +35,9 @@ Three independent network services:
 | `cvslockd` | 2402 | Advisory read/write locks shared between concurrent CVS server processes (`src/lock.cpp:190`) |
 | `cafs_server` / `cafs_proxy_server` | 2403 | Content-addressed blob storage (`keyValueServer/server/cafs_server.cpp`) |
 
-The blob channel is deliberately separate. It carries no repository semantics — only
-`hash → bytes` — which is what makes a dumb caching proxy possible.
+The blob channel is deliberately separate. It carries no revision or path semantics — only
+`repository root + hash → bytes`: the `VERS` handshake carries the root, and the server serves
+`<dir_for_roots>/<root>/blobs` from it — which is what makes a dumb caching proxy possible.
 
 ## The single binary
 
@@ -117,20 +118,25 @@ directory, which is a different thing.
    (`src/download_blob_to.cpp`), optionally with several worker threads (`cvs -j N`).
 5. **Client** writes the file, updates `CVS/Entries`, and moves on.
 
-Step 4 is the pivot of the whole design: the CVS connection never carries large payloads, so it stays
-responsive and its cost is proportional to the *number* of files, not their size.
+Step 4 is the pivot of the whole design: on update the CVS connection never carries large
+payloads, so it stays responsive and its cost is proportional to the *number* of files, not their
+size. (Commit has one fallback that does put payload on the CVS connection — see below.)
 
 ## Commit flow for a `-kB` file
 
-1. Client hashes the working file with BLAKE3, compresses it, and **pushes the blob first**
-   (`src/blob_kv_processor.cpp` / `src/blob_http_processor.cpp`). If the store already has that hash,
-   the push is deduplicated server-side and costs one round trip.
+1. Client hashes the working file with BLAKE3 and **pushes the blob first** over the KV protocol
+   (`src/blob_kv_processor.cpp`; the HTTP processor is download-only, `canUpload() == false`). If
+   the store already has that hash, the client's `SIZE` probe reports it and the push is skipped
+   altogether (`src/blob_kv_processor.cpp:144-151`) — no payload bytes move. If the background
+   pre-upload has not finished by send time, the client falls back to `Blob-transfer` with the
+   payload on the CVS connection (`send_blob_file_direct`, `src/client.cpp:5775`).
 2. Client sends `Blob-ref-transfer` with the reference in place of file content.
 3. Server checks in a new revision whose *text* is the 71-byte reference. The shrink from the
    79-byte server-side session marker down to the 71-byte reference happens in
    `RCS_write_binary_rev_data` (`src/rcs_cvt_kB.cpp:91`).
 
-Because the `,v` file grows by ~100 bytes per revision regardless of file size, tag, branch and
+Because the `,v` file grows by only ~250 bytes plus the log message per revision regardless of file
+size (see [05-repository-layout.md](05-repository-layout.md) for the breakdown), tag, branch and
 `rlog` costs stop tracking payload size.
 
 ## Triggers

--- a/docs/03-content-addressed-storage.md
+++ b/docs/03-content-addressed-storage.md
@@ -1,0 +1,155 @@
+# Content-addressed storage (CAFS)
+
+CAFS is the store that holds the bytes of every `-kB`/`-kBz` file. It is a plain
+`hash → immutable byte string` map on a filesystem. It knows nothing about revisions, branches,
+paths or users; the RCS `,v` files remain the only place where *history* lives.
+
+Source: `ca_blobs_fs/` (on-disk store) and `keyValueServer/` (network layer).
+
+## The key: BLAKE3
+
+The key of a blob is the **BLAKE3-256 hash of its uncompressed content**, lower-case hex, 64
+characters (`src/sha_blob_reference.h:9`).
+
+BLAKE3 was chosen over SHA-256 for two stated reasons (`src/sha_blob_reference.h:6`): it is not
+vulnerable to length extension, and it is several times faster — 4× in plain C, 8× with SSE2, more
+with AVX-512. Hashing throughput matters because every commit and every integrity check re-hashes
+whole files. The implementation is vendored in `blake3/` with SSE2/SSE4.1/AVX2/AVX-512 kernels
+selected at run time.
+
+## On-disk layout
+
+```
+<dir_for_roots>/<root>/blobs/<h0><h1>/<h2><h3>/<64-hex-hash>
+```
+
+Two levels of 256-way fan-out from the first four hex characters keep directory sizes manageable
+(`ca_blobs_fs/src/content_addressed_fs.cpp:66`). Example:
+
+```
+/cvs/myrepo/blobs/3f/a9/3fa91c2e...<64 chars total>
+```
+
+`set_dir_for_roots()` sets the parent, `set_root()` appends the repository root and the fixed
+`blobs` sub-folder. `set_temp_dir()` chooses where partially-written blobs live; when unset, the
+temp file is created inside the *destination* directory so the final step is a same-filesystem
+rename.
+
+## Blob file format
+
+Every blob file starts with a 16-byte header (`ca_blobs_fs/ca_blob_format.h`):
+
+| Offset | Size | Field | Meaning |
+| --- | --- | --- | --- |
+| 0 | 4 | `magic` | `ZSTD`, `ZLIB`, or `NONE` |
+| 4 | 2 | `headerSize` | `sizeof(BlobHeader)` |
+| 6 | 2 | `flags` | bit 0 = `BEST_POSSIBLE_COMPRESSION` |
+| 8 | 8 | `uncompressedLen` | size of the original content |
+
+The payload follows, compressed according to `magic`. The *hash is always of the uncompressed
+content*, so re-compressing a blob with a different algorithm does not change its key — which is
+exactly what makes `repack-blobs` safe.
+
+`BEST_POSSIBLE_COMPRESSION` is set only by the offline `repack-blobs` maintenance tool. Clients and
+the server compress on the fly, favouring speed; the flag records "this one has already been
+squeezed as hard as we can, don't bother again".
+
+Compression is abstracted over zlib and zstd by `ca_blobs_fs/streaming_compressors.h`
+(`StreamType::{Unpacked, ZLIB, ZSTD}`), so a store can hold a mixture and readers cope.
+
+## The blob reference
+
+A `-kB` revision stores, as its RCS revision text, a fixed-size reference:
+
+```
+blake3:<64 hex characters>          71 bytes
+```
+
+`src/sha_blob_reference.h` defines `HASH_TYPE_REV_STRING "blake3:"`, `hash_encoded_size = 64`,
+`blob_reference_size = 71`. `is_blob_reference_data()` /
+`get_blob_reference_content_hash()` (`src/blob_operations.cpp:9`) recognise and parse it.
+
+### The session blob reference
+
+There is a second, related form used **only inside the server**: the **session blob reference**,
+79 bytes (`session_blob_reference_size = blob_reference_size + 8`). The extra 8 bytes are an FNV-1a
+hash of the 71-byte reference mixed with a per-process random salt (`gen_session_crypt()`,
+`src/blob_operations.cpp:47`; salt in `src/server.cpp:7217`, seeded from `rdtsc`).
+
+It exists because the server reconstructs a scratch working directory from the client's requests.
+When a client sends `Blob-ref-transfer`, the server writes a 79-byte marker file instead of real
+content (`src/server.cpp:1926`). Later, on the way out, the server treats any 79-byte file that
+carries a valid session MAC as "this is a reference, not content", truncates it to 71 bytes and sends
+`Blob-ref` (`src/server.cpp:4429`); `rcs_checkin` does the same on the commit path
+(`src/rcs_checkin.cpp:1491`).
+
+The salt is what stops an ordinary versioned file whose content happens to be 79 bytes beginning
+with `blake3:` and 64 hex digits — or a deliberately crafted one uploaded by a client — from being
+mistaken for a server-side blob marker. It is a disambiguation tag scoped to one server process, not
+an access-control mechanism.
+
+## Write path (`push`)
+
+`ca_blobs_fs/src/content_addressed_fs.cpp`, API in `ca_blobs_fs/content_addressed_fs.h`:
+
+```
+start_push(ctx, hash)  →  stream_push(pd, data, len)*  →  finish(pd, &actual_hash)
+```
+
+1. **Early dedup.** If `hash` is supplied and that file already exists, `start_push` returns a
+   sentinel handle and all subsequent writes are no-ops; `finish` reports `DEDUPLICATED`. This costs
+   one `stat` and no data transfer at all.
+2. Otherwise a temp file is opened, ideally in the destination directory.
+3. Each `stream_push` writes the *already-compressed* bytes straight through, and — unless the
+   client's hash is trusted — simultaneously decompresses them into a BLAKE3 hasher so the true hash
+   of the uncompressed content is known by the end.
+4. `finish` compares the computed hash with the claimed one (`WRONG_HASH` on mismatch), then
+   `rename`s the temp file into place with `blob_fileio_rename_file_if_nexist`. If someone else won
+   the race, the temp file is unlinked and the result is `DEDUPLICATED`.
+
+Results are `OK`, `DEDUPLICATED`, `IO_ERROR`, `WRONG_HASH`, `EMPTY_DATA`; `is_ok()` treats the first
+two as success.
+
+### The trust model
+
+`set_allow_trust(bool)` decides whether a client-supplied hash is believed without verification. It
+defaults to **on**, and the reasoning is written out at `ca_blobs_fs/content_addressed_fs.h:27`:
+an existing blob is never overwritten, so a lying client cannot corrupt content that is already
+stored — the worst outcome is an unreferenced junk blob that garbage collection later removes.
+Trust is switched off automatically when the server runs with encryption enabled
+(`keyValueServer/server/cafs_server.cpp:44`), and the network server never trusts clients on the
+verification path.
+
+## Read path (`pull`)
+
+```
+start_pull(ctx, hash, &blob_sz)  →  pull(pd, from, &data_pulled)*  →  destroy(pd)
+```
+
+Reads are memory-mapped and support random access from an arbitrary offset, which is what lets the
+network layer serve a blob in 1 MB chunks (`blob_push_proto::pull_chunk_size`) and lets a client
+resume.
+
+## Immutability and its consequences
+
+Blobs are never modified in place and never overwritten. That gives:
+
+* **Free dedup** — the same asset committed on ten branches is one file.
+* **Trivial caching** — a proxy can cache a blob forever; content can never change under a hash.
+* **Cheap integrity checking** — re-hash the file, compare to the filename.
+* **No reference counting** — nothing tracks how many `,v` files point at a blob. Reclaiming space
+  therefore requires a *mark-and-sweep* pass, which is what `gc-blobs` does: scan every `,v` file
+  in the repository for references, then delete unreferenced blobs. See
+  [06-server-operations.md](06-server-operations.md).
+
+## Related tools
+
+| Tool | Source | Purpose |
+| --- | --- | --- |
+| `cvtblob` | `tools/convert_to_blob.cpp` | Rewrites existing `,v` files, moving inline binary revisions into the blob store and replacing them with references |
+| `gc-blobs` | `tools/gc-blobs.cpp` | Mark-and-sweep collection of unreferenced blobs |
+| `repack-blobs` | `tools/repack-blobs.cpp` | Recompresses blobs to the best available ratio and sets `BEST_POSSIBLE_COMPRESSION` |
+| `blake3-calc` | `tools/blake3-calc.cpp` | Prints a file's blob key |
+
+All four take the repository root and operate directly on the filesystem; they coordinate with the
+running server through `tools/simpleLock.cpp.inc`.

--- a/docs/03-content-addressed-storage.md
+++ b/docs/03-content-addressed-storage.md
@@ -86,8 +86,9 @@ It exists because the server reconstructs a scratch working directory from the c
 When a client sends `Blob-ref-transfer`, the server writes a 79-byte marker file instead of real
 content (`src/server.cpp:1926`). Later, on the way out, the server treats any 79-byte file that
 carries a valid session MAC as "this is a reference, not content", truncates it to 71 bytes and sends
-`Blob-ref` (`src/server.cpp:4429`); `rcs_checkin` does the same on the commit path
-(`src/rcs_checkin.cpp:1491`).
+`Blob-ref` (`src/server.cpp:4429`); on the commit path the shrink happens in
+`RCS_write_binary_rev_data` (`src/rcs_cvt_kB.cpp:91`), while `rcs_checkin` only extracts the
+referenced hash to compare revisions (`src/rcs_checkin.cpp:1491`).
 
 The salt is what stops an ordinary versioned file whose content happens to be 79 bytes beginning
 with `blake3:` and 64 hex digits — or a deliberately crafted one uploaded by a client — from being
@@ -112,7 +113,9 @@ start_push(ctx, hash)  →  stream_push(pd, data, len)*  →  finish(pd, &actual
 3. Each `stream_push` writes the *already-compressed* bytes straight through, and — unless the
    client's hash is trusted — simultaneously decompresses them into a BLAKE3 hasher so the true hash
    of the uncompressed content is known by the end.
-4. `finish` compares the computed hash with the claimed one (`WRONG_HASH` on mismatch), then
+4. `finish` compares the computed hash with the claimed one (`WRONG_HASH` on mismatch) — but only
+   when trust is off or no hash was provided; with default trust and a client hash the claim is
+   copied unverified (`content_addressed_fs.cpp:203-211`, see the trust model below). Then it
    `rename`s the temp file into place with `blob_fileio_rename_file_if_nexist`. If someone else won
    the race, the temp file is unlinked and the result is `DEDUPLICATED`.
 
@@ -122,11 +125,17 @@ two as success.
 ### The trust model
 
 `set_allow_trust(bool)` decides whether a client-supplied hash is believed without verification. It
-defaults to **on**, and the reasoning is written out at `ca_blobs_fs/content_addressed_fs.h:27`:
-an existing blob is never overwritten, so a lying client cannot corrupt content that is already
-stored — the worst outcome is an unreferenced junk blob that garbage collection later removes.
-Trust is switched off automatically when the server runs with encryption enabled
-(`keyValueServer/server/cafs_server.cpp:46`).
+defaults to **on**. The reasoning written out at `ca_blobs_fs/content_addressed_fs.h:27` — an
+existing blob is never overwritten, so a lying client cannot corrupt content that is already
+stored — undersells the risk: with trust on the data is stored under the client-supplied hash
+unverified (`content_addressed_fs.cpp:158,203-211`) and the first writer wins. A client that
+pushes junk under a real BLAKE3 key binds that key for good — later honest pushes of the true
+content return `DEDUPLICATED` and never overwrite, `gc-blobs` keeps the referenced poison, and
+every later download of it fails client-side validation. Working copies are not silently
+corrupted, but that store key is dead.
+Enabling encryption switches trust off automatically — but only when `allow_trust` was `on`: the
+clear sits inside `if (allow)` (`keyValueServer/server/cafs_server.cpp:45-46`), so with
+`allow_trust off` (itself a no-op, see below) the never-applied default stays trusting.
 
 The header comment at `ca_blobs_fs/content_addressed_fs.h:41` claims the networking server never
 trusts client hashes. **The code does not implement that.**
@@ -141,15 +150,21 @@ see `_reports/BUG-blob-07-cafs-server-allow-trust-off-ignored.md`.
 start_pull(ctx, hash, &blob_sz)  →  pull(pd, from, &data_pulled)*  →  destroy(pd)
 ```
 
-Reads are memory-mapped and support random access from an arbitrary offset, which is what lets a
-client resume a `PULL` from any megabyte boundary (`blob_push_proto::pull_chunk_size` quantises the
-start offset). The body of a `PULL` is streamed in one run, not in chunks.
+Reads are memory-mapped. The API shape allows random access, but the implementation returns data
+from the start of the mapping no matter what `from` says (`ca_blobs_fs/src/fileio.cpp:305-313`),
+so a `PULL` resumed at a nonzero megabyte boundary yields wrong bytes — whole-blob pulls are the
+only correct form today (see [04-protocols.md](04-protocols.md)). The body of a `PULL` is streamed
+in one run, not in chunks.
 
 ## Immutability and its consequences
 
-A blob's *uncompressed content* under a given hash never changes, and the push path never
-overwrites an existing file (`blob_fileio_rename_file_if_nexist`,
-`ca_blobs_fs/src/content_addressed_fs.cpp:219`). The stored *bytes* can still be replaced by a
+A blob's *uncompressed content* under a given hash never changes as long as hashes are verified.
+The push path's no-overwrite guard is check-then-rename (`blob_fileio_rename_file_if_nexist`,
+`ca_blobs_fs/src/fileio.h:19-27`, used at `content_addressed_fs.cpp:219`), and a POSIX `rename`
+replaces its target: two concurrent pushers of one hash can both pass the check, and the later
+rename silently replaces the earlier file. With verified hashes both hold the same content and the
+race is harmless; with `allow_trust` on it is one more way a wrong payload can land under a real
+key. The stored *bytes* can still be replaced by a
 repack, which rewrites the same path with a better-compressed payload using the unconditional
 rename (`ca_blobs_fs/src/content_addressed_fs.cpp:354`); the proxy accounts for this
 (`keyValueServer/proxy/proxy_file_lib.cpp:198`).

--- a/docs/03-content-addressed-storage.md
+++ b/docs/03-content-addressed-storage.md
@@ -9,11 +9,11 @@ Source: `ca_blobs_fs/` (on-disk store) and `keyValueServer/` (network layer).
 ## The key: BLAKE3
 
 The key of a blob is the **BLAKE3-256 hash of its uncompressed content**, lower-case hex, 64
-characters (`src/sha_blob_reference.h:9`).
+characters (`src/sha_blob_reference.h:10`).
 
-BLAKE3 was chosen over SHA-256 for two stated reasons (`src/sha_blob_reference.h:6`): it is not
-vulnerable to length extension, and it is several times faster — 4× in plain C, 8× with SSE2, more
-with AVX-512. Hashing throughput matters because every commit and every integrity check re-hashes
+BLAKE3 was chosen over SHA-256 for two stated reasons (`src/sha_blob_reference.h:7`): it is not
+vulnerable to length extension, and it is several times faster — the comment claims 4× in plain C
+and 8× with SSE2 alone, with more available from AVX. Hashing throughput matters because every commit and every integrity check re-hashes
 whole files. The implementation is vendored in `blake3/` with SSE2/SSE4.1/AVX2/AVX-512 kernels
 selected at run time.
 
@@ -50,9 +50,15 @@ The payload follows, compressed according to `magic`. The *hash is always of the
 content*, so re-compressing a blob with a different algorithm does not change its key — which is
 exactly what makes `repack-blobs` safe.
 
-`BEST_POSSIBLE_COMPRESSION` is set only by the offline `repack-blobs` maintenance tool. Clients and
-the server compress on the fly, favouring speed; the flag records "this one has already been
-squeezed as hard as we can, don't bother again".
+`BEST_POSSIBLE_COMPRESSION` is set by `repack()` (`ca_blobs_fs/src/content_addressed_fs.cpp:288`).
+That is called both by the offline `repack-blobs` tool *and* by `cafs_server` itself for every newly
+stored blob, at lowered priority, unless the server was started with `norepack`
+(`keyValueServer/server/blob_file_lib.cpp:70`, `cafs_server.cpp:9`). Clients compress on the fly,
+favouring speed; the flag records "this one has already been squeezed as hard as we can, don't
+bother again".
+
+(The comment at `ca_blob_format.h:11` still says only a maintenance utility sets it. That comment is
+stale relative to the code.)
 
 Compression is abstracted over zlib and zstd by `ca_blobs_fs/streaming_compressors.h`
 (`StreamType::{Unpacked, ZLIB, ZSTD}`), so a store can hold a mixture and readers cope.
@@ -98,7 +104,10 @@ start_push(ctx, hash)  →  stream_push(pd, data, len)*  →  finish(pd, &actual
 
 1. **Early dedup.** If `hash` is supplied and that file already exists, `start_push` returns a
    sentinel handle and all subsequent writes are no-ops; `finish` reports `DEDUPLICATED`. This costs
-   one `stat` and no data transfer at all.
+   one `stat` and no disk I/O — but note the server still reads the whole blob off the socket first
+   (`keyValueServer/serverLib/blob_push_proc.cpp:116`). Avoiding the *network* transfer is a
+   separate, client-side optimisation: the client issues a `SIZE` query and skips the push
+   altogether (`src/blob_kv_processor.cpp`, `upload()`).
 2. Otherwise a temp file is opened, ideally in the destination directory.
 3. Each `stream_push` writes the *already-compressed* bytes straight through, and — unless the
    client's hash is trusted — simultaneously decompresses them into a BLAKE3 hasher so the true hash
@@ -117,8 +126,14 @@ defaults to **on**, and the reasoning is written out at `ca_blobs_fs/content_add
 an existing blob is never overwritten, so a lying client cannot corrupt content that is already
 stored — the worst outcome is an unreferenced junk blob that garbage collection later removes.
 Trust is switched off automatically when the server runs with encryption enabled
-(`keyValueServer/server/cafs_server.cpp:44`), and the network server never trusts clients on the
-verification path.
+(`keyValueServer/server/cafs_server.cpp:46`).
+
+The header comment at `ca_blobs_fs/content_addressed_fs.h:41` claims the networking server never
+trusts client hashes. **The code does not implement that.**
+`keyValueServer/server/blob_file_lib.cpp:18` passes the client-supplied hash straight into
+`start_push`, so with the default `allow_trust` an unencrypted `cafs_server` does accept it
+unverified. Worse, `cafs_server`'s own `allow_trust(on|off)` argument is parsed but never applied —
+see `_reports/BUG-blob-07-cafs-server-allow-trust-off-ignored.md`.
 
 ## Read path (`pull`)
 
@@ -126,17 +141,26 @@ verification path.
 start_pull(ctx, hash, &blob_sz)  →  pull(pd, from, &data_pulled)*  →  destroy(pd)
 ```
 
-Reads are memory-mapped and support random access from an arbitrary offset, which is what lets the
-network layer serve a blob in 1 MB chunks (`blob_push_proto::pull_chunk_size`) and lets a client
-resume.
+Reads are memory-mapped and support random access from an arbitrary offset, which is what lets a
+client resume a `PULL` from any megabyte boundary (`blob_push_proto::pull_chunk_size` quantises the
+start offset). The body of a `PULL` is streamed in one run, not in chunks.
 
 ## Immutability and its consequences
 
-Blobs are never modified in place and never overwritten. That gives:
+A blob's *uncompressed content* under a given hash never changes, and the push path never
+overwrites an existing file (`blob_fileio_rename_file_if_nexist`,
+`ca_blobs_fs/src/content_addressed_fs.cpp:219`). The stored *bytes* can still be replaced by a
+repack, which rewrites the same path with a better-compressed payload using the unconditional
+rename (`ca_blobs_fs/src/content_addressed_fs.cpp:354`); the proxy accounts for this
+(`keyValueServer/proxy/proxy_file_lib.cpp:198`).
+
+Content stability gives:
 
 * **Free dedup** — the same asset committed on ten branches is one file.
 * **Trivial caching** — a proxy can cache a blob forever; content can never change under a hash.
-* **Cheap integrity checking** — re-hash the file, compare to the filename.
+* **Integrity checking** — decompress the payload, re-hash it, compare to the filename
+  (`ca_blobs_fs/src/content_addressed_fs.cpp:161`). Note that you cannot hash the blob file's raw
+  bytes: the hash is of the *uncompressed* content, and the file is header-plus-compressed-payload.
 * **No reference counting** — nothing tracks how many `,v` files point at a blob. Reclaiming space
   therefore requires a *mark-and-sweep* pass, which is what `gc-blobs` does: scan every `,v` file
   in the repository for references, then delete unreferenced blobs. See
@@ -151,5 +175,7 @@ Blobs are never modified in place and never overwritten. That gives:
 | `repack-blobs` | `tools/repack-blobs.cpp` | Recompresses blobs to the best available ratio and sets `BEST_POSSIBLE_COMPRESSION` |
 | `blake3-calc` | `tools/blake3-calc.cpp` | Prints a file's blob key |
 
-All four take the repository root and operate directly on the filesystem; they coordinate with the
-running server through `tools/simpleLock.cpp.inc`.
+`cvtblob` and `gc-blobs` take the repository root and coordinate with a running server through the
+lock server (`tools/simpleLock.cpp.inc`). `repack-blobs` takes the root but takes **no** lock.
+`blake3-calc` takes a single filename — not a repository — and touches neither the repository nor
+the lock server.

--- a/docs/04-protocols.md
+++ b/docs/04-protocols.md
@@ -75,7 +75,7 @@ reference path (`src/update.cpp:410`); on commit the fallback decision sits in `
 | Response | Handler | Purpose |
 | --- | --- | --- |
 | `Blob-ref` | `handle_updated_blobs_refs` | "This file's content is blob *H*" — replaces `Updated` |
-| `Blob-ref-created` | `handle_created_blobs_refs` | Same, for a file being created (replaces `Created`) |
+| `Blob-ref-created` | `handle_created_blobs_refs` | Same, for a file being created (replaces `Created`). Advertised and handled, but never sent: the server-side test at `src/server.cpp:4506` reads `vers == NULL && vers->ts_user == NULL` (inverted, and a null dereference if it were ever true), so new `-kB` files arrive as plain `Blob-ref` |
 | `Blob-url` | `handle_blob_url` | Where to fetch blobs from; may be repeated to give several proxies |
 | `Blob-OTP` | `handle_blob_otp` | Time-based one-time secret plus page number, for authenticating to an encrypted blob server |
 

--- a/docs/04-protocols.md
+++ b/docs/04-protocols.md
@@ -21,25 +21,30 @@ used, which is how new features stay backward compatible.
 ### Typical `update` exchange
 
 ```
-C: Root /cvs
 C: Valid-responses ok error Updated Blob-ref Blob-ref-created ...
 C: valid-requests
 S: Valid-requests Root Directory Entry Modified Blob-transfer ...
 S: ok
+C: Root /cvs
 C: UseUnchanged
 C: Argument -d
 C: Directory develop/assets
 C: /cvs/game/develop/assets
-C: Entry /tex.dds/1.14/Wed Jun 4 10:00:00 2025//
+C: Entry /tex.dds/1.14/Wed Jun  4 10:00:00 2025/-kB/
 C: Unchanged tex.dds
 C: update
 S: Blob-ref develop/assets/
 S: /cvs/game/develop/assets/tex.dds
-S: /tex.dds/1.15///
+S: /tex.dds/1.15//-kB/
 S: u=rw,g=rw,o=r
+S: 71
 S: blake3:3fa91c2e...
 S: ok
 ```
+
+Note the ordering: the client sends `Valid-responses` and `valid-requests` and reads the server's
+capability list *before* it sends `Root` (`src/client.cpp:4646`, `:4659`, `:4682`). `Root` is never
+the first request.
 
 The client then fetches `3fa91c2e...` over the blob connection and writes `tex.dds`.
 
@@ -47,7 +52,7 @@ The client then fetches `3fa91c2e...` over the blob connection and writes `tex.d
 
 | Request | Handler | Purpose |
 | --- | --- | --- |
-| `Blob-transfer` | `serve_blob` | Client uploads file content that the server should turn into a blob |
+| `Blob-transfer` | `serve_blob` | Client uploads a *prepared blob* — header plus framed payload — keyed by its content hash; the server streams it into the CAFS as-is (`src/client.cpp:5775`, `src/server.cpp:1836`) |
 | `Blob-ref-transfer` | `serve_blob_ref` | Client has already pushed the blob itself and sends only the reference |
 | `Binary-transfer` | `serve_binary_transfer` | Binary file transfer that bypasses text/codepage translation |
 | `Zstd-stream` | `serve_zstd_stream` | Switch the whole connection to zstd framing instead of gzip |
@@ -59,8 +64,10 @@ them to `0`/`rs_optional` if you need to interoperate with a pre-blob peer
 an old client or an old server** — the blob extensions are mandatory.
 
 `Blob-ref-transfer` is the fast path: the client pushes the blob directly to the CAFS server, then
-tells the CVS server only the 71-byte reference, so the payload never crosses the CVS connection at
-all.
+tells the CVS server only the 71-byte reference — so the payload does not cross the CVS connection,
+*provided* the background pre-upload already placed it in the store. If it did not, the client falls
+back to `Blob-transfer` with the full payload (`src/client.cpp:5864`). `update` always takes the
+reference path (`src/update.cpp:410`); `commit` can fall back (`src/commit.cpp:662`).
 
 ### Responses added by this fork
 
@@ -71,13 +78,17 @@ all.
 | `Blob-url` | `handle_blob_url` | Where to fetch blobs from; may be repeated to give several proxies |
 | `Blob-OTP` | `handle_blob_otp` | Time-based one-time secret plus page number, for authenticating to an encrypted blob server |
 
-`Blob-ref` carries the same envelope as `Updated` (directory, repository path, entry line, mode) but
-its "content" is the 71-byte reference rather than the file (`src/server.cpp:4509`).
+`Blob-ref` carries the same envelope as `Updated` — directory, repository path, entry line, mode,
+then a decimal byte count — but its "content" is the 71-byte reference rather than the file
+(`src/server.cpp:4509`, byte count at `src/server.cpp:4565`).
 
 `Blob-url` values come from the server's own configuration: `cvsnt/PServer/BlobURL` and
 `BlobURL0`...`BlobURL31` (`src/server.cpp:3346`). Later values *override* earlier ones, and the
-client can round-robin between them. When an OTP is configured,
-`BlobEncryptedURL0`...`BlobEncryptedURL31` are sent instead (`src/server.cpp:3379`).
+client round-robins between them: every value is appended to a list, none is discarded
+(`add_blobs_url`, `src/client.cpp:2138`; `get_round_robin_blob_url`, `src/client.cpp:2183`). The
+"overwrite" wording in the server-side comments is stale. When an OTP is configured,
+`BlobEncryptedURL0`...`BlobEncryptedURL31` are sent *as well*, after the `Blob-OTP` line
+(`src/server.cpp:3406`); the client files those separately as encrypting URLs.
 
 `Blob-OTP` sends a TOTP secret derived from the server-side shared secret `cvsnt/PServer/BlobOTP`
 plus the current page number, both hex-encoded (`src/server.cpp:3380`). The client uses it to
@@ -85,19 +96,25 @@ authenticate to the CAFS server without ever seeing the shared secret.
 
 ### Client-side override
 
-`cvs --blob_url <url>` (`src/main.cpp:761`) overrides whatever the server advertises. The value is a
-`|`-separated list, each entry `host[/path][@port]`, with `def` meaning "the master". Examples:
+`cvs --blob_url <url>` (`src/main.cpp:761`) overrides whatever the server advertises:
 
 ```
-cvs --blob_url http://cvs-proxy.lan@8080 up
-cvs --blob_url "localhost@2403|cvs-master.lan@2403" up
+cvs --blob_url cvs-proxy.lan@2403 up
 ```
+
+The help text at `src/main.cpp:349` advertises a `|`-separated list with `def` meaning "the master".
+**Neither is implemented.** `parse_url_port` (`src/client.cpp:2123`) truncates at the first `@` and
+`atoi()`s the rest, so everything after the first entry is silently discarded, and
+`src/download_blob_to.cpp:258` then forces a single URL with no round-robin. No code anywhere
+compares against `def`.
 
 Two transport back-ends implement `BlobNetworkProcessor` (`src/blob_network_processor.h`):
 
 * `src/blob_kv_processor.cpp` — the native `blob_push` TCP protocol (`host@port`)
-* `src/blob_http_processor.cpp` — plain HTTP GET/PUT (`http://...`), using the vendored
-  `src/httplib.h`; useful when a CDN or ordinary web cache sits in front of the store
+* `src/blob_http_processor.cpp` — HTTP GET only, using the vendored `src/httplib.h`. Uploading is a
+  stub (`canUpload()` returns `false`, `src/blob_http_processor.cpp:8`) and the back-end is never
+  selected: `BackgroundProcessor::init()` constructs only `get_kv_processor`
+  (`src/download_blob_to.cpp:292`). The file compiles but is currently unreachable.
 
 ## 2. The `blob_push` protocol
 
@@ -113,21 +130,28 @@ client replies `VERS` plus its own three-character version, then one of two nego
   Diffie-Hellman parameters, all encrypted with the OTP. The server answers with its own 8 random
   bytes and DH parameters. Both derive the same session keys from the two nonces, the OTP page and
   the DH exchange. The client then sends its 64-bit timestamp plus 64 padding bits, encrypted with
-  the session keys ("Client Ready"); the server answers `HAVE` (encryption stays on), `NONE`
-  (continue in clear), `ERIO` (bad timestamp) or `EBRD` (bad version). The root is always sent
-  encrypted.
-* **Prototype (legacy)** — the root is sent immediately; the server answers `NONE` or `EBRD`.
+  the session keys ("Client Ready"). The server echoes 64 bits of ones, which the client verifies —
+  an explicit server-authentication / MITM check (`keyValueServer/clientLib/blob_push_pull_client.cpp:192`,
+  server side `keyValueServer/serverLib/blob_push_proc.cpp:313`). The client then sends the root, and
+  only afterwards reads the 4-byte verdict: `HAVE` (encryption stays on), `NONE` (continue in clear),
+  `ERIO` (bad timestamp) or `ERBD` (bad version). The two are pipelined — the server writes its
+  verdict before reading the root (`blob_push_proc.cpp:361`). The root is always sent encrypted.
+* **Prototype (legacy)** — the root is sent immediately; the server answers `NONE` or `ERBD`.
+
+(The header comment spells the bad-version code `EBRD`; the wire constant is `ERBD`,
+`keyValueServer/include/blob_push_protocol.h:73`.)
 
 Encryption is all-or-nothing for the rest of the connection.
 
 ### Commands
 
-All commands are 4 ASCII bytes. Hashes travel as 32 raw bytes (`bin_hash_len`), prefixed by the
-`blake3:` tag, for `hash_len = 38` bytes total.
+All commands are 4 ASCII bytes. Hashes travel as a **6-byte** type tag — `blake3`, with the trailing
+`:` of `HASH_TYPE_REV_STRING` dropped on the wire (`keyValueServer/include/blob_hash_util.h:87`) —
+followed by 32 raw bytes (`bin_hash_len`), for `hash_len = 38` bytes total.
 
 | Command | Payload | Responses |
 | --- | --- | --- |
-| `VERS` | 3-byte version, then the handshake above | `HAVE` / `NONE` / `ERIO` / `EBRD` |
+| `VERS` | 3-byte version, then the handshake above | `HAVE` / `NONE` / `ERIO` / `ERBD` |
 | `SIZE` | hash | `SIZE` plus 8-byte size, `NONE`, `ERxx` |
 | `CHCK` | hash | `HAVE`, `NONE`, `ERxx` |
 | `PUSH` | hash plus 8-byte size, then that many bytes of prepared blob | `HAVE`, `ERxx` |
@@ -136,11 +160,14 @@ All commands are 4 ASCII bytes. Hashes travel as 32 raw bytes (`bin_hash_len`), 
 
 Notes:
 
-* `PULL` with size 0 and offset 0 means "the whole blob". The offset is counted in units of
-  `1 << 20`, so transfers are naturally chunked at 1 MB (`pull_chunk_size`) and a client can resume
-  from an arbitrary megabyte boundary.
-* `STRM` chunks are `uint16_t` length plus that many bytes; a zero length ends the stream. This is
-  the path used when the client does not know the final compressed size in advance.
+* `PULL` with size 0 and offset 0 means "the whole blob". The *start offset* is counted in units of
+  `1 << 20` (`pull_chunk_size`), so a client can resume from any megabyte boundary. The body itself
+  is not chunked — after the `TAKE` header the server streams the whole remaining length in one run
+  (`keyValueServer/serverLib/blob_push_proc.cpp:214`).
+* `STRM` chunks are `uint16_t` length plus that many bytes; a zero length ends the stream, and
+  `0xFFFF` aborts it (the server replies `ERIO`,
+  `keyValueServer/serverLib/blob_push_proc.cpp:151`), so the largest data chunk is 65534 bytes. This
+  is the path used when the client does not know the final compressed size in advance.
 * What travels for `PUSH`/`STRM` is the *prepared blob* — header plus compressed payload, exactly as
   it will land on disk — not the raw file. The hash, however, is of the uncompressed content.
 * Any response beginning with `ER` is an error (`is_error_response`).
@@ -151,7 +178,10 @@ Notes:
 * Content addressing makes the service cacheable by a proxy that understands nothing about CVS
   (`keyValueServer/proxy/`).
 * Downloads can be parallelised across worker threads (`cvs -j N`) and across several URLs.
-* `CHCK` before `PUSH` turns a re-commit of unchanged content into two small round trips.
+* `SIZE` before `STRM` turns a re-commit of unchanged content into two small round trips
+  (`src/blob_kv_processor.cpp:144`). Note that the CVS client uses `SIZE`/`STRM`, not `CHCK`/`PUSH`:
+  `CHCK` is used by the proxy (`keyValueServer/proxy/proxy_file_lib.cpp:216`) and `PUSH` only by the
+  sample clients.
 
 ## 3. Stream compression
 

--- a/docs/04-protocols.md
+++ b/docs/04-protocols.md
@@ -1,0 +1,167 @@
+# Protocols
+
+G-CVSNT speaks two protocols on two separate connections:
+
+1. The **CVS client/server protocol** — inherited from CVS/CVSNT, extended with a handful of
+   requests and responses for blobs and zstd.
+2. The **`blob_push` protocol** — new in this fork; a small binary protocol that moves blob bytes.
+
+## 1. The CVS client/server protocol
+
+Line-oriented and text-based. The client sends *requests*; the server replies with *responses*
+terminated by `ok` or `error`. Both sides negotiate capabilities up front: the client asks
+`valid-requests`, the server answers with the list it supports; the client announces
+`Valid-responses` with the list *it* supports. Anything not in the other side's list is simply not
+used, which is how new features stay backward compatible.
+
+* Request table: `src/server.cpp:4908` (`struct request requests[]`)
+* Response table: `src/client.cpp:4022` (`struct response responses[]`)
+* Reference for the base protocol: `doc/cvsclient.dbk`
+
+### Typical `update` exchange
+
+```
+C: Root /cvs
+C: Valid-responses ok error Updated Blob-ref Blob-ref-created ...
+C: valid-requests
+S: Valid-requests Root Directory Entry Modified Blob-transfer ...
+S: ok
+C: UseUnchanged
+C: Argument -d
+C: Directory develop/assets
+C: /cvs/game/develop/assets
+C: Entry /tex.dds/1.14/Wed Jun 4 10:00:00 2025//
+C: Unchanged tex.dds
+C: update
+S: Blob-ref develop/assets/
+S: /cvs/game/develop/assets/tex.dds
+S: /tex.dds/1.15///
+S: u=rw,g=rw,o=r
+S: blake3:3fa91c2e...
+S: ok
+```
+
+The client then fetches `3fa91c2e...` over the blob connection and writes `tex.dds`.
+
+### Requests added by this fork
+
+| Request | Handler | Purpose |
+| --- | --- | --- |
+| `Blob-transfer` | `serve_blob` | Client uploads file content that the server should turn into a blob |
+| `Blob-ref-transfer` | `serve_blob_ref` | Client has already pushed the blob itself and sends only the reference |
+| `Binary-transfer` | `serve_binary_transfer` | Binary file transfer that bypasses text/codepage translation |
+| `Zstd-stream` | `serve_zstd_stream` | Switch the whole connection to zstd framing instead of gzip |
+
+`Blob-transfer` is marked `GAIJIN_RQ_ESSENTIAL`, and `Blob-ref` is marked `GAIJIN_rs_essential`.
+Both are aliases for the ordinary `RQ_ESSENTIAL`/`rs_essential`, with a comment saying to redefine
+them to `0`/`rs_optional` if you need to interoperate with a pre-blob peer
+(`src/server.cpp:4907`, `src/client.cpp:4020`). As shipped, therefore, **this build does not talk to
+an old client or an old server** — the blob extensions are mandatory.
+
+`Blob-ref-transfer` is the fast path: the client pushes the blob directly to the CAFS server, then
+tells the CVS server only the 71-byte reference, so the payload never crosses the CVS connection at
+all.
+
+### Responses added by this fork
+
+| Response | Handler | Purpose |
+| --- | --- | --- |
+| `Blob-ref` | `handle_updated_blobs_refs` | "This file's content is blob *H*" — replaces `Updated` |
+| `Blob-ref-created` | `handle_created_blobs_refs` | Same, for a file being created (replaces `Created`) |
+| `Blob-url` | `handle_blob_url` | Where to fetch blobs from; may be repeated to give several proxies |
+| `Blob-OTP` | `handle_blob_otp` | Time-based one-time secret plus page number, for authenticating to an encrypted blob server |
+
+`Blob-ref` carries the same envelope as `Updated` (directory, repository path, entry line, mode) but
+its "content" is the 71-byte reference rather than the file (`src/server.cpp:4509`).
+
+`Blob-url` values come from the server's own configuration: `cvsnt/PServer/BlobURL` and
+`BlobURL0`...`BlobURL31` (`src/server.cpp:3346`). Later values *override* earlier ones, and the
+client can round-robin between them. When an OTP is configured,
+`BlobEncryptedURL0`...`BlobEncryptedURL31` are sent instead (`src/server.cpp:3379`).
+
+`Blob-OTP` sends a TOTP secret derived from the server-side shared secret `cvsnt/PServer/BlobOTP`
+plus the current page number, both hex-encoded (`src/server.cpp:3380`). The client uses it to
+authenticate to the CAFS server without ever seeing the shared secret.
+
+### Client-side override
+
+`cvs --blob_url <url>` (`src/main.cpp:761`) overrides whatever the server advertises. The value is a
+`|`-separated list, each entry `host[/path][@port]`, with `def` meaning "the master". Examples:
+
+```
+cvs --blob_url http://cvs-proxy.lan@8080 up
+cvs --blob_url "localhost@2403|cvs-master.lan@2403" up
+```
+
+Two transport back-ends implement `BlobNetworkProcessor` (`src/blob_network_processor.h`):
+
+* `src/blob_kv_processor.cpp` — the native `blob_push` TCP protocol (`host@port`)
+* `src/blob_http_processor.cpp` — plain HTTP GET/PUT (`http://...`), using the vendored
+  `src/httplib.h`; useful when a CDN or ordinary web cache sits in front of the store
+
+## 2. The `blob_push` protocol
+
+Specified in `keyValueServer/include/blob_push_protocol.h`. Binary, request/response, over one TCP
+connection; little-endian lengths.
+
+### Handshake
+
+The server greets with `BLOBPUSH_SERVER_V` plus a three-character version (20 bytes total). The
+client replies `VERS` plus its own three-character version, then one of two negotiations:
+
+* **Authenticated (current)** — client sends an 8-byte OTP page number, then 8 random bytes and its
+  Diffie-Hellman parameters, all encrypted with the OTP. The server answers with its own 8 random
+  bytes and DH parameters. Both derive the same session keys from the two nonces, the OTP page and
+  the DH exchange. The client then sends its 64-bit timestamp plus 64 padding bits, encrypted with
+  the session keys ("Client Ready"); the server answers `HAVE` (encryption stays on), `NONE`
+  (continue in clear), `ERIO` (bad timestamp) or `EBRD` (bad version). The root is always sent
+  encrypted.
+* **Prototype (legacy)** — the root is sent immediately; the server answers `NONE` or `EBRD`.
+
+Encryption is all-or-nothing for the rest of the connection.
+
+### Commands
+
+All commands are 4 ASCII bytes. Hashes travel as 32 raw bytes (`bin_hash_len`), prefixed by the
+`blake3:` tag, for `hash_len = 38` bytes total.
+
+| Command | Payload | Responses |
+| --- | --- | --- |
+| `VERS` | 3-byte version, then the handshake above | `HAVE` / `NONE` / `ERIO` / `EBRD` |
+| `SIZE` | hash | `SIZE` plus 8-byte size, `NONE`, `ERxx` |
+| `CHCK` | hash | `HAVE`, `NONE`, `ERxx` |
+| `PUSH` | hash plus 8-byte size, then that many bytes of prepared blob | `HAVE`, `ERxx` |
+| `STRM` | hash, then chunks until a zero-length chunk | `HAVE`, `ERxx` |
+| `PULL` | hash plus 8-byte size plus 4-byte start offset | `TAKE` plus echo of the request, then the bytes; or `NONE` / `ERxx` |
+
+Notes:
+
+* `PULL` with size 0 and offset 0 means "the whole blob". The offset is counted in units of
+  `1 << 20`, so transfers are naturally chunked at 1 MB (`pull_chunk_size`) and a client can resume
+  from an arbitrary megabyte boundary.
+* `STRM` chunks are `uint16_t` length plus that many bytes; a zero length ends the stream. This is
+  the path used when the client does not know the final compressed size in advance.
+* What travels for `PUSH`/`STRM` is the *prepared blob* — header plus compressed payload, exactly as
+  it will land on disk — not the raw file. The hash, however, is of the uncompressed content.
+* Any response beginning with `ER` is an error (`is_error_response`).
+
+### Why a separate protocol
+
+* Blob bytes never occupy the CVS connection, so metadata stays responsive on a slow link.
+* Content addressing makes the service cacheable by a proxy that understands nothing about CVS
+  (`keyValueServer/proxy/`).
+* Downloads can be parallelised across worker threads (`cvs -j N`) and across several URLs.
+* `CHCK` before `PUSH` turns a re-commit of unchanged content into two small round trips.
+
+## 3. Stream compression
+
+The CVS connection itself can be compressed:
+
+| Request | Meaning |
+| --- | --- |
+| `Gzip-stream <level>` | Classic CVS zlib framing (`src/zlib.cpp`) |
+| `Zstd-stream <level>` | zstd framing, added by this fork (`src/zstd_buffer.cpp`) |
+
+Selected with the global `-z <0-9>` option. zstd is preferred when both ends support it: it
+compresses metadata-heavy streams faster at comparable ratios. Blob payloads are already compressed
+inside the blob format, so this affects mainly protocol chatter and text files.

--- a/docs/04-protocols.md
+++ b/docs/04-protocols.md
@@ -67,7 +67,8 @@ an old client or an old server** — the blob extensions are mandatory.
 tells the CVS server only the 71-byte reference — so the payload does not cross the CVS connection,
 *provided* the background pre-upload already placed it in the store. If it did not, the client falls
 back to `Blob-transfer` with the full payload (`src/client.cpp:5864`). `update` always takes the
-reference path (`src/update.cpp:410`); `commit` can fall back (`src/commit.cpp:662`).
+reference path (`src/update.cpp:410`); on commit the fallback decision sits in `send_blob_file`
+(`src/client.cpp:5864`).
 
 ### Responses added by this fork
 
@@ -83,8 +84,8 @@ then a decimal byte count — but its "content" is the 71-byte reference rather 
 (`src/server.cpp:4509`, byte count at `src/server.cpp:4565`).
 
 `Blob-url` values come from the server's own configuration: `cvsnt/PServer/BlobURL` and
-`BlobURL0`...`BlobURL31` (`src/server.cpp:3346`). Later values *override* earlier ones, and the
-client round-robins between them: every value is appended to a list, none is discarded
+`BlobURL0`...`BlobURL31` (`src/server.cpp:3346`). The client appends every value to a list and
+round-robins between them — nothing is discarded
 (`add_blobs_url`, `src/client.cpp:2138`; `get_round_robin_blob_url`, `src/client.cpp:2183`). The
 "overwrite" wording in the server-side comments is stale. When an OTP is configured,
 `BlobEncryptedURL0`...`BlobEncryptedURL31` are sent *as well*, after the `Blob-OTP` line
@@ -92,7 +93,11 @@ client round-robins between them: every value is appended to a list, none is dis
 
 `Blob-OTP` sends a TOTP secret derived from the server-side shared secret `cvsnt/PServer/BlobOTP`
 plus the current page number, both hex-encoded (`src/server.cpp:3380`). The client uses it to
-authenticate to the CAFS server without ever seeing the shared secret.
+authenticate to the CAFS server without ever seeing the shared secret. The response rides the
+ordinary CVS stream (`buf_to_net`, `src/server.cpp:3402-3405`), so over a cleartext method such as
+`:pserver:` a network observer can read the OTP page and present it to the blob server for the
+page window — a `BlobOTP` deployment needs an encrypted CVS transport (`-x`, `sserver`, ssh) or an
+equivalently private path for that response.
 
 ### Client-side override
 
@@ -104,9 +109,12 @@ cvs --blob_url cvs-proxy.lan@2403 up
 
 The help text at `src/main.cpp:349` advertises a `|`-separated list with `def` meaning "the master".
 **Neither is implemented.** `parse_url_port` (`src/client.cpp:2123`) truncates at the first `@` and
-`atoi()`s the rest, so everything after the first entry is silently discarded, and
-`src/download_blob_to.cpp:258` then forces a single URL with no round-robin. No code anywhere
-compares against `def`.
+`atoi()`s the rest, so everything after the first entry is silently discarded. No code anywhere
+compares against `def`. The parsed URL replaces only the advertised download list: the master URL
+is still appended after it (`src/download_blob_to.cpp:258,283`), so downloads fall back to the
+master when the override fails, and uploads ignore the override entirely — an upload client always
+talks to the master (`getNext` with `id < 0` returns the last URL,
+`src/download_blob_to.cpp:216-222`).
 
 Two transport back-ends implement `BlobNetworkProcessor` (`src/blob_network_processor.h`):
 
@@ -126,8 +134,8 @@ connection; little-endian lengths.
 The server greets with `BLOBPUSH_SERVER_V` plus a three-character version (20 bytes total). The
 client replies `VERS` plus its own three-character version, then one of two negotiations:
 
-* **Authenticated (current)** — client sends an 8-byte OTP page number, then 8 random bytes and its
-  Diffie-Hellman parameters, all encrypted with the OTP. The server answers with its own 8 random
+* **Authenticated (current)** — client sends its 8-byte OTP page number in the clear, then 8 random
+  bytes and its Diffie-Hellman parameters encrypted with the OTP (`blob_push_protocol.h:17`). The server answers with its own 8 random
   bytes and DH parameters. Both derive the same session keys from the two nonces, the OTP page and
   the DH exchange. The client then sends its 64-bit timestamp plus 64 padding bits, encrypted with
   the session keys ("Client Ready"). The server echoes 64 bits of ones, which the client verifies —
@@ -156,14 +164,19 @@ followed by 32 raw bytes (`bin_hash_len`), for `hash_len = 38` bytes total.
 | `CHCK` | hash | `HAVE`, `NONE`, `ERxx` |
 | `PUSH` | hash plus 8-byte size, then that many bytes of prepared blob | `HAVE`, `ERxx` |
 | `STRM` | hash, then chunks until a zero-length chunk | `HAVE`, `ERxx` |
-| `PULL` | hash plus 8-byte size plus 4-byte start offset | `TAKE` plus echo of the request, then the bytes; or `NONE` / `ERxx` |
+| `PULL` | hash plus 8-byte size plus 4-byte start offset | `TAKE` with hash, 8-byte body length, 4-byte offset, then the bytes; or `NONE` / `ERxx` |
 
 Notes:
 
-* `PULL` with size 0 and offset 0 means "the whole blob". The *start offset* is counted in units of
-  `1 << 20` (`pull_chunk_size`), so a client can resume from any megabyte boundary. The body itself
-  is not chunked — after the `TAKE` header the server streams the whole remaining length in one run
-  (`keyValueServer/serverLib/blob_push_proc.cpp:214`).
+* `PULL` with size 0 and offset 0 means "the whole blob" — and that is the only shape that works
+  today. The `TAKE` size field is not an echo of the request: the server writes the byte count it
+  intends to send (`sizeLeft`, `blob_push_proc.cpp:201-208`). Two implementation defects break the
+  general form: a nonzero size is never clamped in the send loop — `blobe_fileio_pull` hands back
+  the whole remaining mapping and the server streams all of it (`blob_push_proc.cpp:217-229`),
+  misframing the connection; and a nonzero offset (counted in `1 << 20` units,
+  `pull_chunk_size`) returns bytes from the *start* of the blob — `ca_blobs_fs/src/fileio.cpp:313`
+  ignores `from` in the returned pointer — so a resume reconstructs invalid content. The body is
+  not chunked: after the `TAKE` header the server streams in one run.
 * `STRM` chunks are `uint16_t` length plus that many bytes; a zero length ends the stream, and
   `0xFFFF` aborts it (the server replies `ERIO`,
   `keyValueServer/serverLib/blob_push_proc.cpp:151`), so the largest data chunk is 65534 bytes. This
@@ -174,7 +187,8 @@ Notes:
 
 ### Why a separate protocol
 
-* Blob bytes never occupy the CVS connection, so metadata stays responsive on a slow link.
+* Blob bytes stay off the CVS connection (apart from the commit `Blob-transfer` fallback above),
+  so metadata stays responsive on a slow link.
 * Content addressing makes the service cacheable by a proxy that understands nothing about CVS
   (`keyValueServer/proxy/`).
 * Downloads can be parallelised across worker threads (`cvs -j N`) and across several URLs.

--- a/docs/05-repository-layout.md
+++ b/docs/05-repository-layout.md
@@ -172,9 +172,11 @@ written regardless. Where `-n` does apply, the local version is deleted outright
 Two mechanisms coexist:
 
 1. **Filesystem locks** in the repository directory: `#cvs.lock` (the master lock — a *directory*,
-   created with `CVS_MKDIR` at `src/lock.cpp:1088`), `#cvs.rfl.<host>(<user>).<pid>` (read) and
-   `#cvs.wfl.<host>(<user>).<pid>` (write). Names at `src/cvs.h:222`; construction at
-   `src/lock.cpp:722` and `src/lock.cpp:878`. `LockDir` in `CVSROOT/config` can redirect them to a
+   created with `CVS_MKDIR` at `src/lock.cpp:1088`), plus read (`#cvs.rfl`) and write (`#cvs.wfl`)
+   marker files. On a Windows server the name is `#cvs.rfl.<host>(<user>).<pid>`; on POSIX it is
+   `#cvs.rfl.<host>.<pid>` (or a short form without the host when `HAVE_LONG_FILE_NAMES` is
+   absent) — the `(<user>)` part exists only in the `_WIN32` branches. Names at `src/cvs.h:222`;
+   construction at `src/lock.cpp:719-745` (read) and its write-lock mirror at `src/lock.cpp:878`. `LockDir` in `CVSROOT/config` can redirect them to a
    scratch filesystem.
 2. **The lock server** `cvslockd` on port 2402, selected with `LockServer` in `CVSROOT/config`
    (`src/lock.cpp:152`, connection at `src/lock.cpp:190`). Locks become in-memory state in a single

--- a/docs/05-repository-layout.md
+++ b/docs/05-repository-layout.md
@@ -1,0 +1,173 @@
+# Repository and working-copy layout
+
+## Server side
+
+```
+/cvs/                                  <- CVSROOT (the "root")
+├── CVSROOT/                           <- administrative directory
+│   ├── config            server configuration (LockDir, LockServer, ...)
+│   ├── modules           module definitions
+│   ├── modules2          CVSNT extended module definitions
+│   ├── passwd            pserver accounts
+│   ├── users             mail aliases
+│   ├── readers, writers  coarse access control
+│   ├── group             group definitions for ACLs
+│   ├── loginfo           post-commit log trigger
+│   ├── commitinfo        pre-commit trigger
+│   ├── verifymsg         log message validation
+│   ├── taginfo           tag/rtag trigger
+│   ├── historyinfo       history record trigger
+│   ├── precommand, postcommand, premodule, postmodule, postcommit
+│   ├── rcsinfo           log message template
+│   ├── cvswrappers       per-pattern -k defaults
+│   ├── cvsignore         server-wide ignore patterns
+│   ├── keywords          custom keyword definitions
+│   ├── triggers          trigger plugin list
+│   ├── checkoutlist      extra admin files to keep checked out
+│   ├── notify            watch notification trigger
+│   ├── history           the history log
+│   └── val-tags          cache of known-valid tags
+│
+├── blobs/                             <- content-addressed store (CAFS)
+│   ├── 00/
+│   │   ├── 00/
+│   │   └── ...
+│   ├── 3f/
+│   │   └── a9/
+│   │       └── 3fa91c2e...            <- one blob, 64-hex filename
+│   └── ff/
+│
+└── mymodule/                          <- an actual module
+    ├── CVS/                           <- per-directory repository metadata
+    │   └── fileattr                   watchers, ACLs, edit state
+    ├── src/
+    │   ├── main.cpp,v                 RCS file (text, normal deltas)
+    │   └── Attic/                     ,v files for deleted-on-this-branch files
+    └── assets/
+        └── tex.dds,v                  RCS file whose revisions are blob references
+```
+
+The names above are the `CVSROOTADM_*` and `CVSREP` constants in `src/cvs.h:179` and
+`src/cvs.h:171`.
+
+### A `,v` file for a `-kB` file
+
+An ordinary CVS `,v` file stores each revision's text (or a delta) in a `@...@` block. For a `-kB`
+file the block holds only the 71-byte reference:
+
+```
+head	1.15;
+access;
+symbols
+	BRANCH_2025:1.14.0.2
+	REL_1_0:1.9;
+locks; strict;
+
+1.15
+date	2025.06.04.10.00.00;	author artist;	state Exp;
+branches;
+next	1.14;
+deltatype	text;
+kopt	B;
+
+desc
+@@
+
+1.15
+log
+@new normal map@
+text
+@blake3:3fa91c2e6d4b...@
+```
+
+Two CVSNT-specific details in that header: there is **no `expand` keyword in the admin block** —
+the `-k` mode is recorded per revision as `kopt` (`src/rcs.cpp:6680`) — and each revision also
+carries a `deltatype` (`src/rcs.cpp:6678`). The admin block CVSNT writes is `head`, `branch`,
+`access`, `symbols`, `properties`, `locks`, `comment`, in that order (`RCS_putadmin`,
+`src/rcs.cpp:6576` onwards).
+
+Consequences:
+
+* The `,v` file grows by roughly 100 bytes per revision no matter how large the asset is.
+* `cvs log`, `cvs status` and tag operations never touch the payload.
+* The payload itself is at `/cvs/blobs/3f/a9/3fa91c2e6d4b...`.
+* Nothing in the `,v` file records the blob's *size*; that comes from the blob header or from a
+  `SIZE` query.
+
+`src/rcs.cpp:4288` (`get_binary_blob_ver_file_path`) is where the reference is turned back into a
+path on the server.
+
+## Client side
+
+```
+myworkdir/
+├── CVS/
+│   ├── Root                  the CVSROOT this tree was checked out from
+│   ├── Repository            path of this directory inside the repository
+│   ├── Entries               one line per versioned file/subdirectory
+│   ├── Entries.Log           pending appends to Entries (merged lazily)
+│   ├── Entries.Extra         CVSNT extra per-entry data
+│   ├── Entries.Extra.Log
+│   ├── Entries.Static        marks a directory checked out non-recursively
+│   ├── Tag                   sticky tag/date for this directory
+│   ├── Template              cached log message template
+│   ├── Notify                pending watch notifications
+│   ├── Base/                 pristine copies of files opened with `cvs edit`
+│   ├── Rename                pending renames
+│   └── Repository.Virtual    virtual repository mapping, if used
+├── src/
+│   └── main.cpp
+└── assets/
+    └── tex.dds               real content, fetched from the blob store
+```
+
+Constants are at `src/cvs.h:139`.
+
+### `CVS/Entries` format
+
+```
+/<filename>/<revision>/<timestamp>/<options>/<tagdate>
+D/<dirname>////
+```
+
+* `<timestamp>` is the mtime the file had when CVS last wrote it. A file whose mtime differs is a
+  candidate for "modified" and gets content-compared.
+* `<options>` is the `-k` string, e.g. `-kB`.
+* A leading `D` marks a subdirectory. A bare `D` on its own line means "this directory has
+  subdirectories recorded".
+
+`cvs.py`-style tooling exploits the `D/<dirname>////` form: writing such a stub into `CVS/Entries`
+before an update makes CVS descend into a subdirectory that is not yet present locally, which is how
+partial checkouts are bootstrapped.
+
+### Files CVS creates in the working copy
+
+| Pattern | Created by | Meaning |
+| --- | --- | --- |
+| `.#<file>.<rev>` | `update` merge (`src/update.cpp:2329`) | Your version before a merge overwrote it; `<rev>` is the revision you were on |
+| `.#<file>.<rev>` | `update -C` (`src/update.cpp:801`) | Your locally modified version before it was reverted |
+| `.#<file>.<rev>` | `commit`/`send_files` with backup (`src/client.cpp:5436`) | Same, on the send path |
+| `#cvs.lock`, `#cvs.rfl.*`, `#cvs.wfl.*` | server locking (`src/lock.cpp:684`) | Present in the *repository*, not the working copy |
+
+The prefix is `BAKPREFIX`, defined as `".#"` at `src/cvs.h:269`. CVS never removes these files; the
+upstream comment says they are expected to "stay around for a few days before being automatically
+removed by some cron daemon" (`src/update.cpp:2319`), which on a developer workstation means they
+accumulate forever.
+
+`update -n` sets `backup_local_files = 0` (`src/update.cpp:205`) and suppresses every one of those
+backups, deleting the local version outright. This is irreversible; the option help says so.
+
+## Locking
+
+Two mechanisms coexist:
+
+1. **Filesystem locks** in the repository directory: `#cvs.lock` (master), `#cvs.rfl.<pid>` (read),
+   `#cvs.wfl` (write). Implemented in `src/lock.cpp`. `LockDir` in `CVSROOT/config` can redirect
+   them to a scratch filesystem.
+2. **The lock server** `cvslockd` on port 2402, selected with `LockServer` in `CVSROOT/config`
+   (`src/lock.cpp:152`, connection at `src/lock.cpp:190`). Locks become in-memory state in a single
+   daemon rather than files, which removes a large amount of directory churn.
+
+The blob store needs no locking for reads: blobs are immutable, and a partially-written blob lives
+under a temporary name until its final `rename`. Maintenance tools that *delete* blobs
+(`gc-blobs`) do take a lock, via `tools/simpleLock.cpp.inc`.

--- a/docs/05-repository-layout.md
+++ b/docs/05-repository-layout.md
@@ -39,16 +39,19 @@
 │
 └── mymodule/                          <- an actual module
     ├── CVS/                           <- per-directory repository metadata
-    │   └── fileattr                   watchers, ACLs, edit state
+    │   └── fileattr.xml               watchers, ACLs, edit state (legacy name: fileattr)
     ├── src/
     │   ├── main.cpp,v                 RCS file (text, normal deltas)
-    │   └── Attic/                     ,v files for deleted-on-this-branch files
+    │   └── Attic/                     ,v files whose head trunk revision is dead
     └── assets/
         └── tex.dds,v                  RCS file whose revisions are blob references
 ```
 
-The names above are the `CVSROOTADM_*` and `CVSREP` constants in `src/cvs.h:179` and
-`src/cvs.h:171`.
+The `CVSROOT/` names are the `CVSROOTADM_*` constants at `src/cvs.h:179`, and the per-directory
+`CVS/` name is `CVSREP` at `src/cvs.h:170`. The others come from elsewhere: `Attic` is `CVSATTIC`
+(`src/cvs.h:217`), `blobs` is `BLOBS_SUB_FOLDER`
+(`ca_blobs_fs/src/content_addressed_fs.cpp:16`), and `fileattr.xml` is `CVSREP_FILEATTR`
+(`src/fileattr.h:41`).
 
 ### A `,v` file for a `-kB` file
 
@@ -88,14 +91,16 @@ carries a `deltatype` (`src/rcs.cpp:6678`). The admin block CVSNT writes is `hea
 
 Consequences:
 
-* The `,v` file grows by roughly 100 bytes per revision no matter how large the asset is.
+* The `,v` file grows by roughly 250 bytes per revision plus the log message, no matter how large
+  the asset is. (The delta node alone is ~150-200 bytes: `putdelta`, `src/rcs.cpp:6643`, plus the
+  `other_delta` fields added at `src/rcs_checkin.cpp:627`.)
 * `cvs log`, `cvs status` and tag operations never touch the payload.
 * The payload itself is at `/cvs/blobs/3f/a9/3fa91c2e6d4b...`.
 * Nothing in the `,v` file records the blob's *size*; that comes from the blob header or from a
   `SIZE` query.
 
-`src/rcs.cpp:4288` (`get_binary_blob_ver_file_path`) is where the reference is turned back into a
-path on the server.
+`ca_blobs_fs/src/content_addressed_fs.cpp:71` (`get_file_path`, with the root set by `set_root` at
+`:39`) is where a hash is turned into `<root>/blobs/xx/yy/<64-hex>` on the server.
 
 ## Client side
 
@@ -133,12 +138,15 @@ D/<dirname>////
 * `<timestamp>` is the mtime the file had when CVS last wrote it. A file whose mtime differs is a
   candidate for "modified" and gets content-compared.
 * `<options>` is the `-k` string, e.g. `-kB`.
-* A leading `D` marks a subdirectory. A bare `D` on its own line means "this directory has
-  subdirectories recorded".
+* A leading `D` marks a subdirectory. A bare `D` on its own line signals that this `Entries` file
+  lists **all** known subdirectories — it is written precisely when subdirectory tracking is in
+  effect, typically with no subdirectories at all (`src/entries.cpp:489`, written at
+  `src/entries.cpp:194`).
 
-`cvs.py`-style tooling exploits the `D/<dirname>////` form: writing such a stub into `CVS/Entries`
-before an update makes CVS descend into a subdirectory that is not yet present locally, which is how
-partial checkouts are bootstrapped.
+External tooling sometimes exploits the `D/<dirname>////` form by writing such a stub into
+`CVS/Entries` before an update, to bootstrap a partial checkout. Nothing in this source tree
+documents or implements that behaviour — treat it as an external convention, not a supported
+interface.
 
 ### Files CVS creates in the working copy
 
@@ -146,7 +154,7 @@ partial checkouts are bootstrapped.
 | --- | --- | --- |
 | `.#<file>.<rev>` | `update` merge (`src/update.cpp:2329`) | Your version before a merge overwrote it; `<rev>` is the revision you were on |
 | `.#<file>.<rev>` | `update -C` (`src/update.cpp:801`) | Your locally modified version before it was reverted |
-| `.#<file>.<rev>` | `commit`/`send_files` with backup (`src/client.cpp:5436`) | Same, on the send path |
+| `.#<file>.<rev>` | `update -C` over client/server (`src/client.cpp:5436`; the flag is set at `src/update.cpp:400`) | Same, on the send path |
 | `#cvs.lock`, `#cvs.rfl.*`, `#cvs.wfl.*` | server locking (`src/lock.cpp:684`) | Present in the *repository*, not the working copy |
 
 The prefix is `BAKPREFIX`, defined as `".#"` at `src/cvs.h:269`. CVS never removes these files; the
@@ -154,16 +162,20 @@ upstream comment says they are expected to "stay around for a few days before be
 removed by some cron daemon" (`src/update.cpp:2319`), which on a developer workstation means they
 accumulate forever.
 
-`update -n` sets `backup_local_files = 0` (`src/update.cpp:205`) and suppresses every one of those
-backups, deleting the local version outright. This is irreversible; the option help says so.
+`update -n` sets `backup_local_files = 0` (`src/update.cpp:205`), which suppresses the **`-C`**
+backups only — the flag is tested in exactly two places, `src/update.cpp:801` and
+`src/client.cpp:5436`. The merge backups at `src/update.cpp:2329` and `src/update.cpp:3105` are
+written regardless. Where `-n` does apply, the local version is deleted outright and irreversibly.
 
 ## Locking
 
 Two mechanisms coexist:
 
-1. **Filesystem locks** in the repository directory: `#cvs.lock` (master), `#cvs.rfl.<pid>` (read),
-   `#cvs.wfl` (write). Implemented in `src/lock.cpp`. `LockDir` in `CVSROOT/config` can redirect
-   them to a scratch filesystem.
+1. **Filesystem locks** in the repository directory: `#cvs.lock` (the master lock — a *directory*,
+   created with `CVS_MKDIR` at `src/lock.cpp:1088`), `#cvs.rfl.<host>(<user>).<pid>` (read) and
+   `#cvs.wfl.<host>(<user>).<pid>` (write). Names at `src/cvs.h:222`; construction at
+   `src/lock.cpp:722` and `src/lock.cpp:878`. `LockDir` in `CVSROOT/config` can redirect them to a
+   scratch filesystem.
 2. **The lock server** `cvslockd` on port 2402, selected with `LockServer` in `CVSROOT/config`
    (`src/lock.cpp:152`, connection at `src/lock.cpp:190`). Locks become in-memory state in a single
    daemon rather than files, which removes a large amount of directory churn.

--- a/docs/06-server-operations.md
+++ b/docs/06-server-operations.md
@@ -2,7 +2,10 @@
 
 ## The three services
 
-A complete G-CVSNT deployment runs up to three server processes. Only the first is mandatory.
+A complete G-CVSNT deployment runs up to three server processes. Only the first is mandatory — and
+only for repositories without `-kB` content: a `-kB` update sends 71-byte references, and the
+client fetches the bytes from the blob service on port 2403, so a blob-enabled deployment also
+needs `cafs_server` (or a proxy backed by it) reachable from every client.
 
 ### 1. The CVS server
 
@@ -22,8 +25,9 @@ LockServer=localhost:2402
 ```
 
 Without it, CVS falls back to `#cvs.lock` / `#cvs.rfl.*` / `#cvs.wfl.*` files created and removed in
-every repository directory it touches (names at `src/cvs.h:222`, read lock created at
-`src/lock.cpp:722`). On a repository with tens of thousands
+every repository directory it touches (names at `src/cvs.h:222`, built at `src/lock.cpp:719-745`;
+the master lock directory itself is made with `CVS_MKDIR` at `src/lock.cpp:1088`). On a repository
+with tens of thousands
 of directories that is a very large amount of filesystem churn, so the lock server is strongly
 recommended at this scale. The wire protocol is documented in
 `lockservice/cvslock_protocol.txt`.
@@ -43,9 +47,9 @@ cafs_server <dir_for_roots> <allow_trust: on|off> [norepack]
 | `dir_for_roots` | Parent directory of all repository roots; `/` means "roots are absolute paths" |
 | `allow_trust` | Intended as `on` = accept client-supplied hashes without re-hashing, `off` = always verify. **`off` currently has no effect** — the argument is parsed but never applied; see `_reports/BUG-blob-07-cafs-server-allow-trust-off-ignored.md` |
 | `norepack` | Do not recompress blobs on arrival. Without it the server repacks every newly stored blob at lowered priority (`keyValueServer/server/blob_file_lib.cpp:70`) |
-| `encryption` | Offer encryption; clients may still opt out |
-| `mandatory_encryption` | Refuse unencrypted clients |
-| `<secret>` | Shared secret, at least `minimum_shared_secret_length` (16) characters. **Either** encryption mode also clears `allow_trust` (`cafs_server.cpp:44`) |
+| `encryption` | Encrypt public-network clients only: an authenticated client at a private IP has encryption removed for the session, and unauthenticated clients are refused only from public IPs (`blob_push_proc.cpp:327-351`) |
+| `mandatory_encryption` | Keep encryption on every address; refuse unencrypted clients outright |
+| `<secret>` | Shared secret, at least `minimum_shared_secret_length` (16) characters. Either encryption mode also clears `allow_trust`, but only when it was `on` — the clear sits inside `if (allow)`, so with `allow_trust off` nothing is cleared and the never-applied default stays trusting (`cafs_server.cpp:45-46`) |
 | `port` | Default 2403 |
 | `max_pending` | Listen backlog, default 1024 |
 
@@ -62,9 +66,17 @@ cafs_proxy_server <master_url> <cache_folder>
 
 (`keyValueServer/proxy/cafs_proxy_server.cpp:19`)
 
-A read-through cache. On a miss it pulls from the master and stores locally; on a hit it serves from
-its own store. Because blobs are immutable there is no invalidation problem — the cache is
-correct by construction.
+Both the listen port and the master port are hard-coded to 2403 and cannot be set from argv
+(`cafs_proxy_server.cpp:61-66`); `master_url` is a host string only. The Visual Studio project for
+it is named `cafs_proxy`, so the Windows build produces `cafs_proxy.exe`, not
+`cafs_proxy_server.exe`.
+
+A read-and-write-through cache. On a miss it pulls from the master and stores locally; on a hit it
+serves from its own store. Pushes are accepted and forwarded to the master by default
+(`proxy_allow_push` starts true, `keyValueServer/proxy/proxy_file_lib.cpp:228`); only
+`mandatory_encryption` turns that off (`cafs_proxy_server.cpp:46`), so a default proxy is a write
+endpoint too, not cache-only. Because blobs are immutable there is no invalidation problem for
+cached reads.
 
 * `validate_blobs_from_master` re-hashes what the master sends before caching it.
 * `update_mtime_on_access` makes the cache LRU-evictable by mtime.
@@ -85,16 +97,19 @@ The CVS server advertises blob URLs to clients using its own global settings (se
 | `BlobURL` | Primary blob URL |
 | `BlobURL0` … `BlobURL31` | Additional URLs; the client may round-robin. Enumeration stops at the first missing index |
 | `BlobOTP` | Shared secret for TOTP authentication to an encrypted blob server |
-| `BlobEncryptedURL0` … `BlobEncryptedURL31` | URLs used instead of the plain ones once `BlobOTP` is configured |
+| `BlobEncryptedURL0` … `BlobEncryptedURL31` | Sent *in addition to* the plain ones once `BlobOTP` is configured, after the `Blob-OTP` line (`src/server.cpp:3406-3413`); the client files them as a separate encrypting list, so keep the plain `BlobURL*` entries too |
 
-Values are `host[/path][@port]`, e.g. `cvs-proxy.lan@2403`, or `http://cache.lan@8080` for the HTTP
-back-end.
+Values are `host[@port]`, e.g. `cvs-proxy.lan@2403`. A `/path` component is not supported by the
+native client: `parse_url_port` (`src/client.cpp:2123`) strips only `@port`, so a path stays inside
+the host string and name resolution fails. An `http://` value does not select the
+HTTP back-end: the client builds only KV-protocol processors (`src/download_blob_to.cpp:291-295`),
+so the HTTP processor is compiled but unreachable from here.
 
 Where these settings live:
 
 * **Unix** — a plain `key=value` file at `<sysconfdir>/cvsnt/PServer`
   (`cvstools/unix/GlobalSettings.cpp:91`). `<sysconfdir>/cvsnt` is the default and is overridable
-  wholesale with `--with-config_dir` at configure time (`configure.in:805`) — it replaces the entire
+  wholesale with `--with-config-dir` at configure time (`configure.in:805`) — it replaces the entire
   path, not just the `<sysconfdir>` part. Per-user settings go in `~/.cvs/<key>`.
 * **Windows** — the registry, under the CVSNT product key
   (`cvstools/win32/GlobalSettings.cpp`).
@@ -144,8 +159,9 @@ On Linux the main `make` builds all four, as `convert_to_blob`, `gc_blobs`, `rep
 `blake3_calc` (`tools/Makefile.am:12`). `tools/build_tools` is an alternative clang path that
 produces the hyphenated names used below.
 
-Only `cvtblob` and `gc-blobs` take a lock-server lock (`tools/simpleLock.cpp.inc`), so only those two
-are safe to run against a live server. `repack-blobs` and `blake3-calc` take no lock at all.
+Only `cvtblob` and `gc-blobs` take a lock-server lock (`tools/simpleLock.cpp.inc`);
+`repack-blobs` and `blake3-calc` take no lock at all. The lock alone does not make
+`gc-blobs delete_unused` safe on a live repository — see its section below.
 
 ### `cvtblob` — migrate existing binaries into the blob store
 
@@ -167,6 +183,12 @@ cvtblob -root <cvs_root> -lock_url <lock_server_url> -user <lock_user>
   scratch space the conversion needs.
 * `-db` (default `cvs_cvt_db.txt`) records progress so an interrupted conversion can resume.
 
+`cvtblob` rewrites RCS history in place: by default the converted temporary `,v` replaces the
+original and the extracted old-version files are removed. Take a verified repository backup before
+a real run, and stage the migration: `-no_rcs` (leave `,v` files untouched) and `-no_remove` (keep
+old version files) let you validate the blob push and the rewrite separately before the
+destructive pass (`tools/convert_to_blob.cpp:652-653`).
+
 ### `gc-blobs` — reclaim space
 
 `tools/gc-blobs.cpp`. Nothing reference-counts blobs, so collection is mark-and-sweep:
@@ -183,9 +205,11 @@ The mode is positional and decides what the tool does: `used` and `unused` only 
 lists `,v` references whose blob is **missing from the store** — it does not read or verify blob
 contents; and `delete_unused` is the only mode that removes anything. Start with `unused` and read the output before ever running `delete_unused`.
 
-It takes a per-`,v` read lock through the lock server while scanning (`tools/gc-blobs.cpp:102`), so
-it can run against a live repository. Do not work around that lock: a blob pushed during the mark
-phase and referenced only after the sweep would otherwise be deleted while in use.
+It takes a per-`,v` read lock through the lock server while scanning (`tools/gc-blobs.cpp:102`),
+but each lock is released as soon as that file is copied, and the sweep later unlinks with no lock
+and no re-scan. A commit that lands after its `,v` was scanned can reference a blob the mark phase
+classified unused, and `delete_unused` then removes it while referenced. The listing modes are
+safe anywhere; run `delete_unused` only on an offline or otherwise quiescent repository.
 
 ### `repack-blobs` — improve compression
 
@@ -197,8 +221,9 @@ for the full option list.
 ### `blake3-calc`
 
 `tools/blake3-calc.cpp`. A BLAKE3 micro-benchmark — it hashes the file 500 times inside an `rdtsc`
-loop — that also prints the file's blob key on its second output line. Useful for answering "is this
-asset already in the store?".
+loop — whose second output line is `BLAKE3=` followed by the file's blob key: the key is the 64 hex
+digits after that prefix (`tools/blake3-calc.cpp:52-54`). Useful for answering "is this asset
+already in the store?".
 
 ## Operational notes for large repositories
 

--- a/docs/06-server-operations.md
+++ b/docs/06-server-operations.md
@@ -22,7 +22,8 @@ LockServer=localhost:2402
 ```
 
 Without it, CVS falls back to `#cvs.lock` / `#cvs.rfl.*` / `#cvs.wfl.*` files created and removed in
-every repository directory it touches (`src/lock.cpp:684`). On a repository with tens of thousands
+every repository directory it touches (names at `src/cvs.h:222`, read lock created at
+`src/lock.cpp:722`). On a repository with tens of thousands
 of directories that is a very large amount of filesystem churn, so the lock server is strongly
 recommended at this scale. The wire protocol is documented in
 `lockservice/cvslock_protocol.txt`.
@@ -35,16 +36,16 @@ cafs_server <dir_for_roots> <allow_trust: on|off> [norepack]
             [port] [max_pending_connections]
 ```
 
-(`keyValueServer/server/cafs_server.cpp:12`)
+(`keyValueServer/server/cafs_server.cpp:15`)
 
 | Argument | Meaning |
 | --- | --- |
 | `dir_for_roots` | Parent directory of all repository roots; `/` means "roots are absolute paths" |
-| `allow_trust` | `on` accepts client-supplied hashes without re-hashing; `off` always verifies |
-| `norepack` | Do not recompress blobs on arrival |
+| `allow_trust` | Intended as `on` = accept client-supplied hashes without re-hashing, `off` = always verify. **`off` currently has no effect** — the argument is parsed but never applied; see `_reports/BUG-blob-07-cafs-server-allow-trust-off-ignored.md` |
+| `norepack` | Do not recompress blobs on arrival. Without it the server repacks every newly stored blob at lowered priority (`keyValueServer/server/blob_file_lib.cpp:70`) |
 | `encryption` | Offer encryption; clients may still opt out |
-| `mandatory_encryption` | Refuse unencrypted clients. Also forces `allow_trust` off |
-| `<secret>` | Shared secret, at least `minimum_shared_secret_length` characters |
+| `mandatory_encryption` | Refuse unencrypted clients |
+| `<secret>` | Shared secret, at least `minimum_shared_secret_length` (16) characters. **Either** encryption mode also clears `allow_trust` (`cafs_server.cpp:44`) |
 | `port` | Default 2403 |
 | `max_pending` | Listen backlog, default 1024 |
 
@@ -59,7 +60,7 @@ cafs_proxy_server <master_url> <cache_folder>
                   [cache_soft_limit_size_mb]
 ```
 
-(`keyValueServer/proxy/cafs_proxy_server.cpp:17`)
+(`keyValueServer/proxy/cafs_proxy_server.cpp:19`)
 
 A read-through cache. On a miss it pulls from the master and stores locally; on a hit it serves from
 its own store. Because blobs are immutable there is no invalidation problem — the cache is
@@ -68,7 +69,8 @@ correct by construction.
 * `validate_blobs_from_master` re-hashes what the master sends before caching it.
 * `update_mtime_on_access` makes the cache LRU-evictable by mtime.
 * The default soft cache limit is 102400 MB (100 GB); eviction is driven by
-  `keyValueServer/proxy/gc_thread_monitor.cpp` and `keyValueServer/proxy/free_disk_space.cpp`.
+  `keyValueServer/proxy/free_disk_space.cpp` plus `gc_proc_monitor.cpp` on the autotools/Unix build,
+  or `gc_thread_monitor.cpp` on the Visual Studio build.
 
 Deploy one proxy per studio/office/build farm and point clients at it. Latency and WAN bandwidth for
 binary payload drop to near zero for anything another local user has already fetched.
@@ -91,8 +93,9 @@ back-end.
 Where these settings live:
 
 * **Unix** — a plain `key=value` file at `<sysconfdir>/cvsnt/PServer`
-  (`cvstools/unix/GlobalSettings.cpp:91`); `<sysconfdir>` is set by `--with-config_dir` at configure
-  time. Per-user settings go in `~/.cvs/<key>`.
+  (`cvstools/unix/GlobalSettings.cpp:91`). `<sysconfdir>/cvsnt` is the default and is overridable
+  wholesale with `--with-config_dir` at configure time (`configure.in:805`) — it replaces the entire
+  path, not just the `<sysconfdir>` part. Per-user settings go in `~/.cvs/<key>`.
 * **Windows** — the registry, under the CVSNT product key
   (`cvstools/win32/GlobalSettings.cpp`).
 
@@ -106,11 +109,11 @@ Parsed by `src/parseinfo.cpp`. Keys recognised by this build:
 | --- | --- | --- |
 | `RCSBIN` | path | Legacy; ignored |
 | `SystemAuth` | `yes`/`no` | Fall back to system accounts for `pserver` |
-| `PreservePermissions` | `yes`/`no` | |
+| `PreservePermissions` | `yes`/`no` | Accepted and silently ignored (`src/parseinfo.cpp:291`) |
 | `TopLevelAdmin` | `yes`/`no` | Create `CVS/` at the top of a checkout |
 | `AclMode` | `none`/`compat`/`normal` | CVSNT ACL behaviour |
 | `LockDir` | path | Put lock files somewhere other than the repository |
-| `LockServer` | `host:port` | Use `cvslockd` instead of lock files |
+| `LockServer` | `host[:port]`, or `none` | Use `cvslockd` instead of lock files. Port defaults to 2402; the literal `none` clears it (`src/parseinfo.cpp:329`) |
 | `LogHistory` | letters | Which record types to write to `CVSROOT/history` |
 | `AtomicCommits` | `yes`/`no` | |
 | `RereadLogAfterVerify` | `no`/`never`/`yes`/`always`/`stat` | |
@@ -124,20 +127,25 @@ Server-side hooks are shared libraries implementing `trigger_interface`
 
 | Trigger | Source | Purpose |
 | --- | --- | --- |
-| `info` | `triggers/info_trigger.cpp` | Implements the classic file-driven hooks: `loginfo`, `commitinfo`, `taginfo`, `verifymsg`, `historyinfo`, `precommand`, `postcommand`, `premodule`, `postmodule`, `postcommit` |
+| `info` | `triggers/info_trigger.cpp` | Implements the classic file-driven hooks: `loginfo`, `commitinfo`, `taginfo`, `verifymsg`, `historyinfo`, `precommand`, `postcommand`, `premodule`, `postmodule`, `postcommit`, `notify`, `rcsinfo`, `keywords` (`triggers/info_trigger.cpp:50`) |
 | `script` | `triggers/script_trigger.cpp` | Runs a scripting-language hook |
 | `audit` | `triggers/audit_trigger.cpp` | Writes an audit trail to a SQL database (`triggers/sql/`) |
 | `email` | `triggers/email_trigger.cpp` | Commit notification mail |
 | `checkout` | `triggers/checkout_trigger.cpp` | Keeps a working copy in sync with commits |
 
-Note that `historyinfo` receives a directory parameter `%p`, and that `taginfo` fires per tag
-operation. Triggers that spawn a process are a real cost on large tag operations — see
-`_reports/PERF-02-tag-branch-path.md`.
+Note that `historyinfo` receives a directory parameter `%p`, and that `taginfo` fires once per
+*directory* containing tagged files, not once per operation — it is dispatched from the
+`filesdoneproc` of the tag recursion (`src/tag.cpp:409`, `src/tag.cpp:588`). Triggers that spawn a
+process are still a real cost on large tag operations; see `_reports/PERF-02-tag-branch-path.md`.
 
 ## Maintenance tools
 
-Built by `tools/build_tools` (clang++, C++17). All of them operate directly on the repository
-filesystem and take the lock via `tools/simpleLock.cpp.inc`, so they can run against a live server.
+On Linux the main `make` builds all four, as `convert_to_blob`, `gc_blobs`, `repack_blobs` and
+`blake3_calc` (`tools/Makefile.am:12`). `tools/build_tools` is an alternative clang path that
+produces the hyphenated names used below.
+
+Only `cvtblob` and `gc-blobs` take a lock-server lock (`tools/simpleLock.cpp.inc`), so only those two
+are safe to run against a live server. `repack-blobs` and `blake3-calc` take no lock at all.
 
 ### `cvtblob` — migrate existing binaries into the blob store
 
@@ -150,6 +158,7 @@ cvtblob -root <cvs_root> -lock_url <lock_server_url> -user <lock_user>
         [-dir <subdir>] [-file <file>] [-j <threads>]
         [-tmp_rcs <dir>] [-tmp_blobs <dir>]
         [-db <assist_db_path>] [-max_files <n>]
+        [-no_rcs] [-no_remove] [-use_db_only]
 ```
 
 * `-lock_url offline` declares that nobody else is using the repository, so no lock server is
@@ -170,9 +179,9 @@ cvtblob -root <cvs_root> -lock_url <lock_server_url> -user <lock_user>
 gc-blobs -root <rootDir> -lock_url <lock_url> -user <lock_user> used|unused|broken|delete_unused
 ```
 
-The mode is positional and decides what the tool does: `used` and `unused` only *list*, `broken`
-reports blobs that fail their own hash check, and `delete_unused` is the only mode that removes
-anything. Start with `unused` and read the output before ever running `delete_unused`.
+The mode is positional and decides what the tool does: `used` and `unused` only *list*; `broken`
+lists `,v` references whose blob is **missing from the store** — it does not read or verify blob
+contents; and `delete_unused` is the only mode that removes anything. Start with `unused` and read the output before ever running `delete_unused`.
 
 It takes a per-`,v` read lock through the lock server while scanning (`tools/gc-blobs.cpp:102`), so
 it can run against a live repository. Do not work around that lock: a blob pushed during the mark
@@ -187,8 +196,9 @@ for the full option list.
 
 ### `blake3-calc`
 
-`tools/blake3-calc.cpp`. Prints a file's blob key. Useful for answering "is this asset already in
-the store?" with a `CHCK`.
+`tools/blake3-calc.cpp`. A BLAKE3 micro-benchmark — it hashes the file 500 times inside an `rdtsc`
+loop — that also prints the file's blob key on its second output line. Useful for answering "is this
+asset already in the store?".
 
 ## Operational notes for large repositories
 

--- a/docs/06-server-operations.md
+++ b/docs/06-server-operations.md
@@ -1,0 +1,203 @@
+# Server operations
+
+## The three services
+
+A complete G-CVSNT deployment runs up to three server processes. Only the first is mandatory.
+
+### 1. The CVS server
+
+The same `cvs` binary, invoked as `cvs server` (over `ext`/`ssh`) or `cvs authserver` /
+`cvs pserver` (direct TCP). Traditionally started from `inetd`/`xinetd` (a sample is in
+`cvsnt/cvsnt.xinetd`) or, on Windows, by the `cvsservice` NT service.
+
+Default port for `pserver` is 2401.
+
+### 2. `cvslockd` — the lock server
+
+`cvslockd` (sources in `lockservice/`) keeps read/write locks in memory instead of as files in the
+repository. Enable it by putting a `LockServer` line in `CVSROOT/config`:
+
+```
+LockServer=localhost:2402
+```
+
+Without it, CVS falls back to `#cvs.lock` / `#cvs.rfl.*` / `#cvs.wfl.*` files created and removed in
+every repository directory it touches (`src/lock.cpp:684`). On a repository with tens of thousands
+of directories that is a very large amount of filesystem churn, so the lock server is strongly
+recommended at this scale. The wire protocol is documented in
+`lockservice/cvslock_protocol.txt`.
+
+### 3. `cafs_server` — the blob store
+
+```
+cafs_server <dir_for_roots> <allow_trust: on|off> [norepack]
+            [encryption|mandatory_encryption <secret>]
+            [port] [max_pending_connections]
+```
+
+(`keyValueServer/server/cafs_server.cpp:12`)
+
+| Argument | Meaning |
+| --- | --- |
+| `dir_for_roots` | Parent directory of all repository roots; `/` means "roots are absolute paths" |
+| `allow_trust` | `on` accepts client-supplied hashes without re-hashing; `off` always verifies |
+| `norepack` | Do not recompress blobs on arrival |
+| `encryption` | Offer encryption; clients may still opt out |
+| `mandatory_encryption` | Refuse unencrypted clients. Also forces `allow_trust` off |
+| `<secret>` | Shared secret, at least `minimum_shared_secret_length` characters |
+| `port` | Default 2403 |
+| `max_pending` | Listen backlog, default 1024 |
+
+Blobs land in `<dir_for_roots>/<root>/blobs/xx/yy/<hash>`.
+
+### 4. `cafs_proxy_server` — the caching proxy
+
+```
+cafs_proxy_server <master_url> <cache_folder>
+                  [validate_blobs_from_master] [update_mtime_on_access]
+                  [encryption|mandatory_encryption <secret>]
+                  [cache_soft_limit_size_mb]
+```
+
+(`keyValueServer/proxy/cafs_proxy_server.cpp:17`)
+
+A read-through cache. On a miss it pulls from the master and stores locally; on a hit it serves from
+its own store. Because blobs are immutable there is no invalidation problem — the cache is
+correct by construction.
+
+* `validate_blobs_from_master` re-hashes what the master sends before caching it.
+* `update_mtime_on_access` makes the cache LRU-evictable by mtime.
+* The default soft cache limit is 102400 MB (100 GB); eviction is driven by
+  `keyValueServer/proxy/gc_thread_monitor.cpp` and `keyValueServer/proxy/free_disk_space.cpp`.
+
+Deploy one proxy per studio/office/build farm and point clients at it. Latency and WAN bandwidth for
+binary payload drop to near zero for anything another local user has already fetched.
+
+## Telling clients where the blobs are
+
+The CVS server advertises blob URLs to clients using its own global settings (see
+`src/server.cpp:3346`):
+
+| Setting (`cvsnt` / `PServer` / *key*) | Meaning |
+| --- | --- |
+| `BlobURL` | Primary blob URL |
+| `BlobURL0` … `BlobURL31` | Additional URLs; the client may round-robin. Enumeration stops at the first missing index |
+| `BlobOTP` | Shared secret for TOTP authentication to an encrypted blob server |
+| `BlobEncryptedURL0` … `BlobEncryptedURL31` | URLs used instead of the plain ones once `BlobOTP` is configured |
+
+Values are `host[/path][@port]`, e.g. `cvs-proxy.lan@2403`, or `http://cache.lan@8080` for the HTTP
+back-end.
+
+Where these settings live:
+
+* **Unix** — a plain `key=value` file at `<sysconfdir>/cvsnt/PServer`
+  (`cvstools/unix/GlobalSettings.cpp:91`); `<sysconfdir>` is set by `--with-config_dir` at configure
+  time. Per-user settings go in `~/.cvs/<key>`.
+* **Windows** — the registry, under the CVSNT product key
+  (`cvstools/win32/GlobalSettings.cpp`).
+
+A client can always override with `cvs --blob_url ...`.
+
+## `CVSROOT/config`
+
+Parsed by `src/parseinfo.cpp`. Keys recognised by this build:
+
+| Key | Values | Notes |
+| --- | --- | --- |
+| `RCSBIN` | path | Legacy; ignored |
+| `SystemAuth` | `yes`/`no` | Fall back to system accounts for `pserver` |
+| `PreservePermissions` | `yes`/`no` | |
+| `TopLevelAdmin` | `yes`/`no` | Create `CVS/` at the top of a checkout |
+| `AclMode` | `none`/`compat`/`normal` | CVSNT ACL behaviour |
+| `LockDir` | path | Put lock files somewhere other than the repository |
+| `LockServer` | `host:port` | Use `cvslockd` instead of lock files |
+| `LogHistory` | letters | Which record types to write to `CVSROOT/history` |
+| `AtomicCommits` | `yes`/`no` | |
+| `RereadLogAfterVerify` | `no`/`never`/`yes`/`always`/`stat` | |
+| `Watcher` | | Watch/notify configuration |
+
+## Triggers
+
+Server-side hooks are shared libraries implementing `trigger_interface`
+(`cvstools/trigger_interface.h`), listed in `CVSROOT/triggers` and resolved through
+`cvsnt`/`Plugins` settings (`cvstools/TriggerLibrary.cpp:448`).
+
+| Trigger | Source | Purpose |
+| --- | --- | --- |
+| `info` | `triggers/info_trigger.cpp` | Implements the classic file-driven hooks: `loginfo`, `commitinfo`, `taginfo`, `verifymsg`, `historyinfo`, `precommand`, `postcommand`, `premodule`, `postmodule`, `postcommit` |
+| `script` | `triggers/script_trigger.cpp` | Runs a scripting-language hook |
+| `audit` | `triggers/audit_trigger.cpp` | Writes an audit trail to a SQL database (`triggers/sql/`) |
+| `email` | `triggers/email_trigger.cpp` | Commit notification mail |
+| `checkout` | `triggers/checkout_trigger.cpp` | Keeps a working copy in sync with commits |
+
+Note that `historyinfo` receives a directory parameter `%p`, and that `taginfo` fires per tag
+operation. Triggers that spawn a process are a real cost on large tag operations — see
+`_reports/PERF-02-tag-branch-path.md`.
+
+## Maintenance tools
+
+Built by `tools/build_tools` (clang++, C++17). All of them operate directly on the repository
+filesystem and take the lock via `tools/simpleLock.cpp.inc`, so they can run against a live server.
+
+### `cvtblob` — migrate existing binaries into the blob store
+
+`tools/convert_to_blob.cpp`. Walks `,v` files, extracts each binary revision's content, pushes it
+into the blob store, and rewrites the revision text as a `blake3:` reference. This is the one-time
+migration that turns a classic CVSNT repository into a G-CVSNT one.
+
+```
+cvtblob -root <cvs_root> -lock_url <lock_server_url> -user <lock_user>
+        [-dir <subdir>] [-file <file>] [-j <threads>]
+        [-tmp_rcs <dir>] [-tmp_blobs <dir>]
+        [-db <assist_db_path>] [-max_files <n>]
+```
+
+* `-lock_url offline` declares that nobody else is using the repository, so no lock server is
+  needed. Use it only when that is actually true.
+* `-max_files` (default 256) bounds how many revisions are held at once, and therefore how much
+  scratch space the conversion needs.
+* `-db` (default `cvs_cvt_db.txt`) records progress so an interrupted conversion can resume.
+
+### `gc-blobs` — reclaim space
+
+`tools/gc-blobs.cpp`. Nothing reference-counts blobs, so collection is mark-and-sweep:
+
+1. Scan every `,v` file in the repository and collect every `blake3:` reference into a sparse hash
+   set (`tools/tsl/sparse_set.h`).
+2. Walk `blobs/` and act on every file whose name is not in the set.
+
+```
+gc-blobs -root <rootDir> -lock_url <lock_url> -user <lock_user> used|unused|broken|delete_unused
+```
+
+The mode is positional and decides what the tool does: `used` and `unused` only *list*, `broken`
+reports blobs that fail their own hash check, and `delete_unused` is the only mode that removes
+anything. Start with `unused` and read the output before ever running `delete_unused`.
+
+It takes a per-`,v` read lock through the lock server while scanning (`tools/gc-blobs.cpp:102`), so
+it can run against a live repository. Do not work around that lock: a blob pushed during the mark
+phase and referenced only after the sweep would otherwise be deleted while in use.
+
+### `repack-blobs` — improve compression
+
+`tools/repack-blobs.cpp`. Recompresses blobs with the best available settings and sets the
+`BEST_POSSIBLE_COMPRESSION` flag so later runs skip them. Because the hash is of the *uncompressed*
+content, repacking never changes a blob's identity. Supports `-j <threads>`; run `repack-blobs -h`
+for the full option list.
+
+### `blake3-calc`
+
+`tools/blake3-calc.cpp`. Prints a file's blob key. Useful for answering "is this asset already in
+the store?" with a `CHCK`.
+
+## Operational notes for large repositories
+
+* Turn on `LockServer`. Lock-file churn dominates otherwise.
+* Put `LockDir` on a fast local filesystem if you cannot use the lock server.
+* Deploy a `cafs_proxy_server` at every site. Clients should never pull blobs across a WAN twice.
+* Use `cvs -j N` on clients to parallelise blob downloads.
+* `cvs update --blob_zero` writes zero-length files instead of real content — intended for
+  "hot-proxy" scenarios where a machine only needs to populate a cache, not the files themselves
+  (`src/update.cpp:157`).
+* Schedule `repack-blobs` off-hours; schedule `gc-blobs` rarely and only when you are confident no
+  migration or mass import is in flight.

--- a/docs/07-client-usage.md
+++ b/docs/07-client-usage.md
@@ -30,8 +30,8 @@ Run `cvs --help-options` for the full list. The ones specific to, or important f
 
 | Option | Effect |
 | --- | --- |
-| `-j N` | Number of blob download worker threads. `0` downloads on the main thread. When not given, the default is `min(8, max(1, cpu_count - 1))` (`src/download_blob_to.cpp:241`). This is the single biggest client-side knob for update speed on binary-heavy trees (`src/main.cpp:1013`) |
-| `--blob_url <spec>` | Override the blob server(s) the server advertised. `\|`-separated; each entry `host[/path][@port]`; `def` means the master (`src/main.cpp:1017`) |
+| `-j N` | Number of blob download worker threads. When not given, the default is `min(8, max(1, cpu_count - 1))` (`src/download_blob_to.cpp:241`). The single biggest client-side knob for update speed on binary-heavy trees (`src/main.cpp:1013`). `-j 0` is documented as "download in the main thread" but is currently a no-op — `src/client.cpp:2210` treats 0 as "unset", so the default applies |
+| `--blob_url <spec>` | Override the blob server the CVS server advertised. Takes a **single** URL `host[/path][@port]`, and disables round-robin (`src/download_blob_to.cpp:258`). The `\|`-separated list and `def` shown in `cvs --help-options` are not implemented — only the first `@` is parsed (`src/client.cpp:2123`) |
 | `-z <0-9>` | Stream compression level for the CVS connection (gzip or zstd, negotiated) |
 | `-x` / `-y` | Require / request encryption of the CVS connection |
 | `-a` | Authenticate (sign) all traffic |
@@ -40,8 +40,8 @@ Run `cvs --help-options` for the full list. The ones specific to, or important f
 | `-t` | Trace execution; `-t -t` and more increase the trace level. Invaluable for diagnosing blob-fetch problems |
 
 Note the collision hazard: **`-j` is a global option here** (blob concurrency) but **`-j rev` is a
-per-command option** for `update`, `checkout` and `diff` (merge from revision). Position decides
-which one you get:
+per-command option** for `update` and `checkout` (merge from revision; `diff` has no `-j`). Position
+decides which one you get:
 
 ```
 cvs -j 8 update -d          # 8 blob download threads
@@ -62,7 +62,7 @@ cvs add -kBz compressible_binary.bin
 | `-kB` | `KFLAG_BINARY \| KFLAG_BINARY_DELTA` | Content goes to the blob store; the `,v` holds a 71-byte reference |
 | `-kBz` | as `-kB` plus `KFLAG_COMPRESS_DELTA` | Same, and the blob is stored compressed |
 
-(`src/rcs.cpp:42`, `src/rcs.cpp:3501`)
+(`src/rcs.cpp:38` and `src/rcs.cpp:55` for the two flag tables; `src/rcs.cpp:3502` for serialisation)
 
 Use `-kB`/`-kBz` for **every** large binary asset. A binary added with plain `-kb` will bloat its
 `,v` file and slow down every tag, branch and `rlog` that touches its directory.
@@ -93,7 +93,8 @@ cvs update [-3ACPdfilRpbmnt] [-k kopt] [-r rev] [-D date] [-j rev]
            [-B bugid] [-I ign] [-W spec] [--blob_zero] [files...]
 ```
 
-(`src/update.cpp:130`)
+(`update_usage`, `src/update.cpp:131`. The synopsis above is expanded to include `-3`, `-n` and
+`--blob_zero`, which the getopt string at `src/update.cpp:184` accepts but the usage text omits.)
 
 | Option | Meaning |
 | --- | --- |
@@ -154,7 +155,7 @@ cvs rtag [-abdFflnR] [-r rev|-D date] tag modules...
 | --- | --- |
 | `-b` | Make it a branch tag |
 | `-A` | Make an alias of an existing branch (needs `-r`) |
-| `-M` | Create a floating branch |
+| `-M` | (`tag` only) Create a floating branch. `rtag`'s usage text advertises it, but `rtag_opts` (`src/tag.cpp:86`) does not accept it |
 | `-d` | Delete the tag |
 | `-F` | Move the tag if it already exists |
 | `-B` | Permit moving/deleting a *branch* tag. Not recommended |
@@ -186,8 +187,9 @@ repository, costs almost nothing.
 
 ## `.cvsrc`
 
-Per-user default options live in `~/.cvsrc` (`%USERPROFILE%\.cvsrc` on Windows), one line per
-command:
+Per-user default options live in `~/.cvsrc`, one line per command. On Windows the home directory
+comes from `%HOME%`, falling back to `%HOMEDRIVE%%HOMEPATH%` — `%USERPROFILE%` is never consulted
+(`windows-NT/filesubr.cpp:1137`):
 
 ```
 cvs -q -j 8
@@ -211,11 +213,11 @@ cvs -t -t -t update -d 2> trace.log
 ```
 
 Trace level 3 logs blob URL selection, blob-reference detection and per-file decisions
-(`src/server.cpp:3355`, `src/server.cpp:4431`). This is the first thing to collect when blobs fail
+(`src/server.cpp:3354`, `src/server.cpp:4431`). This is the first thing to collect when blobs fail
 to download.
 
 ```
 cvs version          # client and server versions
 cvs status -v file   # revision, sticky tag, and all tags on the file
-cvs ls -e            # server-side directory listing without a working copy
+cvs ls -e            # server-side listing, printed in CVS/Entries format
 ```

--- a/docs/07-client-usage.md
+++ b/docs/07-client-usage.md
@@ -31,7 +31,7 @@ Run `cvs --help-options` for the full list. The ones specific to, or important f
 | Option | Effect |
 | --- | --- |
 | `-j N` | Number of blob download worker threads. When not given, the default is `min(8, max(1, cpu_count - 1))` (`src/download_blob_to.cpp:241`). The single biggest client-side knob for update speed on binary-heavy trees (`src/main.cpp:1013`). `-j 0` is documented as "download in the main thread" but is currently a no-op — `src/client.cpp:2210` treats 0 as "unset", so the default applies |
-| `--blob_url <spec>` | Override the blob server the CVS server advertised. Takes a **single** URL `host[/path][@port]`, and disables round-robin (`src/download_blob_to.cpp:258`). The `\|`-separated list and `def` shown in `cvs --help-options` are not implemented — only the first `@` is parsed (`src/client.cpp:2123`) |
+| `--blob_url <spec>` | Override the advertised blob download list with a single URL `host[@port]` (a `/path` is not parsed out and breaks name resolution, `src/client.cpp:2123`). The master URL is still appended as a fallback (`src/download_blob_to.cpp:258,283`), and uploads ignore the override — they always go to the master. The `\|`-separated list and `def` shown in `cvs --help-options` are not implemented — only the first `@` is parsed (`src/client.cpp:2123`) |
 | `-z <0-9>` | Stream compression level for the CVS connection (gzip or zstd, negotiated) |
 | `-x` / `-y` | Require / request encryption of the CVS connection |
 | `-a` | Authenticate (sign) all traffic |
@@ -93,8 +93,10 @@ cvs update [-3ACPdfilRpbmnt] [-k kopt] [-r rev] [-D date] [-j rev]
            [-B bugid] [-I ign] [-W spec] [--blob_zero] [files...]
 ```
 
-(`update_usage`, `src/update.cpp:131`. The synopsis above is expanded to include `-3`, `-n` and
-`--blob_zero`, which the getopt string at `src/update.cpp:184` accepts but the usage text omits.)
+(`update_usage`, `src/update.cpp:131`. The synopsis above adds `3` and `n` to the short-option
+cluster, which the Usage line omits even though the detailed text lists all of `-3`, `-n` and
+`--blob_zero` (`src/update.cpp:133,155,157`) and the getopt string at `src/update.cpp:183`
+accepts them.)
 
 | Option | Meaning |
 | --- | --- |
@@ -102,7 +104,7 @@ cvs update [-3ACPdfilRpbmnt] [-k kopt] [-r rev] [-D date] [-j rev]
 | `-P` | Prune directories that became empty |
 | `-A` | Reset sticky tag/date/kopt back to HEAD |
 | `-C` | Overwrite locally modified files with clean repository copies, keeping a `.#file.rev` backup |
-| `-n` | Do *not* keep those backups — silently discard local modifications. Irreversible |
+| `-n` | With `-C`: do not keep those backups — discard local modifications irreversibly. Alone it changes nothing: `backup_local_files` is tested only on the `-C` paths (`src/update.cpp:801`, `src/client.cpp:5436`) |
 | `-r rev` | Update to a tag/branch/revision (sticky) |
 | `-D date` | Update as of a date (sticky) |
 | `-f` | Fall back to the head revision when the tag/date does not match a file |
@@ -113,15 +115,15 @@ cvs update [-3ACPdfilRpbmnt] [-k kopt] [-r rev] [-D date] [-j rev]
 
 Note the asymmetry between `-C` and `-n`: `-C` is what you want for a clean rebuild of a working
 copy, but by default it leaves a `.#name.rev` backup for every modified file, and those are never
-cleaned up. `cvs update -C -n` discards instead of backing up.
+cleaned up. `cvs update -C -n` discards instead of backing up; `-n` without `-C` changes nothing.
 
 **`-n` means two different things depending on position.** As a *global* option it is the classic
-CVS dry run (`noexec`, `src/main.cpp:938`); as an *update* option it means "do not keep backups"
+CVS dry run (`noexec`, `src/main.cpp:938`); as an *update* option it merely drops the `-C` backups
 (`src/update.cpp:204`):
 
 ```
 cvs -n update -d       # dry run: show what would happen, change nothing
-cvs update -d -n       # really update, and destroy local modifications without a backup
+cvs update -d -C -n    # really update, and overwrite local modifications without a backup
 ```
 
 Getting these the wrong way round destroys work. Prefer `cvs -n update` written exactly that way
@@ -178,8 +180,9 @@ reasons and the proposed fixes.
 Nothing fork-specific in the option set, but the blob path changes the shape of a commit:
 
 1. The client hashes each `-kB` file with BLAKE3.
-2. It asks the blob server `CHCK <hash>`. If the answer is `HAVE`, no bytes are transferred at all.
-3. Otherwise it compresses and `PUSH`es the blob.
+2. It asks the blob server `SIZE <hash>`. If the blob is already there, no bytes are transferred at
+   all (`src/blob_kv_processor.cpp:144-151`).
+3. Otherwise it compresses the blob and streams it with `STRM`.
 4. Only then does it send `Blob-ref-transfer` on the CVS connection.
 
 So re-committing an unchanged asset, or committing an asset that already exists elsewhere in the

--- a/docs/07-client-usage.md
+++ b/docs/07-client-usage.md
@@ -1,0 +1,221 @@
+# Client usage
+
+This page covers what is different or important in G-CVSNT. For the base CVS command set, the
+CVSNT manual (`doc/cvs.dbk`, shipped as `cvs.chm` on Windows) still applies.
+
+## Connecting
+
+```
+cvs -d :pserver:user@cvs.example.lan:/cvs checkout mymodule
+```
+
+`CVSROOT` syntax is CVSNT's:
+
+```
+:method[;keyword=value...]:[user[:password]@]host[:port]:/path
+```
+
+Common methods: `pserver`, `sserver` (TLS), `sspi` (Windows integrated), `gserver` (GSSAPI),
+`ssh`, `ext`, `server`, `fork`. See [02-architecture.md](02-architecture.md#connection-methods-protocol-plugins).
+
+Log in once per root:
+
+```
+cvs -d :pserver:user@cvs.example.lan:/cvs login
+```
+
+## Global options that matter here
+
+Run `cvs --help-options` for the full list. The ones specific to, or important for, this fork:
+
+| Option | Effect |
+| --- | --- |
+| `-j N` | Number of blob download worker threads. `0` downloads on the main thread. When not given, the default is `min(8, max(1, cpu_count - 1))` (`src/download_blob_to.cpp:241`). This is the single biggest client-side knob for update speed on binary-heavy trees (`src/main.cpp:1013`) |
+| `--blob_url <spec>` | Override the blob server(s) the server advertised. `\|`-separated; each entry `host[/path][@port]`; `def` means the master (`src/main.cpp:1017`) |
+| `-z <0-9>` | Stream compression level for the CVS connection (gzip or zstd, negotiated) |
+| `-x` / `-y` | Require / request encryption of the CVS connection |
+| `-a` | Authenticate (sign) all traffic |
+| `-q` / `-Q` | Quiet / very quiet — worth using on huge trees, output formatting is not free |
+| `@response-file` | Read the remaining arguments from a file, one per line. Must be the last argument. Use this instead of chunking long file lists to dodge the Windows ~8 KB command-line limit |
+| `-t` | Trace execution; `-t -t` and more increase the trace level. Invaluable for diagnosing blob-fetch problems |
+
+Note the collision hazard: **`-j` is a global option here** (blob concurrency) but **`-j rev` is a
+per-command option** for `update`, `checkout` and `diff` (merge from revision). Position decides
+which one you get:
+
+```
+cvs -j 8 update -d          # 8 blob download threads
+cvs update -j BRANCH_X      # merge from BRANCH_X
+cvs -j 8 update -j BRANCH_X # both
+```
+
+## `-kB` and `-kBz` — the binary modes
+
+```
+cvs add -kB huge_texture.dds
+cvs add -kBz compressible_binary.bin
+```
+
+| Mode | Flags | Storage |
+| --- | --- | --- |
+| `-kb` | `KFLAG_BINARY` | Classic CVS binary: every revision stored whole inside the `,v` file |
+| `-kB` | `KFLAG_BINARY \| KFLAG_BINARY_DELTA` | Content goes to the blob store; the `,v` holds a 71-byte reference |
+| `-kBz` | as `-kB` plus `KFLAG_COMPRESS_DELTA` | Same, and the blob is stored compressed |
+
+(`src/rcs.cpp:42`, `src/rcs.cpp:3501`)
+
+Use `-kB`/`-kBz` for **every** large binary asset. A binary added with plain `-kb` will bloat its
+`,v` file and slow down every tag, branch and `rlog` that touches its directory.
+
+To make it automatic, put patterns in `CVSROOT/cvswrappers`:
+
+```
+*.dds   -k 'B'
+*.tga   -k 'B'
+*.fbx   -k 'B'
+*.wav   -k 'Bz'
+```
+
+To change an existing file's mode:
+
+```
+cvs admin -kB path/to/file
+```
+
+Then re-commit; existing revisions stay as they are, new ones become blob references. To convert
+history in bulk, use the server-side `cvtblob` tool
+([06-server-operations.md](06-server-operations.md#cvtblob--migrate-existing-binaries-into-the-blob-store)).
+
+## `update`
+
+```
+cvs update [-3ACPdfilRpbmnt] [-k kopt] [-r rev] [-D date] [-j rev]
+           [-B bugid] [-I ign] [-W spec] [--blob_zero] [files...]
+```
+
+(`src/update.cpp:130`)
+
+| Option | Meaning |
+| --- | --- |
+| `-d` | Create directories that appeared in the repository. **Without `-d`, new directories are silently skipped** |
+| `-P` | Prune directories that became empty |
+| `-A` | Reset sticky tag/date/kopt back to HEAD |
+| `-C` | Overwrite locally modified files with clean repository copies, keeping a `.#file.rev` backup |
+| `-n` | Do *not* keep those backups — silently discard local modifications. Irreversible |
+| `-r rev` | Update to a tag/branch/revision (sticky) |
+| `-D date` | Update as of a date (sticky) |
+| `-f` | Fall back to the head revision when the tag/date does not match a file |
+| `-t` | Use the last check-in time as the file mtime instead of "now" |
+| `-l` / `-R` | Local only / recursive (recursive is the default) |
+| `-I ign` | Extra ignore pattern; `-I !` resets the ignore list |
+| `--blob_zero` | Write downloaded blobs as zero-length files. For "hot proxy" machines that only need to warm a cache |
+
+Note the asymmetry between `-C` and `-n`: `-C` is what you want for a clean rebuild of a working
+copy, but by default it leaves a `.#name.rev` backup for every modified file, and those are never
+cleaned up. `cvs update -C -n` discards instead of backing up.
+
+**`-n` means two different things depending on position.** As a *global* option it is the classic
+CVS dry run (`noexec`, `src/main.cpp:938`); as an *update* option it means "do not keep backups"
+(`src/update.cpp:204`):
+
+```
+cvs -n update -d       # dry run: show what would happen, change nothing
+cvs update -d -n       # really update, and destroy local modifications without a backup
+```
+
+Getting these the wrong way round destroys work. Prefer `cvs -n update` written exactly that way
+when you mean a dry run.
+
+### Naming files limits the update to those files
+
+`cvs update file1 dir2` restricts the operation to the named paths — but a named directory is
+still only *descended into*; **files and directories that are new in the repository are only picked
+up where `-d` applies**, and naming specific paths means anything outside them is untouched. There
+is currently no way to say "update everything except X" — see
+`_reports/` for the design work on an exclusion option.
+
+## `checkout`
+
+```
+cvs checkout [-ANPRcflnps] [-r rev] [-D date] [-d dir] [-j rev1] [-j rev2] [-k kopt] modules...
+```
+
+`-r` and `-D` imply `-P`. `-d dir` checks out into `dir` instead of the module name; add `-N` to
+keep the full module path underneath it.
+
+## `tag`, `rtag` and branches
+
+```
+cvs tag  [-bcdFflR] [-r rev|-D date] tag [files...]
+cvs rtag [-abdFflnR] [-r rev|-D date] tag modules...
+```
+
+| Option | Meaning |
+| --- | --- |
+| `-b` | Make it a branch tag |
+| `-A` | Make an alias of an existing branch (needs `-r`) |
+| `-M` | Create a floating branch |
+| `-d` | Delete the tag |
+| `-F` | Move the tag if it already exists |
+| `-B` | Permit moving/deleting a *branch* tag. Not recommended |
+| `-c` | (`tag` only) Fail if any working file is modified |
+| `-f` | Use the head revision when the tag/date does not match |
+| `-n` | (`rtag` only) Skip the tag program |
+
+`rtag` works directly on the repository and does not need a working copy. **Prefer it for tagging a
+whole module** — it is substantially cheaper than `tag`: it writes one history record per module
+instead of one per file, and it skips the client-side working-copy walk and the `Directory`/`Entry`
+upload entirely.
+
+Tagging and branching are the operations that scale worst with file count in this codebase. Every
+tagged file rewrites its whole `,v`, and the cost grows with the number of tags already present, so
+each tag makes the next one slower. See `_reports/PERF-02-tag-branch-path.md` for the measured
+reasons and the proposed fixes.
+
+## `commit`
+
+Nothing fork-specific in the option set, but the blob path changes the shape of a commit:
+
+1. The client hashes each `-kB` file with BLAKE3.
+2. It asks the blob server `CHCK <hash>`. If the answer is `HAVE`, no bytes are transferred at all.
+3. Otherwise it compresses and `PUSH`es the blob.
+4. Only then does it send `Blob-ref-transfer` on the CVS connection.
+
+So re-committing an unchanged asset, or committing an asset that already exists elsewhere in the
+repository, costs almost nothing.
+
+## `.cvsrc`
+
+Per-user default options live in `~/.cvsrc` (`%USERPROFILE%\.cvsrc` on Windows), one line per
+command:
+
+```
+cvs -q -j 8
+update -d -P
+diff -u
+checkout -P
+```
+
+`cvs -f ...` ignores the file for one invocation.
+
+## Ignoring files
+
+Sources, in increasing precedence: the built-in list, `CVSROOT/cvsignore`, `~/.cvsignore`,
+`$CVSIGNORE`, the `-I` option, and a `.cvsignore` file in each directory. `!` anywhere in a list
+clears everything seen so far (`src/ignore.cpp`).
+
+## Diagnostics
+
+```
+cvs -t -t -t update -d 2> trace.log
+```
+
+Trace level 3 logs blob URL selection, blob-reference detection and per-file decisions
+(`src/server.cpp:3355`, `src/server.cpp:4431`). This is the first thing to collect when blobs fail
+to download.
+
+```
+cvs version          # client and server versions
+cvs status -v file   # revision, sticky tag, and all tags on the file
+cvs ls -e            # server-side directory listing without a working copy
+```

--- a/docs/08-source-map.md
+++ b/docs/08-source-map.md
@@ -34,7 +34,7 @@ sending requests) and the server half (executing against the repository), separa
 | `rcs_checkin.cpp` | 2236 | Writing a new revision into a `,v` file |
 | `import.cpp` | 1960 | `import` |
 | `log.cpp` | 1884 | `log` / `rlog` |
-| `main.cpp` | 1873 | Entry point, global options (`:745`), command table (`:159`) |
+| `main.cpp` | 1873 | Entry point, global options (`:736`), command table (`:159`) |
 | `buffer.cpp` | 1790 | The buffered-I/O abstraction the whole protocol sits on |
 | `mapping.cpp` | 1636 | Path/name mapping and virtual repositories |
 | `tag.cpp` | 1611 | `tag` / `rtag`, including branch creation |
@@ -48,7 +48,7 @@ sending requests) and the server half (executing against the repository), separa
 | `filesubr.cpp` | 1320 | POSIX filesystem helpers (Windows equivalents are in `windows-NT/`) |
 | `lock.cpp` | 1316 | Repository locking, both file-based and lock-server |
 | `root.cpp` | 1176 | `CVSROOT` string parsing, protocol plugin selection |
-| `modules.cpp`, `Modules1.cpp`, `Modules2.cpp` | | Module database |
+| `modules.cpp` | | Module database |
 | `classify.cpp`, `vers_ts.cpp` | | Deciding a file's state (up-to-date / modified / needs merge / …) |
 | `hash.cpp` | 521 | The `List`/`Node` container used pervasively for entries, files, directories |
 | `httplib.h` | 6707 | Vendored single-header HTTP client, used by the HTTP blob back-end |
@@ -77,7 +77,7 @@ Small and self-contained. Read it in full before touching anything blob-related.
 | `content_addressed_fs.h` | Public API: `start_push`/`stream_push`/`finish`, `start_pull`/`pull`, `exists`, `get_size` |
 | `src/content_addressed_fs.cpp` | Implementation: path layout, temp-file-then-rename, dedup |
 | `ca_blob_format.h` | The 16-byte blob header and magic values |
-| `src/fileio.cpp`, `fileio.h` | Filesystem primitives, memory-mapped pull |
+| `src/fileio.cpp`, `src/fileio.h` | Filesystem primitives, memory-mapped pull |
 | `streaming_compressors.h`, `src/streaming_compressors.cpp` | zlib/zstd abstraction |
 | `calc_hash.h`, `src/calc_hash.cpp` | Hex/binary hash conversion |
 | `streaming_blobs.h`, `push_whole_blob.h` | Higher-level streaming helpers |
@@ -100,9 +100,9 @@ Small and self-contained. Read it in full before touching anything blob-related.
 
 | Path | Role |
 | --- | --- |
-| `cvsapi/` (~26 kLoC) | C++ support library: sockets, HTTP, TLS, compression, `db/` back-ends (MySQL, PostgreSQL, SQLite, ODBC, Oracle, MSSQL, DB2), `mdns/`, `unix/` and `win32/` platform layers |
-| `cvstools/` (~6 kLoC) | `CGlobalSettings`, `CLibraryAccess`, `EntriesParser`, `RootSplitter`, `Scramble`, plugin interfaces |
-| `lib/` (~11 kLoC) | GNU portability layer: `getline`, `fnmatch`, `getopt`, `xmalloc`, `regex`, `md5`, `savecwd` |
+| `cvsapi/` (~26 kLoC) | C++ support library: sockets, HTTP, TLS, `CLibraryAccess` (dynamic loading), XML, codepage conversion, `db/` back-ends (MySQL, PostgreSQL, SQLite, ODBC, Oracle, MSSQL, DB2), `mdns/`, `unix/` and `win32/` platform layers |
+| `cvstools/` (~6 kLoC) | `CGlobalSettings`, `CProtocolLibrary`, `CTriggerLibrary`, `EntriesParser`, `RootSplitter`, `Scramble`, `ServerConnection`, `ServerInfo`, plugin-interface headers |
+| `lib/` (~11 kLoC) | GNU portability layer: `getline`, `getdelim`, `fnmatch`, `getopt_long`, `regcomp`, `getaddrinfo`/`getnameinfo`, `timegm`, `waitpid`. (`xmalloc` is `src/subr.cpp:67`, `savecwd` is `src/savecwd.cpp`, MD5 is `cvsapi/lib/md5.c`) |
 | `diff/` (~8.5 kLoC) | GNU diff |
 | `xdiff/` | Pluggable external and XML diff back-ends |
 | `windows-NT/` | Windows implementations of `filesubr`, `mkdir`, `pwd`, `setuid`, `waitpid`, plus `cvsdiag`, `gss-ad`, `setuid` helpers |
@@ -133,7 +133,7 @@ Small and self-contained. Read it in full before touching anything blob-related.
 | `cvsgui/` | GUI integration protocol (used by WinCVS/TortoiseCVS) |
 | `cvsdelta/`, `rcs/`, `rcs_convert.vcxproj` | Auxiliary RCS tools (`co`, `rlog`, `rcsdiff`) |
 | `mdnsclient/`, `extnt/`, `su/`, `genkey/`, `genbuild/`, `postinst/`, `uninsthlp/` | Small helper executables |
-| `tools/` | `cvtblob`, `gc-blobs`, `repack-blobs`, `blake3-calc`, `simplelock`, `unlock` |
+| `tools/` | `cvtblob`, `gc-blobs`, `repack-blobs`, `blake3-calc`. (`simplelock.cpp`, `unlock.cpp` and `sha256_calc.cpp` are present but appear in no build file) |
 
 ### Build system
 
@@ -151,8 +151,20 @@ Small and self-contained. Read it in full before touching anything blob-related.
 3. `src/update.cpp` — the most-used command, and the clearest example of the client/server split.
 4. `src/server.cpp:4908` and `src/client.cpp:4022` — the two protocol tables side by side.
 5. `keyValueServer/include/blob_push_protocol.h` — the blob protocol, in one file.
-6. `ca_blobs_fs/content_addressed_fs.h` and `src/content_addressed_fs.cpp` — the store.
+6. `ca_blobs_fs/content_addressed_fs.h` and `ca_blobs_fs/src/content_addressed_fs.cpp` — the store.
 7. `src/rcs.cpp` — last, and carefully. Everything about repository integrity lives here.
+
+## Dead code
+
+Three files are present in the tree but are in **no build file** and are included by nothing except
+each other:
+
+* `src/Modules1.cpp` / `Modules1.h`
+* `src/Modules2.cpp` / `Modules2.h`
+* `src/RecurseRepository.cpp` / `RecurseRepository.h`
+
+They appear in neither `src/Makefile.am` nor `cvsnt.vcxproj`. Do not use them as a reference for how
+anything currently works, and do not "fix" bugs in them expecting an effect.
 
 ## Conventions to expect
 

--- a/docs/08-source-map.md
+++ b/docs/08-source-map.md
@@ -1,0 +1,168 @@
+# Source map
+
+Everything lives under `cvsnt/cvsnt-2.5.05.3744/`. The directory name is historical — it does not
+match the shipped version (3.5.x).
+
+Paths below are relative to that directory unless stated otherwise.
+
+## Top-level layout of the repository
+
+| Path | Contents |
+| --- | --- |
+| `cvsnt/build-linux-server`, `build-macosx`, `build-rhel6`, `build-altlinux` | Platform build drivers |
+| `cvsnt/install-yum-packages` | RHEL/CentOS dependency list |
+| `cvsnt/*.wxs`, `cvsnt/make_msi*.bat`, `cvsnt/msi_tools/` | WiX installer definitions for Windows |
+| `cvsnt/*.patch` | Patches against stock CVSNT kept for reference |
+| `cvsnt/tortoiseCVS/` | TortoiseCVS integration |
+| `cvsnt/cvsnt-2.5.05.3744/` | The actual source tree |
+
+## The source tree
+
+### Core command implementation — `src/` (~85 kLoC)
+
+The heart of CVS. Each command has one file; most contain both the client half (argument parsing,
+sending requests) and the server half (executing against the repository), separated by
+`server_active` checks and `#ifdef SERVER_SUPPORT` / `CLIENT_SUPPORT`.
+
+| File | Lines | Role |
+| --- | ---: | --- |
+| `rcs.cpp` | 7615 | RCS `,v` parsing, revision extraction, symbol/branch manipulation, rewriting. The most delicate file in the tree |
+| `server.cpp` | 7227 | Server request loop, request table (`:4908`), response emission |
+| `client.cpp` | 6261 | Client request emission, response table (`:4022`), response handlers |
+| `update.cpp` | 3480 | `update`: classification, checkout, merge, join |
+| `commit.cpp` | 2516 | `commit` |
+| `rcs_checkin.cpp` | 2236 | Writing a new revision into a `,v` file |
+| `import.cpp` | 1960 | `import` |
+| `log.cpp` | 1884 | `log` / `rlog` |
+| `main.cpp` | 1873 | Entry point, global options (`:745`), command table (`:159`) |
+| `buffer.cpp` | 1790 | The buffered-I/O abstraction the whole protocol sits on |
+| `mapping.cpp` | 1636 | Path/name mapping and virtual repositories |
+| `tag.cpp` | 1611 | `tag` / `rtag`, including branch creation |
+| `subr.cpp` | 1571 | Assorted helpers |
+| `edit.cpp` | 1546 | `edit`/`unedit`/`watch` |
+| `recurse.cpp` | 1527 | `start_recursion` — the directory walker every command uses |
+| `mkmodules.cpp` | 1456 | `CVSROOT` administrative file handling |
+| `entries.cpp` | 1429 | `CVS/Entries` reading and writing |
+| `history.cpp` | 1410 | `CVSROOT/history` |
+| `checkout.cpp` | 1388 | `checkout` / `export` |
+| `filesubr.cpp` | 1320 | POSIX filesystem helpers (Windows equivalents are in `windows-NT/`) |
+| `lock.cpp` | 1316 | Repository locking, both file-based and lock-server |
+| `root.cpp` | 1176 | `CVSROOT` string parsing, protocol plugin selection |
+| `modules.cpp`, `Modules1.cpp`, `Modules2.cpp` | | Module database |
+| `classify.cpp`, `vers_ts.cpp` | | Deciding a file's state (up-to-date / modified / needs merge / …) |
+| `hash.cpp` | 521 | The `List`/`Node` container used pervasively for entries, files, directories |
+| `httplib.h` | 6707 | Vendored single-header HTTP client, used by the HTTP blob back-end |
+
+#### Gaijin-specific files in `src/`
+
+| File | Role |
+| --- | --- |
+| `sha_blob_reference.h` | Blob reference format constants and predicates |
+| `blob_operations.cpp` | Reference encode/decode, session MAC |
+| `blob_network_processor.h` | `BlobNetworkProcessor` / `UrlProvider` interfaces |
+| `blob_kv_processor.cpp` | Native `blob_push` transport |
+| `blob_http_processor.cpp` | HTTP transport |
+| `download_blob_to.cpp` | Client download orchestration, worker threads, URL failover |
+| `rcs_cvt_kB.cpp` | `-kB` conversion helpers |
+| `concurrent_queue.h` | Work queue for parallel downloads |
+| `zstd_buffer.cpp` | zstd stream framing for the CVS connection |
+| `sha256/` | SHA-256 (legacy; BLAKE3 is the current hash) |
+
+### The blob store — `ca_blobs_fs/` (~1.5 kLoC)
+
+Small and self-contained. Read it in full before touching anything blob-related.
+
+| File | Role |
+| --- | --- |
+| `content_addressed_fs.h` | Public API: `start_push`/`stream_push`/`finish`, `start_pull`/`pull`, `exists`, `get_size` |
+| `src/content_addressed_fs.cpp` | Implementation: path layout, temp-file-then-rename, dedup |
+| `ca_blob_format.h` | The 16-byte blob header and magic values |
+| `src/fileio.cpp`, `fileio.h` | Filesystem primitives, memory-mapped pull |
+| `streaming_compressors.h`, `src/streaming_compressors.cpp` | zlib/zstd abstraction |
+| `calc_hash.h`, `src/calc_hash.cpp` | Hex/binary hash conversion |
+| `streaming_blobs.h`, `push_whole_blob.h` | Higher-level streaming helpers |
+
+### The blob network layer — `keyValueServer/` (~4 kLoC)
+
+| Path | Role |
+| --- | --- |
+| `include/blob_push_protocol.h` | **The protocol specification.** Read this first |
+| `include/blob_raw_sockets.h`, `blob_common_net.h`, `blob_hash_util.h` | Shared helpers |
+| `include/blobs_encryption.h` | Encryption/handshake types |
+| `blob_sockets/blob_sockets.cpp` | Portable socket layer |
+| `clientLib/` | Client side: `blob_push_pull_client.cpp` plus one file per command |
+| `serverLib/` | Server side: `blob_push_proc.cpp` (command dispatch), `blob_push_server.cpp` (accept loop) |
+| `server/` | The `cafs_server` executable and its file back-end |
+| `proxy/` | The `cafs_proxy_server` executable, cache eviction, disk-space monitoring |
+| `sample/`, `sampleImplementation/` | Example client/server and logging stubs |
+
+### Support libraries
+
+| Path | Role |
+| --- | --- |
+| `cvsapi/` (~26 kLoC) | C++ support library: sockets, HTTP, TLS, compression, `db/` back-ends (MySQL, PostgreSQL, SQLite, ODBC, Oracle, MSSQL, DB2), `mdns/`, `unix/` and `win32/` platform layers |
+| `cvstools/` (~6 kLoC) | `CGlobalSettings`, `CLibraryAccess`, `EntriesParser`, `RootSplitter`, `Scramble`, plugin interfaces |
+| `lib/` (~11 kLoC) | GNU portability layer: `getline`, `fnmatch`, `getopt`, `xmalloc`, `regex`, `md5`, `savecwd` |
+| `diff/` (~8.5 kLoC) | GNU diff |
+| `xdiff/` | Pluggable external and XML diff back-ends |
+| `windows-NT/` | Windows implementations of `filesubr`, `mkdir`, `pwd`, `setuid`, `waitpid`, plus `cvsdiag`, `gss-ad`, `setuid` helpers |
+| `osx/` | macOS packaging and build scripts |
+
+### Vendored third-party code
+
+| Path | What |
+| --- | --- |
+| `blake3/` | BLAKE3 reference implementation with SIMD kernels |
+| `zlib/`, `zstd/` | Compression libraries |
+| `pcre/` | Perl-compatible regex |
+| `libxml/` | libxml2 |
+| `plink/` | PuTTY's plink, for the built-in `ssh` method |
+| `ufc-crypt/` | `crypt()` implementation |
+| `external_libs/` | Prebuilt OpenSSL / iconv / dnssd import libraries and headers for Windows |
+| `tools/tsl/` | Sparse hash map/set used by the maintenance tools |
+
+### Plugins and executables
+
+| Path | Produces |
+| --- | --- |
+| `protocols/` | One shared library per connection method |
+| `triggers/` | One shared library per server-side hook family |
+| `lockservice/` | `cvslockd` |
+| `cvsservice/`, `cvsntcpl/`, `control-panel/` | Windows NT service and control-panel applet |
+| `cvsagent/` | Credential agent |
+| `cvsgui/` | GUI integration protocol (used by WinCVS/TortoiseCVS) |
+| `cvsdelta/`, `rcs/`, `rcs_convert.vcxproj` | Auxiliary RCS tools (`co`, `rlog`, `rcsdiff`) |
+| `mdnsclient/`, `extnt/`, `su/`, `genkey/`, `genbuild/`, `postinst/`, `uninsthlp/` | Small helper executables |
+| `tools/` | `cvtblob`, `gc-blobs`, `repack-blobs`, `blake3-calc`, `simplelock`, `unlock` |
+
+### Build system
+
+| Path | Role |
+| --- | --- |
+| `configure.in`, `acinclude.m4`, `Makefile.am` (per directory) | Autotools, used on Linux and macOS |
+| `cvsnt.sln`, `*.vcxproj` | Visual Studio solution, used on Windows |
+| `debian/`, `redhat/` | Distribution packaging |
+| `tools/build_tools` | Standalone clang++ build for the maintenance tools |
+
+## Reading order for a newcomer
+
+1. `src/main.cpp` — the command table and global options; how a command is dispatched.
+2. `src/recurse.cpp` — `start_recursion`, the walker every command is built on.
+3. `src/update.cpp` — the most-used command, and the clearest example of the client/server split.
+4. `src/server.cpp:4908` and `src/client.cpp:4022` — the two protocol tables side by side.
+5. `keyValueServer/include/blob_push_protocol.h` — the blob protocol, in one file.
+6. `ca_blobs_fs/content_addressed_fs.h` and `src/content_addressed_fs.cpp` — the store.
+7. `src/rcs.cpp` — last, and carefully. Everything about repository integrity lives here.
+
+## Conventions to expect
+
+* C-style C++: raw pointers, `xmalloc`/`xfree`, `char*` strings, `List`/`Node` from `src/hash.cpp`.
+  `xmalloc` never returns NULL — it calls `error(1, ...)` on failure — so unchecked allocations are
+  intentional, not bugs.
+* `error(status, errno_value, format, ...)` is the universal error path; a non-zero `status` exits.
+* Functions passed to `start_recursion` follow fixed signatures: `fileproc`, `filesdoneproc`,
+  `direntproc`, `dirleaveproc`.
+* Windows and POSIX diverge through `windows-NT/` and `lib/`, not through inline `#ifdef`s, in most
+  places. `cvsapi/` splits by `unix/` vs `win32/` subdirectories.
+* Indentation is inconsistent (tabs and spaces mixed, several eras of style). Match the surrounding
+  block rather than the file.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,5 @@ command set, the RCS format, ACLs, triggers — is unchanged.
 The `_reports/` directory at the repository root holds code-analysis output: individual bug findings
 (`BUG-*.md`), performance analyses of the update and tag paths (`PERF-*.md`), and build notes
 (`BUILD-*.md`). Each bug file is self-contained, with the offending code, a concrete failure
-scenario, and a suggested fix.
+scenario, and a suggested fix. The tree lands in the next slice of this audit series; on this
+branch every `_reports/` path is a forward reference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# G-CVSNT documentation
+
+G-CVSNT is Gaijin Entertainment's fork of CVSNT, adapted for repositories that hold hundreds of
+thousands of large binary files.
+
+| Document | What it covers |
+| --- | --- |
+| [01-overview.md](01-overview.md) | What this fork is, why it exists, what it changes and what it leaves alone |
+| [02-architecture.md](02-architecture.md) | Processes, connection methods, library layers, request flow |
+| [03-content-addressed-storage.md](03-content-addressed-storage.md) | The blob store: hashing, on-disk format, dedup, trust model |
+| [04-protocols.md](04-protocols.md) | CVS protocol extensions and the `blob_push` protocol |
+| [05-repository-layout.md](05-repository-layout.md) | What is on disk, server side and client side |
+| [06-server-operations.md](06-server-operations.md) | Running the CVS server, lock server, blob server and proxy; maintenance tools |
+| [07-client-usage.md](07-client-usage.md) | Commands and options that matter in this fork |
+| [08-source-map.md](08-source-map.md) | Directory-by-directory guide to the source tree |
+| [../HOWTOBUILD.md](../HOWTOBUILD.md) | Building on Windows, Linux and macOS |
+
+## The one-paragraph version
+
+Classic CVS stores every revision of a binary file inside its `,v` file and rewrites that whole file
+to add a tag. For a game repository this is fatal. G-CVSNT adds a keyword mode `-kB` under which a
+file's content is stored once, keyed by its BLAKE3 hash, in a separate content-addressed store
+(CAFS), while the `,v` file keeps only a 71-byte reference per revision. Blob bytes move over their
+own TCP protocol that can be served by a dumb caching proxy near the client. Everything else — the
+command set, the RCS format, ACLs, triggers — is unchanged.
+
+## Analysis reports
+
+The `_reports/` directory at the repository root holds code-analysis output: individual bug findings
+(`BUG-*.md`), performance analyses of the update and tag paths (`PERF-*.md`), and build notes
+(`BUILD-*.md`). Each bug file is self-contained, with the offending code, a concrete failure
+scenario, and a suggested fix.


### PR DESCRIPTION
## Summary

First slice of a six-part stack from an audit pass over the fork. It is
thematically mixed and the title says so: the bulk of the diff is a new
documentation set, but three fixes for real defects found while writing it are
inside the same slice, because that is the order in which the work happened and
the history is being preserved rather than re-cut.

The documentation exists because the repository shipped the upstream CVS and
CVSNT manuals but nothing describing what *this* fork changes: the `-kB`/`-kBz`
binary modes, the content-addressed blob store, the separate blob transport, or
how the pieces are deployed. All of that had to be reconstructed from the
source, so every non-obvious claim in `docs/` is anchored to a `file:line`.
`HOWTOBUILD.md` covers Linux, macOS and Windows, including a verified build
using only a standalone MSVC toolchain without Visual Studio or MSBuild.

The three fixes are small and independent:

* `9fcd6de` — `10.0.0.0/8` was classified with a 4-bit mask instead of an 8-bit
  one, so the private-range test misclassified addresses.
* `c9cfffd` — the unix receive buffer advanced its position by the number of
  bytes *requested* rather than the number *received*, so a short read left the
  buffer position ahead of the valid data.
* `4f8c1b0` — the blob header remainder was taken from the chunk size rather
  than the header size, which overruns when a 16-byte header is split across
  network chunks. This one is load-bearing: reintroducing it later in the
  series makes the unit-test binary die with `STATUS_STACK_BUFFER_OVERRUN`
  rather than merely report a failure.

`01f18ae` is a follow-up that corrects claims and anchors in the new documents
that a review pass found wrong.

## Commits

```
01f18ae docs: correct claims and anchors found wrong by review
4f8c1b0 fix: take the header remainder from the header size, not the chunk size
c9cfffd fix: advance the unix recv buffer position by bytes taken, not bytes wanted
9fcd6de fix: classify 10.0.0.0/8 with an 8-bit mask, not a 4-bit one
2e2c14b docs: document architecture, blob storage, protocols and the build
```

## Verification

The three fixes are behaviour changes in the sense that the buggy paths now do
the right thing; nothing else in this slice changes behaviour — `docs/`,
`README.md` and `HOWTOBUILD.md` are new or additive text.

No test suite exists yet at this point in the history; the suites arrive in
PR 3 of this stack, and the header-remainder fix from `4f8c1b0` is
covered there by the streaming-header accumulator checks (fed at every chunk
size from one byte to the whole blob).

## Reports in this diff

None — the analysis reports land in the next slice.

## Stack

This is the base of the stack. PR 2 (`audit/02-analysis-reports-and-fixes`)
targets this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
