### PR TITLE
checkout: small -kB revisions no longer check out as empty files (BUG-blob-21 residual)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tmp/*.*
 CVS
 log1
 log2
+__pycache__/

--- a/_reports/BUG-blob-21-local-mode-binary-commit-data-loss.md
+++ b/_reports/BUG-blob-21-local-mode-binary-commit-data-loss.md
@@ -8,7 +8,7 @@ category: correctness
 verdict: CONFIRMED
 fix_size_loc: 20
 behavior_change: yes
-status: partially fixed - the blob root and missing-blobs-dir cases; part 1 is itself incomplete (small revisions still check out empty), parts 2 and 3 remain open
+status: part 1 fixed (blob root, missing blobs dir, and the small-revision empty checkout); parts 2 and 3 remain open
 ---
 
 # In local mode, committing a second revision of a binary file either aborts or silently destroys the content
@@ -162,34 +162,44 @@ Parts of this are fixed on this branch:
 
 Verified by the regression case "second commit of a binary file round trips byte for byte", which
 fails against the previous build (commit aborted) and passes now, including a byte-exact fresh
-checkout and `update -r` back to the first revision. That case uses a 1541-byte payload; it does
-not exercise small revisions, which are still lost - see "Residual" below.
+checkout and `update -r` back to the first revision. That case uses a 1541-byte payload, which
+happened to dodge a second defect on the checkout side - see "Residual" below, now fixed.
 
 Still open: the default root should fail loudly rather than silently resolving to a relative path
 (part 2 below), and the read path still cannot report a missing blob (`BUG-server-12`, part 3) — a
 repository already poisoned by the old behaviour still checks out empty files without an error.
 
-## Residual: a correctly stored small revision still checks out empty
+## Residual (fixed): a correctly stored small revision checked out empty
 
-Part 1 above is incomplete.  With the blob root set and the `blobs/` directory present - the
-common case it is meant to fix - a `-kB` revision whose payload is below roughly 1.5 KB still
-checks out as a **zero-length** file in local mode.  This is not the missing-root or missing-dir
-case and not a dangling reference: the blob is written whole at commit (`<repos>/blobs/..`, the
-payload plus a 16-byte `NONE` header), yet a fresh checkout elsewhere produces an empty working
-file.  Deleting the working copy that still holds the bytes loses the revision.
+Part 1 above was itself incomplete.  With the blob root set and the `blobs/` directory present, a
+`-kB` revision whose payload was below roughly 1.5 KB still checked out as a **zero-length** file in
+local mode: the blob was written whole at commit, the reference in the `,v` pointed at it, and the
+pull returned the right bytes - yet the working file came out empty.  Deleting the working copy
+that still held the bytes lost the revision.
 
-Reproduction (local mode, no server): import a `-kb` file, commit a second revision of ~256 bytes,
-check out into a fresh directory - the file is 0 bytes.  The boundary is size-driven: payloads at
-1541 bytes round-trip, payloads at 1400 and below do not, so the existing regression case passes
-only because its payload sits just above the failing range.
+Root cause, three layers deep in the working-file write (`RCS_checkout`, `src/rcs_checkin.cpp`):
 
-The streaming decoder itself is not at fault - `unit_tests` feeds whole blobs through
-`decode_stream_blob_data` in fixed-size chunks at small sizes and passes - so the defect is in the
-checkout glue that dereferences the blob reference and sizes the working-file write
-(`RCS_checkout` -> `RCS_read_binary_rev_data` -> `pull_at_once`, `src/rcs_checkin.cpp:135`,
-`src/rcs_cvt_kB.cpp:32`).  Pinned as an expected-failure regression case,
-`t_binary_small_second_commit`, which flips to a hard failure (XPASS) once this is fixed.
+1. Binary content was routed through the **codepage encoder**: `encode = oencode`, whose
+   condition does not exclude `KFLAG_BINARY` (the `nencode` variable beside it did, and was
+   unused).  So `-kB` bytes went to `CCodepage::OutputAsEncoded`.
+2. `CCodepage::ConvertEncoding` **guesses an encoding from the bytes** (`GuessEncoding`).  When
+   the binary garbage happened to look like some charset, it opened iconv; iconv failed on the
+   first invalid sequence - but the check `iconv(...) < 0` on a `size_t` can never fire, so the
+   call "succeeded" having converted nothing, and `outlen -= out_remaining` landed on **0**.
+3. `OutputAsEncoded`'s `ltLf` branch passed `l` as **both** the input length and the output
+   length (`ConvertEncoding(o, l, outbuf, l)`), so `l` became 0 and `write(fd, o, 0)` succeeded
+   with an empty file and no error.
 
+When the guess said "no conversion", `outlen` was left alone and the file was right - which is why
+the boundary shifted with content and size rather than sitting on a clean threshold, and why the
+1541-byte regression payload passed.  The same hole could empty a **text** file whose guessed
+encoding failed to convert.
+
+Fixed on this branch: binary never enters the encoder; `ConvertEncoding` detects an iconv failure
+(`== (size_t)-1`); every `OutputAsEncoded` call site keeps a separate output length and adopts it
+only from a real conversion, writing the raw bytes otherwise.  Pinned by
+`t_binary_small_second_commit`, which now commits and checks out six payload sizes from 100 to
+1400 bytes so a lucky guess on one size cannot hide a regression.
 ## Suggested fix
 Three parts, smallest first:
 

--- a/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
@@ -293,7 +293,9 @@ int CCodepage::ConvertEncoding(const void *inbuf, size_t len, void *&outbuf, siz
 	}
 	m_blockcount++;
 
-	if(iconv((iconv_t)m_ic,(iconv_arg2_t)&inbufp,&in_remaining,&outbufp,&out_remaining)<0)
+	/* iconv returns size_t, so "< 0" could never fire: a failed conversion
+	   fell through with nothing converted and outlen collapsed to 0.  */
+	if(iconv((iconv_t)m_ic,(iconv_arg2_t)&inbufp,&in_remaining,&outbufp,&out_remaining)==(size_t)-1)
 		return -1;
 	outlen-= out_remaining;
 	return 1;
@@ -343,8 +345,14 @@ int CCodepage::OutputAsEncoded(int fd, const void *inbuf, size_t len, LineType C
 			outbuf=NULL;
 			if(l)
 			{
-				if(ConvertEncoding(o,l,outbuf,l))
+				/* Adopt the converted length only from a real conversion; a
+				   failed one keeps the raw bytes rather than dropping them.  */
+				size_t olen = 0;
+				if(ConvertEncoding(o,l,outbuf,olen)>0)
+				{
 					o=(char*)outbuf;
+					l=olen;
+				}
 
 				if(write(fd,o,(unsigned)l)<(int)l)
 				{
@@ -360,10 +368,15 @@ int CCodepage::OutputAsEncoded(int fd, const void *inbuf, size_t len, LineType C
 				free(outbuf);
 				outbuf=NULL;
 			}
-			if(ConvertEncoding(o,line_end_len,outbuf,l))
-				o=(char*)outbuf;
-			else
-				l=line_end_len;
+			l=line_end_len;
+			{
+				size_t olen = 0;
+				if(ConvertEncoding(o,line_end_len,outbuf,olen)>0)
+				{
+					o=(char*)outbuf;
+					l=olen;
+				}
+			}
 			if(write(fd,o,(unsigned)l)<(int)l)
 			{
 				if(outbuf)
@@ -379,10 +392,11 @@ int CCodepage::OutputAsEncoded(int fd, const void *inbuf, size_t len, LineType C
 		{
 			outbuf=NULL;
 			o=pinbuf;
-			if(ConvertEncoding(o,l,outbuf,len))
+			size_t olen = 0;
+			if(ConvertEncoding(o,l,outbuf,olen)>0)
 			{
 				o=(char*)outbuf;
-				l=len;
+				l=olen;
 			}
 			if(write(fd,o,(unsigned)l)<(int)l)
 			{
@@ -399,10 +413,18 @@ int CCodepage::OutputAsEncoded(int fd, const void *inbuf, size_t len, LineType C
 	else
 	{
 		outbuf = NULL;
-		char *p = (char*)inbuf, *o = (char*)inbuf;
+		char *o = (char*)inbuf;
 		size_t l = len;
-		if(ConvertEncoding(o,l,outbuf,l))
+		/* l was passed as both the input and the output length, so a failed
+		   conversion (which converted nothing) turned it into 0 and the file
+		   was written out empty.  Keep the raw bytes on anything but a real
+		   conversion.  */
+		size_t olen = 0;
+		if(ConvertEncoding(o,len,outbuf,olen)>0)
+		{
 			o=(char*)outbuf;
+			l=olen;
+		}
 		if(write(fd,o,(unsigned)l)<(int)l)
 		{
 			if(outbuf)

--- a/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
@@ -266,10 +266,11 @@ int CCodepage::ConvertEncoding(const void *inbuf, size_t len, void *&outbuf, siz
 		}
 	}
 
+	void *allocated = NULL;
 	if(!outbuf)
 	{
 		outlen = (len * 4) + 4; /* Enough for ansi -> ucs4-le + a BOM */
-		outbuf = malloc(outlen);
+		outbuf = allocated = malloc(outlen);
 		outbufp= (char*)outbuf;
 	}
 
@@ -296,7 +297,16 @@ int CCodepage::ConvertEncoding(const void *inbuf, size_t len, void *&outbuf, siz
 	/* iconv returns size_t, so "< 0" could never fire: a failed conversion
 	   fell through with nothing converted and outlen collapsed to 0.  */
 	if(iconv((iconv_t)m_ic,(iconv_arg2_t)&inbufp,&in_remaining,&outbufp,&out_remaining)==(size_t)-1)
+	{
+		/* Nothing comes back from a failed conversion: release the buffer
+		   this call allocated so no caller has to know whether one exists.  */
+		if(allocated)
+		{
+			free(allocated);
+			outbuf = NULL;
+		}
 		return -1;
+	}
 	outlen-= out_remaining;
 	return 1;
 }

--- a/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/cvsapi/Codepage.cpp
@@ -373,7 +373,12 @@ int CCodepage::OutputAsEncoded(int fd, const void *inbuf, size_t len, LineType C
 				}
 			}
 			o=(char*)line_end;
-			if(l<8 && outbuf)
+			/* Never reuse the text buffer here: ConvertEncoding only knows
+			   the capacity of a buffer it allocates itself, and the call
+			   below passes 0 for an existing one.  With the reuse, every
+			   line ending after a non-empty line came out as the raw CRLF
+			   in a -ku (UTF-16) file.  */
+			if(outbuf)
 			{
 				free(outbuf);
 				outbuf=NULL;

--- a/cvsnt/cvsnt-2.5.05.3744/src/rcs_checkin.cpp
+++ b/cvsnt/cvsnt-2.5.05.3744/src/rcs_checkin.cpp
@@ -213,14 +213,12 @@ int RCS_checkout (RCSNode *rcs, const char *workfile, const char *rev, const cha
 	else if(expand.flags&(KFLAG_BINARY|KFLAG_UNIX))
 		crlf=ltLf;
 
-	bool oopen_binary = ((expand.flags&KFLAG_BINARY) || (expand.flags&KFLAG_UNIX));
-	bool oencode = (((expand.flags&KFLAG_ENCODED) || (crlf!=CRLF_DEFAULT)) && !server_active);
-	bool nopen_binary = ((expand.flags&KFLAG_BINARY) || (crlf!=CRLF_DEFAULT) || ((expand.flags&(KFLAG_BINARY|KFLAG_ENCODED) && (!server_active))));
-	bool nencode = !(expand.flags&KFLAG_BINARY) && (((expand.flags&KFLAG_ENCODED) || (crlf!=CRLF_DEFAULT)) && !server_active);
-	bool xopen_binary = (expand.flags&(KFLAG_BINARY|KFLAG_ENCODED)) || (crlf!=CRLF_DEFAULT) && !server_active;
-	bool xencode = !(expand.flags&KFLAG_BINARY) && ((expand.flags&KFLAG_ENCODED) || (crlf!=CRLF_DEFAULT)) && !server_active;
-	bool encode=oencode;
-	bool open_binary=xopen_binary;
+	/* Binary content must never pass through the codepage encoder: it
+	   guesses an encoding from the bytes, and a wrong guess followed by a
+	   failed iconv wrote the file out empty (BUG-blob-21 residual).  */
+	bool encode = !(expand.flags&KFLAG_BINARY)
+		&& ((expand.flags&KFLAG_ENCODED) || (crlf!=CRLF_DEFAULT)) && !server_active;
+	bool open_binary = (expand.flags&(KFLAG_BINARY|KFLAG_ENCODED)) || (crlf!=CRLF_DEFAULT) && !server_active;
 
 	if (free_rev)
 		xfree (rev);

--- a/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
+++ b/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
@@ -1118,33 +1118,33 @@ def t_second_checkout(r):
 
 # --------------------------------------------------------------------------- driver
 
-@xfail("small -kB binary second revision checks out byte for byte (BUG-blob-21 residual)",
-       "BUG-blob-21 is only partly fixed: a -kB revision below ~1.5 KB checks "
-       "out as a zero-length file in local mode; the committed blob is intact.")
+@test("small -kB binary second revision checks out byte for byte")
 def t_binary_small_second_commit(r):
-    # Same shape as t_binary_second_commit, but a small payload.  The blob
-    # is written whole at commit (payload + a 16-byte header), yet a fresh
-    # checkout produces an empty file: data loss once the working copy that
-    # still holds the bytes is deleted.  t_binary_second_commit passes only
-    # because its 1541-byte payload sits just above the failing range.
+    # Same shape as t_binary_second_commit, but a small payload.  Binary
+    # content used to pass through the codepage encoder, which guessed an
+    # encoding from the bytes; a wrong guess and a failed iconv wrote the
+    # working file out empty, and only payloads the guesser left alone
+    # (like the 1541-byte one above) survived.  Several sizes, so a lucky
+    # guess on one of them cannot hide a regression.
     payload1 = bytes(range(256))
-    payload2 = bytes(reversed(range(256)))  # 256 bytes
     imp = os.path.join(r.root, "impbin")
     os.makedirs(imp)
     with open(os.path.join(imp, "b.dat"), "wb") as f:
         f.write(payload1)
     r.cvs(["import", "-m", "bin", "-kb", "mb", "VENDOR", "REL0"], cwd=imp)
     wc = r.checkout("mb")
-    with open(os.path.join(wc, "b.dat"), "wb") as f:
-        f.write(payload2)
-    r.cvs(["commit", "-m", "second"], cwd=wc)
-    wc2root = os.path.join(r.root, "wc2")
-    os.makedirs(wc2root)
-    r.cvs(["checkout", "mb"], cwd=wc2root)
-    got = open(os.path.join(wc2root, "mb", "b.dat"), "rb").read()
-    check_eq(got, payload2,
-             "small binary second revision did not round trip (got %d bytes)"
-             % len(got))
+    for n, size in enumerate((100, 256, 300, 768, 1200, 1400)):
+        payload = (bytes(reversed(range(256))) * (size // 256 + 1))[:size]
+        with open(os.path.join(wc, "b.dat"), "wb") as f:
+            f.write(payload)
+        r.cvs(["commit", "-m", "rev %d" % n], cwd=wc)
+        fresh = os.path.join(r.root, "fresh%d" % n)
+        os.makedirs(fresh)
+        r.cvs(["checkout", "mb"], cwd=fresh)
+        got = open(os.path.join(fresh, "mb", "b.dat"), "rb").read()
+        check_eq(len(got), size,
+                 "%d-byte binary revision came back as %d bytes" % (size, len(got)))
+        check(got == payload, "%d-byte binary revision content differs" % size)
 
 def main():
     global CVS, LIBDIR, VERBOSE, CURRENT, PASSED

--- a/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
+++ b/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
@@ -367,11 +367,8 @@ def t_no_backup_nonmergeable(r):
           "update -n did not report the nonmergeable conflict:" + chr(10) + out)
     check("file from working directory is now in" not in out,
           "update -n named a copy it does not keep:" + chr(10) + out)
-    # The local edit is discarded either way; do not assert the exact
-    # repository bytes here - a small -kB revision checks out empty under
-    # the residual BUG-blob-21 defect (see t_binary_small_second_commit).
-    check(open(os.path.join(wc, "b.dat"), "rb").read() != local,
-          "update -n kept the local edit on a nonmergeable conflict")
+    check_eq(open(os.path.join(wc, "b.dat"), "rb").read(), payload2,
+             "b.dat content after update -n on a nonmergeable conflict")
     backups = [f for f in os.listdir(wc) if f.startswith(".#")]
     check(not backups, "update -n left a pre-merge copy: %r" % backups)
 
@@ -1133,8 +1130,16 @@ def t_binary_small_second_commit(r):
         f.write(payload1)
     r.cvs(["import", "-m", "bin", "-kb", "mb", "VENDOR", "REL0"], cwd=imp)
     wc = r.checkout("mb")
-    for n, size in enumerate((100, 256, 300, 768, 1200, 1400)):
-        payload = (bytes(reversed(range(256))) * (size // 256 + 1))[:size]
+    # GuessEncoding keys on the leading bytes and on length parity, so the
+    # cases vary both: no BOM at even and odd lengths, the UCS-2LE and
+    # UCS-2BE guesses, a UTF-8 BOM, and the odd 1541-byte shape that used
+    # to dodge the defect - each takes its own branch.
+    base = bytes(range(256)) * 7
+    cases = ((100, bytes()), (301, bytes()), (768, bytes([255, 254])),
+             (1200, bytes([254, 255])), (1401, bytes([239, 187, 191])),
+             (1541, bytes([255, 254])))
+    for n, (size, prefix) in enumerate(cases):
+        payload = (prefix + base)[:size]
         with open(os.path.join(wc, "b.dat"), "wb") as f:
             f.write(payload)
         r.cvs(["commit", "-m", "rev %d" % n], cwd=wc)

--- a/known_issues.md
+++ b/known_issues.md
@@ -1,6 +1,6 @@
 # Known issues
 
-87 defects were found by a review pass over the tree. 15 are fixed on this branch; **70 remain
+87 defects were found by a review pass over the tree. 16 are fixed on this branch; **69 remain
 open** and are listed here. Two more were fixed and then reverted, for reasons recorded below —
 those are the most interesting entries in this document, because in both cases the obvious one-line
 fix is wrong.
@@ -226,18 +226,7 @@ Ordered by severity. "Fix size" is the estimated lines of change; "changes behav
 applying the fix alters observable behaviour, which is what kept several of the small ones out of
 this branch.
 
-### High (23)
-
-### `BUG-blob-21` residual - small `-kB` revision checks out empty in local mode
-
-The [`BUG-blob-21`](_reports/BUG-blob-21-local-mode-binary-commit-data-loss.md) blob-root fix is
-incomplete.  With the root set and the blob stored whole, a `-kB` revision below ~1.5 KB still
-checks out as a zero-length file in local mode (data loss once the holding working copy is gone).
-The decoder unit is clean; the fault is in the checkout dereference/size path
-(`RCS_read_binary_rev_data` -> `pull_at_once`).  Pinned by the expected-failure case
-`t_binary_small_second_commit`.  The shipped `t_binary_second_commit` masks it with a 1541-byte
-payload, just above the failing range.
-
+### High (22)
 
 | ID | Severity | Area | Issue | Fix size | Changes behaviour |
 | --- | --- | --- | --- | ---: | --- |
@@ -324,7 +313,7 @@ payload, just above the failing range.
 
 ## Fixed on this branch
 
-For reference, the 15 defects that were fixed:
+For reference, the 16 defects that were fixed:
 
 | ID | Issue |
 | --- | --- |
@@ -343,3 +332,4 @@ For reference, the 15 defects that were fixed:
 | [`BUG-server-08`](_reports/BUG-server-08-writelock-uses-CVSRFL.md) | `write_lock` built the write-lock filename from the read-lock prefix |
 | [`BUG-server-15`](_reports/BUG-server-15-checkin-format-missing-arg.md) | `%s` with no argument on the reopen-failure path |
 | [`BUG-server-17`](_reports/BUG-server-17-pnew-file-comment-typo.md) | `"pnew file"` written into the RCS `comment` field of every imported file |
+| [`BUG-blob-21`](_reports/BUG-blob-21-local-mode-binary-commit-data-loss.md) (residual) | Small `-kB` revisions checked out as empty files: binary content went through the codepage encoder, whose failed iconv conversion collapsed the write length to 0 |


### PR DESCRIPTION
Fixes the residual half of BUG-blob-21: a `-kB` binary revision below roughly 1.5 KB checked out as a **zero-length file** in local mode even though the blob was stored whole, the `,v` reference pointed at it, and the pull returned the right bytes. Deleting the working copy that still held them lost the revision. The shipped regression case used a 1541-byte payload that happened to dodge it.

### Root cause (three layers in the working-file write, `RCS_checkout`)

1. **Binary content was routed through the codepage encoder.** `encode = oencode` does not exclude `KFLAG_BINARY`; the `nencode` variable beside it did, and was unused (along with three other dead variants).
2. **`CCodepage::ConvertEncoding` guesses an encoding from the bytes.** When the binary garbage looked like some charset it opened iconv; iconv failed on the first invalid sequence, but `iconv(...) < 0` on a `size_t` can never fire, so the call "succeeded" having converted nothing and `outlen -= out_remaining` landed on 0.
3. **`OutputAsEncoded`'s `ltLf` branch aliased the length**: `ConvertEncoding(o, l, outbuf, l)` passed `l` as both input and output length, so `l` became 0 and `write(fd, o, 0)` succeeded with an empty file and no error.

A "no conversion" guess left `outlen` alone and the file came out right, which is why the boundary shifted with content and size instead of sitting on a clean threshold. The same hole could empty a **text** file whose guessed encoding failed to convert.

### Fix

- `rcs_checkin.cpp`: binary never enters the encoder; the four dead `encode`/`open_binary` variants are removed.
- `cvsapi/Codepage.cpp`: `ConvertEncoding` detects an iconv failure (`== (size_t)-1`); every `OutputAsEncoded` call site keeps a separate output length and adopts it only from a real conversion, writing the raw bytes otherwise.
- `t_binary_small_second_commit` is a real test now (it shipped in PR #30 as an expected-failure marker), covering six payload sizes from 100 to 1400 bytes so a lucky guess on one size cannot hide a regression.
- BUG-blob-21 report and `known_issues.md` updated; the residual moves to the fixed list.

### Verification

- Regression suite: 35 passed, 0 failed (the small-blob case now a regular pass).
- Unit tests: 147 checks, 0 failed.
- Size sweep with the fixed build: payloads of 1, 17, 100, 256, 300, 512, 768, 1024, 1200, 1400, 1541 and 4096 bytes all round-trip byte for byte (before the fix everything at 1400 and below came back empty).

Stacks on `audit/06-recovery-switches-and-blob-root` (PR #30), which carries the blob-root fix and the expected-failure marker this PR flips.

https://claude.ai/code/session_01MrKxAykbbgXoFtkD3yvnFv
