### PR TITLE
test: pin the -ku line-ending encoding through a client/server checkout

### DIFF
--- a/HOWTOBUILD.md
+++ b/HOWTOBUILD.md
@@ -230,7 +230,9 @@ Two things to know:
   it is the only one of the two the binary actually imports. Copy `libssl-1_1-x64.dll` as well; a
   build that enables `:sserver:` will need it.
 * `cvs init` needs the trigger plugin (`triggers/info_triggers.vcxproj`); without it you get
-  `Couldn't open default trigger library`. Client commands work without it.
+  `Couldn't open default trigger library`. Client commands work without it. The makefile's
+  `plugins` target builds it as `bin\triggers\info.dll`, together with the `pserver` and `ext`
+  protocol plugins under `bin\protocols\`; run the client with `-L <bin>` to use them.
 
 `_reports/BUILD-01-windows-toolchain.md` has the full environment setup, the makefile, the exact
 dependency graph and every problem encountered along the way.

--- a/_reports/BUILD-01-Makefile.nmake
+++ b/_reports/BUILD-01-Makefile.nmake
@@ -268,6 +268,7 @@ $(LIBD)\libsuid.lib: dirs
 CVSAPI_SRC = \
 	"$(S)\cvsapi\Codepage.cpp" "$(S)\cvsapi\crypt.cpp" "$(S)\cvsapi\cvs_string.cpp" \
 	"$(S)\cvsapi\diff\DiffBase.cpp" "$(S)\cvsapi\diff\StringDiff.cpp" \
+	"$(S)\cvsapi\FileContent.cpp" \
 	"$(S)\cvsapi\GetOptions.cpp" "$(S)\cvsapi\lib\fncmp.c" "$(S)\cvsapi\lib\fnmatch.c" \
 	"$(S)\cvsapi\lib\getdate.c" "$(S)\cvsapi\lib\getmode.c" "$(S)\cvsapi\lib\GetOsVersion.cpp" \
 	"$(S)\cvsapi\lib\md5.c" "$(S)\cvsapi\lib\md5crypt.c" "$(S)\cvsapi\lib\ndir.cpp" \
@@ -283,17 +284,17 @@ CVSAPI_SRC = \
 	"$(S)\cvsapi\win32\SSPIHandler.cpp" "$(S)\cvsapi\XmlNode.cpp" \
 	"$(S)\cvsapi\xmltree.cpp" "$(S)\cvsapi\Zeroconf.cpp"
 
-$(BIN)\cvsapi.dll: dirs $(GEN)\cvsapi\ServiceMsg.h $(LIBD)\libxml2.lib $(LIBD)\pcre.lib $(LIBD)\ufccrypt.lib
+$(BIN)\cvsapi.dll: dirs $(GEN)\cvsapi\ServiceMsg.h $(LIBD)\libxml2.lib $(LIBD)\pcre.lib $(LIBD)\ufccrypt.lib $(LIBD)\zstd.lib
 	@if not exist "$(OBJ)\cvsapi" mkdir "$(OBJ)\cvsapi"
 	$(CC) $(CFLAGS_COMMON) $(UNICODE_D) /EHsc /D "_WINDOWS" /D "HAVE_CONFIG_H" \
 		/D "CVSAPI_EXPORT=__declspec(dllexport)" /D "XML_STATIC" /D "PCRE_STATIC" \
 		/I "$(GEN)\cvsapi" /I "$(S)\external_libs" /I "$(S)\cvsapi" /I "$(S)\cvsapi\lib" \
-		/I "$(S)\cvsapi\win32" /I "$(S)\libxml\include" /I "$(S)\pcre" /I "$(S)" \
+		/I "$(S)\cvsapi\win32" /I "$(S)\libxml\include" /I "$(S)\pcre" /I "$(S)\zstd" /I "$(S)" \
 		/Fo"$(OBJ)\cvsapi\\" /Fd"$(OBJ)\cvsapi\a.pdb" $(CVSAPI_SRC)
 	cd /d "$(S)\cvsapi" && $(RC) /nologo /d "NDEBUG" /I "$(GEN)\cvsapi" /I "$(S)\cvsapi\win32" /fo"$(OBJ)\cvsapi\cvsapi.res" win32\cvsapi.rc
 	$(LINK) /nologo /DLL /OUT:$@ /IMPLIB:"$(LIBD)\cvsapi.lib" /DEBUG /INCREMENTAL:NO \
 		"$(OBJ)\cvsapi\*.obj" "$(OBJ)\cvsapi\cvsapi.res" \
-		"$(LIBD)\libxml2.lib" "$(LIBD)\pcre.lib" "$(LIBD)\ufccrypt.lib" \
+		"$(LIBD)\libxml2.lib" "$(LIBD)\pcre.lib" "$(LIBD)\ufccrypt.lib" "$(LIBD)\zstd.lib" \
 		/LIBPATH:"$(EXTLIB)" libiconv.lib ws2_32.lib urlmon.lib wininet.lib secur32.lib \
 		dnsapi.lib wintrust.lib advapi32.lib user32.lib ole32.lib oleaut32.lib shell32.lib \
 		crypt32.lib netapi32.lib mpr.lib
@@ -370,6 +371,40 @@ $(BIN)\cvs.exe: cvsnt_objs $(LIBD)\gnulib.lib $(LIBD)\libdiff.lib $(LIBD)\zlib.l
 		/LIBPATH:"$(EXTLIB)" libssl.lib libcrypto.lib comctl32.lib wsock32.lib ws2_32.lib \
 		netapi32.lib mpr.lib ole32.lib oleaut32.lib libiconv.lib wininet.lib dbghelp.lib \
 		advapi32.lib user32.lib shell32.lib gdi32.lib crypt32.lib secur32.lib
+
+# --------------------------------------------------------------------------- plugins (x64)
+# Layout the client expects under "-L <libdir>": protocols\<name>.dll, triggers\info.dll.
+# pserver is what a real client needs; info lets "cvs init" (and so regress.py) run out of
+# the build tree; ext is what the client/server case in regress.py connects through.
+PLUGIN_INC = /I "$(S)\external_libs" /I "$(S)\cvsapi\win32" /I "$(S)\cvsapi" /I "$(S)\cvstools" \
+	/I "$(S)\libxml\include" /I "$(S)"
+PLUGIN_LIBS = "$(LIBD)\cvsapi.lib" "$(LIBD)\cvstools.lib" ws2_32.lib wsock32.lib advapi32.lib user32.lib
+
+plugins: $(BIN)\protocols\pserver.dll $(BIN)\protocols\ext.dll $(BIN)\triggers\info.dll
+
+$(BIN)\protocols\pserver.dll: $(BIN)\cvsapi.dll $(BIN)\cvstools.dll
+	@if not exist "$(OBJ)\pserver" mkdir "$(OBJ)\pserver"
+	@if not exist "$(BIN)\protocols" mkdir "$(BIN)\protocols"
+	$(CC) $(CFLAGS_COMMON) /EHsc /D "_WINDOWS" /D "_USRDLL" /D "PSERVER_PROTOCOL_EXPORTS" $(PLUGIN_INC) \
+		/Fo"$(OBJ)\pserver\\" /Fd"$(OBJ)\pserver\a.pdb" "$(S)\protocols\common.cpp" "$(S)\protocols\pserver.cpp"
+	cd /d "$(S)\protocols" && $(RC) /nologo /d "NDEBUG" /fo"$(OBJ)\pserver\proto_resource.res" proto_resource.rc
+	$(LINK) /nologo /DLL /OUT:$@ /DEBUG /INCREMENTAL:NO "$(OBJ)\pserver\*.obj" "$(OBJ)\pserver\proto_resource.res" $(PLUGIN_LIBS)
+
+$(BIN)\protocols\ext.dll: $(BIN)\cvsapi.dll $(BIN)\cvstools.dll
+	@if not exist "$(OBJ)\ext" mkdir "$(OBJ)\ext"
+	@if not exist "$(BIN)\protocols" mkdir "$(BIN)\protocols"
+	$(CC) $(CFLAGS_COMMON) /EHsc /D "_WINDOWS" /D "_USRDLL" /D "ext_PROTOCOL_EXPORTS" $(PLUGIN_INC) \
+		/Fo"$(OBJ)\ext\\" /Fd"$(OBJ)\ext\a.pdb" "$(S)\protocols\common.cpp" "$(S)\protocols\ext.cpp"
+	cd /d "$(S)\protocols" && $(RC) /nologo /d "NDEBUG" /fo"$(OBJ)\ext\proto_resource.res" proto_resource.rc
+	$(LINK) /nologo /DLL /OUT:$@ /DEBUG /INCREMENTAL:NO "$(OBJ)\ext\*.obj" "$(OBJ)\ext\proto_resource.res" $(PLUGIN_LIBS)
+
+$(BIN)\triggers\info.dll: $(BIN)\cvsapi.dll $(BIN)\cvstools.dll
+	@if not exist "$(OBJ)\info" mkdir "$(OBJ)\info"
+	@if not exist "$(BIN)\triggers" mkdir "$(BIN)\triggers"
+	$(CC) $(CFLAGS_COMMON) /EHsc /D "_WINDOWS" /D "_USRDLL" /D "info_triggers_EXPORTS" $(PLUGIN_INC) \
+		/Fo"$(OBJ)\info\\" /Fd"$(OBJ)\info\a.pdb" "$(S)\triggers\info_trigger.cpp"
+	cd /d "$(S)\triggers" && $(RC) /nologo /d "NDEBUG" /fo"$(OBJ)\info\info_trigger.res" info_trigger.rc
+	$(LINK) /nologo /DLL /OUT:$@ /DEBUG /INCREMENTAL:NO "$(OBJ)\info\*.obj" "$(OBJ)\info\info_trigger.res" $(PLUGIN_LIBS)
 
 clean:
 	@if exist "$(OBJ)"  rmdir /s /q "$(OBJ)"

--- a/cvsnt/cvsnt-2.5.05.3744/testcvs/README.md
+++ b/cvsnt/cvsnt-2.5.05.3744/testcvs/README.md
@@ -54,6 +54,13 @@ Note that the tests initialise repositories with `cvs init -n`. Without `-n`, `i
 register the repository in the machine-global settings, which needs privileges a test should not
 require.
 
+One case, the `-ku` line-ending test, has to go through a real client/server session because only
+the client-side write path is affected. It uses the `:ext:` protocol with `CVS_EXT` set to a Python
+pass-through and `CVS_SERVER` set to `<cvs> --allow-root=<repo> server`, so it needs the `ext`
+protocol plugin as `<libdir>/protocols/ext.<so|dll>` and nothing registered anywhere. When the
+plugin is missing the case prints a skip note instead of failing. On Windows the standalone
+makefile in `_reports/BUILD-01-Makefile.nmake` builds it with `mk.bat plugins`.
+
 ## `testcvs.py`
 
 The suite that shipped with CVSNT. It expects `cvs` on `PATH` and creates `tree/`, `tree_0/`,

--- a/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
+++ b/cvsnt/cvsnt-2.5.05.3744/testcvs/regress.py
@@ -36,15 +36,20 @@ CURRENT = "<none>"
 
 # --------------------------------------------------------------------------- infra
 
-def run(args, cwd, expect_ok=True):
-    """Run cvs with the global options, return (rc, stdout+stderr)."""
+def run(args, cwd, expect_ok=True, env=None):
+    """Run cvs with the global options, return (rc, stdout+stderr).
+    env adds to (or overrides) the inherited environment."""
     cmd = [CVS]
     if LIBDIR:
         cmd += ["-L", LIBDIR]
     cmd += args
     if VERBOSE:
         print("    $ " + " ".join(cmd) + ("   (in %s)" % cwd))
-    p = subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE,
+    full_env = None
+    if env:
+        full_env = dict(os.environ)
+        full_env.update(env)
+    p = subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE, env=full_env,
                        stderr=subprocess.STDOUT, universal_newlines=True)
     if VERBOSE and p.stdout:
         print("      " + p.stdout.rstrip().replace("\n", "\n      "))
@@ -119,8 +124,9 @@ class Repo:
         # which needs privileges we do not want a test to require.
         run(["-d", self.repo, "init", "-n"], cwd=root)
 
-    def cvs(self, args, cwd=None, expect_ok=True):
-        return run(["-d", self.repo] + args, cwd=cwd or self.wc, expect_ok=expect_ok)
+    def cvs(self, args, cwd=None, expect_ok=True, env=None):
+        return run(["-d", self.repo] + args, cwd=cwd or self.wc, expect_ok=expect_ok,
+                   env=env)
 
     def import_tree(self, module, files):
         imp = os.path.join(self.root, "imp")
@@ -1151,6 +1157,55 @@ def t_binary_small_second_commit(r):
                  "%d-byte binary revision came back as %d bytes" % (size, len(got)))
         check(got == payload, "%d-byte binary revision content differs" % size)
 
+@test("a -ku text file checks out with every line ending encoded")
+def t_unicode_text_line_endings(r):
+    # The line-ending branch of OutputAsEncoded reused the buffer left by
+    # the preceding text conversion but told ConvertEncoding it had no room,
+    # so after every non-empty line the raw CRLF went into the UTF-16 file.
+    # Empty lines had no buffer to reuse and came out right, which is why
+    # the lines below alternate.  A raw 0D 0A inside UTF-16 text decodes
+    # as U+0A0D, so decoding and comparing the lines catches it.
+    #
+    # Only the client side writes through that path (update_entries), so
+    # the checkout goes through a real client/server session: :ext: with
+    # CVS_EXT as a pass-through transport and CVS_SERVER naming this cvs
+    # with --allow-root, which is how the server accepts a repository that
+    # is not registered in the machine settings.  The source is UTF-8 with
+    # a BOM, which is what makes the encoder convert at all.
+    lines = ["first line, long enough to leave a conversion buffer behind",
+             "", "third", "", "x", "last line"]
+    imp = os.path.join(r.root, "impuni")
+    os.makedirs(imp)
+    with open(os.path.join(imp, "u.txt"), "wb") as f:
+        f.write(b"\xef\xbb\xbf" + ("\n".join(lines) + "\n").encode("utf-8"))
+    r.cvs(["import", "-m", "uni", "-kukv", "mu", "VENDOR", "REL0"], cwd=imp)
+
+    repo = r.repo.replace(os.sep, "/")
+    # The transport is a Python pass-through that just runs the rest of
+    # its command line, so every path can be quoted the same way on
+    # Windows (cmd.exe) and POSIX (sh).
+    helper = os.path.join(r.root, "passthru.py")
+    write(helper, "import subprocess, sys\nsys.exit(subprocess.call(sys.argv[1:]))\n")
+    q = lambda s: '"%s"' % s
+    server = q(CVS) + (" -L " + q(LIBDIR) if LIBDIR else "") + " " + q("--allow-root=" + repo)
+    env = {"CVS_EXT": q(sys.executable) + " " + q(helper), "CVS_SERVER": server}
+    wc = os.path.join(r.root, "extwc")
+    os.makedirs(wc)
+    rc, out = run(["-d", ":ext:localhost:" + repo, "checkout", "mu"], cwd=wc,
+                  expect_ok=False, env=env)
+    if rc != 0 and "protocol" in out.lower() and "ext" in out.lower():
+        print("          (skipped: the :ext: protocol plugin is not available here)")
+        return
+    if not check_eq(rc, 0, "checkout over :ext: failed:\n" + out):
+        return
+    raw = open(os.path.join(wc, "mu", "u.txt"), "rb").read()
+    if not check(raw[:2] == b"\xff\xfe" and len(raw) % 2 == 0,
+                 "-ku file is not BOM-led UTF-16LE: %s" % ascii(raw[:16])):
+        return
+    got = raw[2:].decode("utf-16-le").splitlines()
+    check(got == lines, "-ku file lines after checkout: expected %s, got %s"
+          % (ascii(lines), ascii(got)))
+
 @test("binary content is detected on add and import by content, not by name")
 def t_add_binary_by_content(r):
     # Binary is decided by content: a NUL, in the first 8 KB or (when the
@@ -1530,7 +1585,11 @@ def main():
         else:
             print("  FAIL  " + CURRENT)
             for _, msg in FAILURES[before:]:
-                print("          " + msg.replace("\n", "\n          "))
+                # A message may quote file content the console cannot
+                # encode; a failure report must never crash the run.
+                text = "          " + msg.replace("\n", "\n          ")
+                enc = sys.stdout.encoding or "utf-8"
+                print(text.encode(enc, "backslashreplace").decode(enc))
 
     print()
     xf = len(XFAILED)


### PR DESCRIPTION
## Summary

Regression case for the `-ku` (UTF-16 working file) line-ending defect fixed on `audit/08` (commit `286fdf4`, merged into `audit/09` as `b792729`): after every non-empty line the client wrote the raw 2-byte CRLF into the UTF-16 file instead of the encoded one.

- The defect is on the client-side write path only (`update_entries` in `client.cpp`), which a local-mode checkout never takes, so the case runs a real session over `:ext:` with `CVS_EXT` pointing at a Python pass-through and `CVS_SERVER` at `cvs --allow-root=<repo> server`. No repository registration is needed.
- It needs the `ext` protocol plugin next to the cvs under test and prints a skip note when the plugin is missing.
- `run()` and `Repo.cvs()` take an `env` mapping; a failure message the console cannot encode no longer aborts the run (this one quotes U+0A0D, the character a raw CRLF decodes to).
- The Windows makefile in `_reports` gains a `plugins` target (pserver, ext, info) and its cvsapi rule picks up `FileContent.cpp` and zstd, which `audit/09` added; `testcvs/README.md` and `HOWTOBUILD.md` describe both.

## Verification

- Against the `audit/09` tip before the fix merge: `39 passed, 1 failed`, the new case reporting `got [... 'behind\u0a0d', 'third\u0a0d', ...]`.
- Against this branch (fix included): `39 passed, 0 failed` on Windows x64, built with the makefile from `_reports`.
- The same defect was first seen as one differing file (`-kukv`) in a full 16 GB checkout of `dagor/tools` between the shipped client and the PR build; a client with the fix produces a byte-identical file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
